### PR TITLE
Configure release workflow for npm Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Checkout repo
@@ -33,6 +34,7 @@ jobs:
         with:
           node-version-file: "package.json"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install
@@ -45,7 +47,6 @@ jobs:
           branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update docs deployment branch
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Configures the release workflow for [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers) usage, following Step 2 of the npm documentation.

### Changes to `.github/workflows/release.yml`

- **Added `id-token: write` permission** — required for GitHub Actions to generate OIDC tokens that npm uses for Trusted Publisher authentication.
- **Added `registry-url: "https://registry.npmjs.org"` to the `setup-node` step** — ensures the npm CLI knows which registry to authenticate against via OIDC.
- **Removed `NPM_TOKEN` secret** — no longer needed since authentication is handled via OIDC. The npm CLI automatically detects the OIDC environment and uses short-lived, workflow-specific credentials instead of long-lived tokens.

### Prerequisites (Step 1)

Each `@confect/*` package must have a Trusted Publisher configured on npmjs.com, pointing to the `release.yml` workflow file in this repository. See [Step 1 of the npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom).

### Security benefits

- Eliminates long-lived `NPM_TOKEN` secret that could be accidentally exposed or compromised
- Each publish uses short-lived, cryptographically-signed OIDC tokens scoped to this specific workflow
- Provenance attestations are automatically generated for published packages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53bb8518-49cb-44f0-a0c4-73acdc8e3aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53bb8518-49cb-44f0-a0c4-73acdc8e3aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

