### PR TITLE
Biome ignore `package.json`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,6 +30,7 @@
 			".pnpm-store",
 			"coverage",
 			"dist",
+			"package.json",
 			"pnpm-lock.yaml",
 			"test/convex/_generated"
 		]


### PR DESCRIPTION
The changeset Version Packages PR updates `package.json` and formats it with Prettier (I think), which always conflicts with Biome's formatting. That's fine, I dont' care who formats it.