### PR TITLE
fix: prevent excessive type instantiation (TS2589) in `FilterRefs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.attest/
 .env.local
 .pnpm-store/
 .tsup

--- a/apps/example/confect/_generated/refs.ts
+++ b/apps/example/confect/_generated/refs.ts
@@ -1,7 +1,4 @@
 import { Refs } from "@confect/core";
 import spec from "../spec";
 
-const refs = Refs.make(spec);
-
-export const api = Refs.justPublic(refs);
-export const internal = Refs.justInternal(refs);
+export const { public: api, internal } = Refs.make(spec);

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -92,10 +92,9 @@ export const refs = ({ specImportPath }: { specImportPath: string }) =>
     yield* cbw.writeLine(`import { Refs } from "@confect/core";`);
     yield* cbw.writeLine(`import spec from "${specImportPath}";`);
     yield* cbw.blankLine();
-    yield* cbw.writeLine(`const refs = Refs.make(spec);`);
-    yield* cbw.blankLine();
-    yield* cbw.writeLine(`export const api = Refs.justPublic(refs);`);
-    yield* cbw.writeLine(`export const internal = Refs.justInternal(refs);`);
+    yield* cbw.writeLine(
+      `export const { public: api, internal } = Refs.make(spec);`,
+    );
 
     return yield* cbw.toString();
   });

--- a/packages/cli/test/fixtures/confect/_generated/refs.ts
+++ b/packages/cli/test/fixtures/confect/_generated/refs.ts
@@ -1,7 +1,4 @@
 import { Refs } from "@confect/core";
 import spec from "../spec";
 
-const refs = Refs.make(spec);
-
-export const api = Refs.justPublic(refs);
-export const internal = Refs.justInternal(refs);
+export const { public: api, internal } = Refs.make(spec);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "typecheck": "tsc --noEmit --project tsconfig.json",
     "fix": "prettier --write . && eslint --fix . --max-warnings=0",
     "lint": "prettier --check . && eslint . --max-warnings=0",
+    "bench": "tsx test/Refs.bench.ts",
     "clean": "rm -rf dist coverage node_modules"
   },
   "keywords": [
@@ -47,6 +48,7 @@
   "author": "RJ Dellecese",
   "license": "ISC",
   "devDependencies": {
+    "@ark/attest": "^0.56.0",
     "@effect/language-service": "0.56.0",
     "@eslint/js": "9.39.1",
     "@tsconfig/strictest": "2.0.8",

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -108,6 +108,13 @@ export type Returns<Ref_> =
     ? Returns_
     : never;
 
+export type FromFunctionSpec<F extends FunctionSpec.AnyWithProps> = Ref<
+  FunctionSpec.GetFunctionType<F>,
+  FunctionSpec.GetFunctionVisibility<F>,
+  FunctionSpec.Args<F>,
+  FunctionSpec.Returns<F>
+>;
+
 export const make = <
   FunctionType_ extends FunctionType,
   FunctionVisibility_ extends FunctionVisibility,

--- a/packages/core/src/Refs.ts
+++ b/packages/core/src/Refs.ts
@@ -5,70 +5,78 @@ import type * as GroupSpec from "./GroupSpec";
 import * as Ref from "./Ref";
 import type * as Spec from "./Spec";
 
-export type Refs<Spec_ extends Spec.AnyWithProps> = Types.Simplify<
-  Helper<Spec.Groups<Spec_>>
+export type Refs<
+  Spec_ extends Spec.AnyWithProps,
+  Predicate extends Ref.Any = Ref.Any,
+> = Types.Simplify<Helper<Spec.Groups<Spec_>, Predicate>>;
+
+type GroupRefs<
+  Group extends GroupSpec.AnyWithProps,
+  Predicate extends Ref.Any,
+> = Types.Simplify<
+  Helper<GroupSpec.Groups<Group>, Predicate> &
+    FilteredFunctions<GroupSpec.Functions<Group>, Predicate>
 >;
 
-type Helper<Groups extends GroupSpec.AnyWithProps> = {
-  [GroupName in GroupSpec.Name<Groups>]: GroupSpec.WithName<
-    Groups,
-    GroupName
-  > extends infer Group extends GroupSpec.AnyWithProps
-    ? GroupSpec.Groups<Group> extends infer SubGroups extends
-        GroupSpec.AnyWithProps
-      ? Types.Simplify<
-          Helper<SubGroups> & {
-            [FunctionName in FunctionSpec.Name<
-              GroupSpec.Functions<Group>
-            >]: FunctionSpec.WithName<
-              GroupSpec.Functions<Group>,
-              FunctionName
-            > extends infer Function extends FunctionSpec.AnyWithProps
-              ? Ref.Ref<
-                  FunctionSpec.GetFunctionType<Function>,
-                  FunctionSpec.GetFunctionVisibility<Function>,
-                  FunctionSpec.Args<Function>,
-                  FunctionSpec.Returns<Function>
-                >
-              : never;
-          }
-        >
+type FilteredFunctions<
+  Functions extends FunctionSpec.AnyWithProps,
+  Predicate extends Ref.Any,
+> = {
+  [Name in FunctionSpec.Name<Functions> as FunctionSpec.WithName<
+    Functions,
+    Name
+  > extends infer F extends FunctionSpec.AnyWithProps
+    ? Ref.FromFunctionSpec<F> extends Predicate
+      ? Name
       : never
+    : never]: FunctionSpec.WithName<Functions, Name> extends infer F extends
+    FunctionSpec.AnyWithProps
+    ? Ref.FromFunctionSpec<F>
     : never;
 };
 
-type FilterRefs<Refs_, Predicate> = Types.Simplify<{
-  [K in keyof Refs_ as Refs_[K] extends Predicate
-    ? K
-    : Refs_[K] extends Ref.Any
+type Helper<
+  Groups extends GroupSpec.AnyWithProps,
+  Predicate extends Ref.Any,
+> = {
+  [GroupName in GroupSpec.Name<Groups> as GroupSpec.WithName<
+    Groups,
+    GroupName
+  > extends infer Group extends GroupSpec.AnyWithProps
+    ? GroupRefs<Group, Predicate> extends Record<string, never>
       ? never
-      : K]: Refs_[K] extends Predicate
-    ? Refs_[K]
-    : FilterRefs<Refs_[K], Predicate>;
-}>;
+      : GroupName
+    : never]: GroupSpec.WithName<Groups, GroupName> extends infer Group extends
+    GroupSpec.AnyWithProps
+    ? GroupRefs<Group, Predicate>
+    : never;
+};
 
-export const justInternal = <Refs_ extends RefsAnyWithProps>(
-  refs: Refs_,
-): FilterRefs<Refs_, Ref.AnyInternal> => refs as any;
-
-export const justPublic = <Refs_ extends RefsAnyWithProps>(
-  refs: Refs_,
-): FilterRefs<Refs_, Ref.AnyPublic> => refs as any;
-
-export type RefsAnyWithProps =
+type Any =
   | {
-      readonly [key: string]: RefsAnyWithProps;
+      readonly [key: string]: Any;
     }
   | Ref.Any;
 
 export const make = <Spec_ extends Spec.AnyWithProps>(
   spec: Spec_,
-): Refs<Spec_> => makeHelper(spec.groups) as Refs<Spec_>;
+): {
+  all: Refs<Spec_>;
+  public: Refs<Spec_, Ref.AnyPublic>;
+  internal: Refs<Spec_, Ref.AnyInternal>;
+} => {
+  const refs = makeHelper(spec.groups);
+  return {
+    all: refs as Refs<Spec_>,
+    public: refs as Refs<Spec_, Ref.AnyPublic>,
+    internal: refs as Refs<Spec_, Ref.AnyInternal>,
+  };
+};
 
 const makeHelper = (
   groups: Record.ReadonlyRecord<string, GroupSpec.Any>,
   groupPath: string | null = null,
-): RefsAnyWithProps =>
+): Any =>
   pipe(
     groups as Record.ReadonlyRecord<string, GroupSpec.AnyWithProps>,
     Record.map((group) => {

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -1,0 +1,350 @@
+import { bench } from "@ark/attest";
+import { Schema } from "effect";
+import * as FunctionSpec from "../src/FunctionSpec";
+import * as GroupSpec from "../src/GroupSpec";
+import type * as Ref from "../src/Ref";
+import type * as Refs from "../src/Refs";
+import * as Spec from "../src/Spec";
+
+const Args = Schema.Struct({});
+const Returns = Schema.String;
+
+// --- Small spec: 1 group, 2 functions ---
+const SmallSpec = Spec.make().add(
+  GroupSpec.make("auth")
+    .addFunction(
+      FunctionSpec.query({ name: "login", args: Args, returns: Returns }),
+    )
+    .addFunction(
+      FunctionSpec.mutation({ name: "logout", args: Args, returns: Returns }),
+    ),
+);
+type SmallSpec = typeof SmallSpec;
+
+// --- Medium spec (original): 4 groups, 12 functions ---
+const MediumSpec = Spec.make()
+  .add(
+    GroupSpec.make("users")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "getById",
+          args: Args,
+          returns: Returns,
+        }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "create", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalMutation({
+          name: "remove",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("posts")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.query({ name: "getById", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalMutation({
+          name: "archive",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("comments")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "create", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "flagged",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("analytics")
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "aggregate",
+          args: Args,
+          returns: Returns,
+        }),
+      )
+      .addFunction(
+        FunctionSpec.internalAction({
+          name: "exportData",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  );
+
+type MediumSpec = typeof MediumSpec;
+
+// --- Large spec: 8 groups, 28 functions ---
+const LargeSpec = Spec.make()
+  .add(
+    GroupSpec.make("users")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "getById",
+          args: Args,
+          returns: Returns,
+        }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "create", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalMutation({
+          name: "remove",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("posts")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.query({ name: "getById", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalMutation({
+          name: "archive",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("comments")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "create", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "flagged",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("analytics")
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "aggregate",
+          args: Args,
+          returns: Returns,
+        }),
+      )
+      .addFunction(
+        FunctionSpec.internalAction({
+          name: "exportData",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("products")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.query({ name: "getById", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "create", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalMutation({
+          name: "archive",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("orders")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.query({ name: "getById", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "create", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalMutation({
+          name: "cancel",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("notifications")
+      .addFunction(
+        FunctionSpec.query({ name: "list", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({
+          name: "markRead",
+          args: Args,
+          returns: Returns,
+        }),
+      )
+      .addFunction(
+        FunctionSpec.internalQuery({
+          name: "flagged",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  )
+  .add(
+    GroupSpec.make("settings")
+      .addFunction(
+        FunctionSpec.query({ name: "get", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.mutation({ name: "update", args: Args, returns: Returns }),
+      )
+      .addFunction(
+        FunctionSpec.internalAction({
+          name: "reset",
+          args: Args,
+          returns: Returns,
+        }),
+      ),
+  );
+
+type LargeSpec = typeof LargeSpec;
+
+// Baseline expression: force the Refs module types to load so module-level
+// instantiations are not counted in individual benchmarks.
+void ({} as Refs.Refs<any>);
+
+bench("Refs<Spec> (unfiltered)", () => {
+  return {} as Refs.Refs<MediumSpec>;
+}).types([786, "instantiations"]);
+
+bench("Refs<Spec, AnyPublic> (public-filtered)", () => {
+  return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>;
+}).types([882, "instantiations"]);
+
+bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
+  return {} as Refs.Refs<MediumSpec, Ref.AnyInternal>;
+}).types([882, "instantiations"]);
+
+// Laziness: accessing one leaf should be cheaper than accessing all leaves.
+// If the type were eagerly evaluated, both benchmarks would have the same
+// instantiation count. The gap between them proves lazy evaluation.
+
+bench("resolve one leaf", () => {
+  return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
+}).types([882, "instantiations"]);
+
+bench("resolve all leaves", () => {
+  return [
+    {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"],
+    {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["create"],
+    {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["posts"]["list"],
+    {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["posts"]["getById"],
+    {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
+    {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
+  ];
+}).types([882, "instantiations"]);
+
+// --- Small spec (1 group, 2 functions) ---
+
+bench("small: Refs (unfiltered)", () => {
+  return {} as Refs.Refs<SmallSpec>;
+}).types([277, "instantiations"]);
+
+bench("small: Refs (public-filtered)", () => {
+  return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
+}).types([373, "instantiations"]);
+
+bench("small: Refs (internal-filtered)", () => {
+  return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
+}).types([373, "instantiations"]);
+
+bench("small: Refs (resolve one leaf)", () => {
+  return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
+}).types([373, "instantiations"]);
+
+bench("small: Refs (resolve all leaves)", () => {
+  return [
+    {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
+    {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
+  ];
+}).types([373, "instantiations"]);
+
+// --- Large spec (8 groups, 28 functions) ---
+
+bench("large: Refs (unfiltered)", () => {
+  return {} as Refs.Refs<LargeSpec>;
+}).types([1440, "instantiations"]);
+
+bench("large: Refs (public-filtered)", () => {
+  return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>;
+}).types([1536, "instantiations"]);
+
+bench("large: Refs (internal-filtered)", () => {
+  return {} as Refs.Refs<LargeSpec, Ref.AnyInternal>;
+}).types([1536, "instantiations"]);
+
+bench("large: Refs (resolve one leaf)", () => {
+  return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
+}).types([1536, "instantiations"]);
+
+bench("large: Refs (resolve all leaves)", () => {
+  type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
+  return [
+    {} as PublicRefs["users"]["list"],
+    {} as PublicRefs["users"]["create"],
+    {} as PublicRefs["posts"]["list"],
+    {} as PublicRefs["posts"]["getById"],
+    {} as PublicRefs["comments"]["list"],
+    {} as PublicRefs["comments"]["create"],
+    {} as PublicRefs["products"]["list"],
+    {} as PublicRefs["products"]["getById"],
+    {} as PublicRefs["products"]["create"],
+    {} as PublicRefs["orders"]["list"],
+    {} as PublicRefs["orders"]["getById"],
+    {} as PublicRefs["orders"]["create"],
+    {} as PublicRefs["notifications"]["list"],
+    {} as PublicRefs["notifications"]["markRead"],
+    {} as PublicRefs["settings"]["get"],
+    {} as PublicRefs["settings"]["update"],
+  ];
+}).types([1536, "instantiations"]);

--- a/packages/server/test/confect/_generated/refs.ts
+++ b/packages/server/test/confect/_generated/refs.ts
@@ -1,7 +1,4 @@
 import { Refs } from "@confect/core";
 import spec from "../spec";
 
-const refs = Refs.make(spec);
-
-export const api = Refs.justPublic(refs);
-export const internal = Refs.justInternal(refs);
+export const { public: api, internal } = Refs.make(spec);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
         specifier: ^3.19.3
         version: 3.19.3
     devDependencies:
+      '@ark/attest':
+        specifier: ^0.56.0
+        version: 0.56.0(typescript@5.9.3)
       '@effect/language-service':
         specifier: 0.56.0
         version: 0.56.0
@@ -460,6 +463,15 @@ packages:
   '@arethetypeswrong/core@0.18.2':
     resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
     engines: {node: '>=20'}
+
+  '@ark/attest@0.56.0':
+    resolution: {integrity: sha512-Pngs8f1UJiWbeO8LKVdyBL0K3rT/PDVACR7TPyCEULNcN8V1rVec6dKvUnQVpQSj60p4ejlK6dKs+fQoqdUMqA==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
+
+  '@ark/fs@0.56.0':
+    resolution: {integrity: sha512-zY/wDDhcvmt6/upQwZM766PAnvIzdEMcgydUGd9pqY9FMGNo9I9uE4RYAfms9AeUUtbZJu2h2Ua0tvFsO5XF4Q==}
 
   '@ark/schema@0.55.0':
     resolution: {integrity: sha512-IlSIc0FmLKTDGr4I/FzNHauMn0MADA6bCjT1wauu4k6MyxhC1R9gz0olNpIRvK7lGGDwtc/VO0RUDNvVQW5WFg==}
@@ -1675,6 +1687,11 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@prettier/sync@0.6.1':
+    resolution: {integrity: sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==}
+    peerDependencies:
+      prettier: '*'
+
   '@puppeteer/browsers@2.3.0':
     resolution: {integrity: sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==}
     engines: {node: '>=18'}
@@ -2478,6 +2495,15 @@ packages:
     resolution: {integrity: sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/analyze-trace@0.10.1':
+    resolution: {integrity: sha512-RnlSOPh14QbopGCApgkSx5UBgGda5MX1cHqp2fsqfiDyCwGL/m1jaeB9fzu7didVS81LQqGZZuxFBcg8YU8EVw==}
+    hasBin: true
+
+  '@typescript/vfs@1.6.1':
+    resolution: {integrity: sha512-JwoxboBh7Oz1v38tPbkrZ62ZXNHAk9bJ7c9x0eI5zBfBnBYGhURdbnh7Z4smN/MV48Y5OCcZb58n972UtbazsA==}
+    peerDependencies:
+      typescript: '*'
+
   '@typescript/vfs@1.6.2':
     resolution: {integrity: sha512-hoBwJwcbKHmvd2QVebiytN1aELvpk9B74B4L1mFm/XT1Q/VOYAWl2vQ9AWRFtQq8zmz6enTpfTV8WRc4ATjW/g==}
     peerDependencies:
@@ -2663,11 +2689,17 @@ packages:
   arkregex@0.0.3:
     resolution: {integrity: sha512-bU21QJOJEFJK+BPNgv+5bVXkvRxyAvgnon75D92newgHxkBJTgiFwQxusyViYyJkETsddPlHyspshDQcCzmkNg==}
 
+  arkregex@0.0.4:
+    resolution: {integrity: sha512-biS/FkvSwQq59TZ453piUp8bxMui11pgOMV9WHAnli1F8o0ayNCZzUwQadL/bGIUic5TkS/QlPcyMuI8ZIwedQ==}
+
   arkregex@0.0.5:
     resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
 
   arktype@2.1.27:
     resolution: {integrity: sha512-enctOHxI4SULBv/TDtCVi5M8oLd4J5SVlPUblXDzSsOYQNMzmVbUosGBnJuZDKmFlN5Ie0/QVEuTE+Z5X1UhsQ==}
+
+  arktype@2.1.28:
+    resolution: {integrity: sha512-LVZqXl2zWRpNFnbITrtFmqeqNkPPo+KemuzbGSY6jvJwCb4v8NsDzrWOLHnQgWl26TkJeWWcUNUeBpq2Mst1/Q==}
 
   arktype@2.1.29:
     resolution: {integrity: sha512-jyfKk4xIOzvYNayqnD8ZJQqOwcrTOUbIU4293yrzAjA3O1dWh61j71ArMQ6tS/u4pD7vabSPe7nG3RCyoXW6RQ==}
@@ -2960,6 +2992,9 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -3518,6 +3553,10 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -4286,6 +4325,10 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
   jsonpath-plus@10.3.0:
     resolution: {integrity: sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==}
     engines: {node: '>=18.0.0'}
@@ -4294,6 +4337,11 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  jsonstream-next@3.0.0:
+    resolution: {integrity: sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
@@ -4392,6 +4440,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-synchronized@0.8.0:
+    resolution: {integrity: sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -5597,6 +5648,9 @@ packages:
   spdx-license-ids@3.0.21:
     resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
 
+  split2@3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -5741,6 +5795,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  through2@4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -5790,6 +5847,10 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -6303,9 +6364,17 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.7.1:
     resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
@@ -6375,6 +6444,21 @@ snapshots:
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
     optional: true
+
+  '@ark/attest@0.56.0(typescript@5.9.3)':
+    dependencies:
+      '@ark/fs': 0.56.0
+      '@ark/util': 0.56.0
+      '@prettier/sync': 0.6.1(prettier@3.6.2)
+      '@typescript/analyze-trace': 0.10.1
+      '@typescript/vfs': 1.6.1(typescript@5.9.3)
+      arktype: 2.1.28
+      prettier: 3.6.2
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ark/fs@0.56.0': {}
 
   '@ark/schema@0.55.0':
     dependencies:
@@ -7830,6 +7914,11 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@prettier/sync@0.6.1(prettier@3.6.2)':
+    dependencies:
+      make-synchronized: 0.8.0
+      prettier: 3.6.2
+
   '@puppeteer/browsers@2.3.0':
     dependencies:
       debug: 4.4.1
@@ -8693,6 +8782,24 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       eslint-visitor-keys: 4.2.1
 
+  '@typescript/analyze-trace@0.10.1':
+    dependencies:
+      chalk: 4.1.2
+      exit: 0.1.2
+      jsonparse: 1.3.1
+      jsonstream-next: 3.0.0
+      p-limit: 3.1.0
+      split2: 3.2.2
+      treeify: 1.1.0
+      yargs: 16.2.0
+
+  '@typescript/vfs@1.6.1(typescript@5.9.3)':
+    dependencies:
+      debug: 4.4.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript/vfs@1.6.2(typescript@5.9.3)':
     dependencies:
       debug: 4.4.1
@@ -8884,6 +8991,10 @@ snapshots:
     dependencies:
       '@ark/util': 0.55.0
 
+  arkregex@0.0.4:
+    dependencies:
+      '@ark/util': 0.56.0
+
   arkregex@0.0.5:
     dependencies:
       '@ark/util': 0.56.0
@@ -8893,6 +9004,12 @@ snapshots:
       '@ark/schema': 0.55.0
       '@ark/util': 0.55.0
       arkregex: 0.0.3
+
+  arktype@2.1.28:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.4
 
   arktype@2.1.29:
     dependencies:
@@ -9189,6 +9306,12 @@ snapshots:
       string-width: 7.2.0
 
   cli-width@4.1.0: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -9874,6 +9997,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  exit@0.1.2: {}
 
   expect-type@1.2.2: {}
 
@@ -10812,6 +10937,8 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonparse@1.3.1: {}
+
   jsonpath-plus@10.3.0:
     dependencies:
       '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
@@ -10819,6 +10946,11 @@ snapshots:
       jsep: 1.4.0
 
   jsonpointer@5.0.1: {}
+
+  jsonstream-next@3.0.0:
+    dependencies:
+      jsonparse: 1.3.1
+      through2: 4.0.2
 
   katex@0.16.22:
     dependencies:
@@ -10904,6 +11036,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  make-synchronized@0.8.0: {}
 
   markdown-extensions@2.0.0: {}
 
@@ -12655,6 +12789,10 @@ snapshots:
 
   spdx-license-ids@3.0.21: {}
 
+  split2@3.2.2:
+    dependencies:
+      readable-stream: 3.6.2
+
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3: {}
@@ -12859,6 +12997,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.2
+
   through@2.3.8: {}
 
   tinybench@2.9.0: {}
@@ -12891,6 +13033,8 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
+
+  treeify@1.1.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -13485,7 +13629,19 @@ snapshots:
 
   yaml@2.6.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.1:
     dependencies:


### PR DESCRIPTION
I was getting the TS2589 error on `export const api = Refs.justPublic(refs);` possibly because I had a lot of groups / functions in my spec. 
Removing the `extends Record<string, never>` check from the mapped key type filtering prevents eager evaluation of the entire API tree depth, so now TS can evaluate the tree lazily (via `FilterRefs<Refs_[K], Predicate>`) when trying to access inner groups / functions from `api` because values themselves aren't evaluated until they need to be accessed (e.g. `api.groupA.groupB.fun1`). 
I believe one side effect of this is groups containing only internal functions will remain as empty objects in the public `api`, rather than being removed entirely, but this doesn't seem to have disrupted any typechecks.