### PR TITLE
Push to release branch after npm publish so docs deploy only for released versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         run: pnpm install
 
       - name: Create release pull request or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm release
@@ -43,3 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update docs deployment branch
+        if: steps.changesets.outputs.published == 'true'
+        run: git push origin HEAD:refs/heads/release


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects when the `release` branch is updated; failure would mainly impact docs deployment timing, not runtime code.
> 
> **Overview**
> Updates the GitHub Actions `Release` workflow to capture the `changesets/action` step output and, **only when a publish actually occurs** (`steps.changesets.outputs.published == 'true'`), push the current `HEAD` to the `release` branch.
> 
> This gates docs deployment (via the `release` branch) to released versions instead of every run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e40e7f4951981eb3aca9d719a1de18381f396ffb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->