### PR TITLE
Refactor ConfectScheduler to use Duration and DateTime types

### DIFF
--- a/src/server/scheduler.ts
+++ b/src/server/scheduler.ts
@@ -3,16 +3,16 @@ import type {
   SchedulableFunctionReference,
   Scheduler,
 } from "convex/server";
-import { Effect } from "effect";
+import { DateTime, Duration, Effect } from "effect";
 
 export interface ConfectScheduler {
   runAfter<FuncRef extends SchedulableFunctionReference>(
-    delayMs: number,
+    delay: Duration.DurationInput,
     functionReference: FuncRef,
     ...args: OptionalRestArgs<FuncRef>
   ): Effect.Effect<void>;
   runAt<FuncRef extends SchedulableFunctionReference>(
-    timestamp: number | Date,
+    timestamp: number | Date | DateTime.DateTime,
     functionReference: FuncRef,
     ...args: OptionalRestArgs<FuncRef>
   ): Effect.Effect<void>;
@@ -22,21 +22,31 @@ export class ConfectSchedulerImpl implements ConfectScheduler {
   constructor(private scheduler: Scheduler) {}
 
   runAfter<FuncRef extends SchedulableFunctionReference>(
-    delayMs: number,
+    delay: Duration.DurationInput,
     functionReference: FuncRef,
     ...args: OptionalRestArgs<FuncRef>
   ): Effect.Effect<void> {
     return Effect.promise(() =>
-      this.scheduler.runAfter(delayMs, functionReference, ...args),
+      this.scheduler.runAfter(
+        Duration.toMillis(delay),
+        functionReference,
+        ...args,
+      ),
     );
   }
   runAt<FuncRef extends SchedulableFunctionReference>(
-    timestamp: number | Date,
+    timestamp: number | Date | DateTime.DateTime,
     functionReference: FuncRef,
     ...args: OptionalRestArgs<FuncRef>
   ): Effect.Effect<void> {
     return Effect.promise(() =>
-      this.scheduler.runAt(timestamp, functionReference, ...args),
+      this.scheduler.runAt(
+        DateTime.isDateTime(timestamp)
+          ? DateTime.toEpochMillis(timestamp)
+          : timestamp,
+        functionReference,
+        ...args,
+      ),
     );
   }
 }


### PR DESCRIPTION
- Updated runAfter method to accept Duration.DurationInput instead of delay in milliseconds.
- Updated runAt method to accept DateTime.DateTime in addition to Date.
- Adjusted internal logic to convert Duration and DateTime to appropriate formats for the scheduler.