### PR TITLE
Expose original Convex context for component integrations

### DIFF
--- a/.changeset/hip-bottles-fetch.md
+++ b/.changeset/hip-bottles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@rjdellecese/confect": patch
+---
+
+Expose original Convex context for component integrations

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -1,0 +1,6 @@
+import presence from "@convex-dev/presence/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(presence);
+export default app;

--- a/example/convex/presence.ts
+++ b/example/convex/presence.ts
@@ -1,0 +1,69 @@
+import { Presence } from "@convex-dev/presence";
+import { v } from "convex/values";
+import { Effect, Schema } from "effect";
+import { components } from "./_generated/api.js";
+import {
+  ConfectQueryCtx,
+  query,
+  mutation,
+  ConfectMutationCtx,
+} from "./confect";
+
+export const presence = new Presence(components.presence);
+
+export const heartbeat = mutation({
+  args: Schema.Struct({
+    roomId: Schema.String,
+    userId: Schema.String,
+    sessionId: Schema.String,
+    interval: Schema.Number,
+  }),
+  returns: Schema.Struct({
+    roomToken: Schema.String,
+    sessionToken: Schema.String,
+  }),
+  handler: ({ roomId, userId, sessionId, interval }) =>
+    Effect.gen(function* () {
+      const { ctx } = yield* ConfectMutationCtx;
+      return yield* Effect.tryPromise({
+        try: () => presence.heartbeat(ctx, roomId, userId, sessionId, interval),
+        catch: (error) => Effect.fail(error),
+      });
+    }),
+});
+
+export const list = query({
+  args: Schema.Struct({
+    roomToken: Schema.String,
+  }),
+  returns: Schema.Array(
+    Schema.Struct({
+      userId: Schema.String,
+      online: Schema.Boolean,
+      lastDisconnected: Schema.Number,
+    }),
+  ),
+  handler: ({ roomToken }) =>
+    Effect.gen(function* () {
+      const { ctx } = yield* ConfectQueryCtx;
+      return yield* Effect.tryPromise({
+        try: () => presence.list(ctx, roomToken),
+        catch: (error) => Effect.fail(error),
+      });
+    }),
+});
+
+export const disconnect = mutation({
+  args: Schema.Struct({
+    sessionToken: Schema.String,
+  }),
+  returns: Schema.Null,
+  handler: ({ sessionToken }) =>
+    Effect.gen(function* () {
+      const { ctx } = yield* ConfectMutationCtx;
+      return yield* Effect.tryPromise({
+        try: () => presence.disconnect(ctx, sessionToken),
+        catch: (error) => Effect.fail(error),
+      });
+    }),
+});

--- a/example/package.json
+++ b/example/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@convex-dev/presence": "^0.1.5",
     "@effect/platform": "0.90.6",
     "@rjdellecese/confect": "file:../",
     "convex": "1.26.1",

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@convex-dev/presence':
+        specifier: ^0.1.5
+        version: 0.1.5(convex@1.26.1(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@effect/platform':
         specifier: 0.90.6
         version: 0.90.6(effect@3.17.9)
@@ -143,6 +146,13 @@ packages:
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
+
+  '@convex-dev/presence@0.1.5':
+    resolution: {integrity: sha512-tHD03dLnP0bB4lHuXMVx64NkQqn/SR4dJakwkcOEsXZXFJsvoai/O0FcAnrd5KBYzbbt8GFZ7vxPdBO0l1CSUw==}
+    peerDependencies:
+      convex: '>=1.24.8 <1.35.0'
+      react: ~18.3.1 || ^19.0.0
+      react-dom: ~18.3.1 || ^19.0.0
 
   '@effect/platform@0.90.6':
     resolution: {integrity: sha512-aT7aLJR1+rYrSLdw5af2UZzwnWoAy8WmkTxTUD3pFY6vjFmh+8137RhbwKiWjIJBTm2DVyPXl1dx1kGg28xt6Q==}
@@ -939,6 +949,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@convex-dev/presence@0.1.5(convex@1.26.1(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      convex: 1.26.1(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   '@effect/platform@0.90.6(effect@3.17.9)':
     dependencies:

--- a/src/server/ctx.ts
+++ b/src/server/ctx.ts
@@ -40,6 +40,7 @@ import {
 export type ConfectMutationCtx<
   ConfectDataModel extends GenericConfectDataModel,
 > = {
+  ctx: GenericMutationCtx<DataModelFromConfectDataModel<ConfectDataModel>>;
   db: ConfectDatabaseWriter<ConfectDataModel>;
   auth: ConfectAuth;
   storage: ConfectStorageWriter;
@@ -55,6 +56,7 @@ export const ConfectMutationCtx = <
 
 export type ConfectQueryCtx<ConfectDataModel extends GenericConfectDataModel> =
   {
+    ctx: GenericQueryCtx<DataModelFromConfectDataModel<ConfectDataModel>>;
     db: ConfectDatabaseReader<ConfectDataModel>;
     auth: ConfectAuth;
     storage: ConfectStorageReader;
@@ -85,6 +87,8 @@ export type ConfectActionCtx<ConfectDataModel extends GenericConfectDataModel> =
       action: Action,
       ...args: OptionalRestArgs<Action>
     ): Effect.Effect<FunctionReturnType<Action>>;
+
+    ctx: GenericActionCtx<DataModelFromConfectDataModel<ConfectDataModel>>;
     scheduler: ConfectScheduler;
     auth: ConfectAuth;
     storage: ConfectStorageWriter;
@@ -124,6 +128,7 @@ export const makeConfectQueryCtx = <
   ctx: GenericQueryCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
   databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
 ): ConfectQueryCtx<ConfectDataModel> => ({
+  ctx,
   db: new ConfectDatabaseReaderImpl(ctx.db, databaseSchemas),
   auth: new ConfectAuthImpl(ctx.auth),
   storage: new ConfectStorageReaderImpl(ctx.storage),
@@ -135,6 +140,7 @@ export const makeConfectMutationCtx = <
   ctx: GenericMutationCtx<DataModelFromConfectDataModel<ConfectDataModel>>,
   databaseSchemas: DatabaseSchemasFromConfectDataModel<ConfectDataModel>,
 ): ConfectMutationCtx<ConfectDataModel> => ({
+  ctx,
   db: new ConfectDatabaseWriterImpl(ctx.db, databaseSchemas),
   auth: new ConfectAuthImpl(ctx.auth),
   storage: new ConfectStorageWriterImpl(ctx.storage),
@@ -180,6 +186,7 @@ export const makeConfectActionCtx = <
       >
     >,
   ) => Effect.promise(() => ctx.vectorSearch(tableName, indexName, query)),
+  ctx,
   auth: new ConfectAuthImpl(ctx.auth),
   storage: new ConfectStorageWriterImpl(ctx.storage),
   scheduler: new ConfectSchedulerImpl(ctx.scheduler),


### PR DESCRIPTION
Closes https://github.com/rjdellecese/confect/issues/202. Sorry it took so long!

This exposes the original Convex context in a `ctx` field in the query/mutation/action contexts of Confect. Not sure if thats the best naming as it would probably result in `ctx.ctx` without deconstruction, so lmk if you'd like to rename it.

I've also added an example integration with the Presence component from Convex. But I can remove this (or only the first commit can be cherry-picked) if you'd like to keep the example clean and simple.