### PR TITLE
fix(ci): grant contents write for docs deployment branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,6 @@ jobs:
 
       - name: Update docs deployment branch
         if: steps.changesets.outputs.published == 'true'
-        run: git push origin HEAD:refs/heads/release
+        run: |
+          git fetch origin release || true
+          git push --force-with-lease origin HEAD:refs/heads/release


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Actual failure (from `gh run view 23986493151 --log-failed`)

The step failed with a **non-fast-forward** rejection, not a token error:

```
! [rejected]        HEAD -> release (fetch first)
error: failed to push some refs
hint: Updates were rejected because the remote contains work that you do not have locally.
```

So `release` had diverged from `main` (extra commits on `release`, or history that doesn’t fast-forward from the current `HEAD`).

## Fix

1. **`permissions: contents: write`** — still useful so the token may push when org defaults are read-only.
2. **`git fetch origin release || true`** then **`git push --force-with-lease origin HEAD:refs/heads/release`** — updates `release` to match the published `main` while refusing to overwrite if someone else pushed to `release` since the fetch (safer than a bare `--force`).

## Verification

After merge, the next successful Version Packages publish should update `release` even when it had diverged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbcdbfcf-ed88-4850-9036-77fb0404f3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbcdbfcf-ed88-4850-9036-77fb0404f3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

