### PR TITLE
fix "TS2589 Type instantiation is excessively deep and possibly infinite"

### DIFF
--- a/packages/confect/package.json
+++ b/packages/confect/package.json
@@ -23,9 +23,20 @@
     "package.json",
     "src"
   ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./*": "./src/*.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "import": "./dist/*/index.js",
+      "require": "./dist/*/index.cjs"
+    },
     "./internal/*": null
   },
   "scripts": {


### PR DESCRIPTION
The `.ts` exports caused my project to typecheck (`tsc --noEmit`) those files in the installed package (`skipLibCheck` tsconfig setting apparently doesn't apply to `.ts` files), which caused the TS2589 error. Using `.js` and `.d.ts` make `skipLibCheck` work and prevents the error.

But now we're back to TS2742 errors with the `composite` tsconfig setting. I disabled this setting in my project since I don't need it enabled for application code. I think the actual fix for that is exporting types along with the modules but I'm not entirely sure.