### PR TITLE
fix(ci): add pull-requests write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `release.yml` workflow failure on `main` introduced after PR #364.

### Root Cause

PR #364 added `id-token: write` to the explicit `permissions` block for npm Trusted Publishers support, but did not add `pull-requests: write`. When GitHub Actions has an explicit `permissions` block, **all unlisted permissions default to `none`**. The `changesets/action` needs `pull-requests: write` to create the "Version Packages" PR.

The PR #364 merge commit itself (`d008f22`) succeeded because there were no pending changesets at the time, so the action never attempted to create a PR. Subsequent commits (`3f5947a`, `5ee8afb`) added changesets, and the workflow began failing with:

```
HttpError: Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

### Fix

Added `pull-requests: write` to the job's `permissions` block.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dc2d852-0015-4146-ae4d-5af9984527d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dc2d852-0015-4146-ae4d-5af9984527d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

