### PR TITLE
docs: document `useQuery` `"skip"` option

### DIFF
--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -78,6 +78,34 @@ const NoteList = () => {
 };
 ```
 
+### Skipping queries
+
+Pass `"skip"` instead of args to disable the query subscription. The hook returns `undefined` when skipped, just as it does while loading. This is useful for conditional queries where a prerequisite value may not yet be available.
+
+```tsx
+import { useQuery } from "@confect/react";
+import refs from "../confect/_generated/refs";
+
+const NoteDetail = ({
+  selectedId,
+}: {
+  selectedId: string | undefined;
+}) => {
+  const note = useQuery(
+    refs.public.notes.get,
+    selectedId !== undefined ? { id: selectedId } : "skip",
+  );
+
+  if (note === undefined) {
+    return (
+      <p>{selectedId === undefined ? "Select a note" : "Loading…"}</p>
+    );
+  }
+
+  return <p>{note.text}</p>;
+};
+```
+
 ## `useMutation`
 
 Returns a function that encodes args using the spec's `args` schema, calls the Convex mutation, and decodes the result using the spec's `returns` schema. Returns `(args) => Promise<T>`, matching Convex's `useMutation`.
@@ -147,3 +175,4 @@ const RandomNumber = () => {
 | Functions referenced via `api.module.fn` | Functions referenced via `refs` |
 | Args passed directly to Convex as-is | Args are schema-encoded from `Type` to `Encoded` before sending to Convex |
 | Return values received directly from Convex as-is | Return values are schema-decoded from `Encoded` to `Type` before returning |
+| Pass `"skip"` to disable query subscription | Same — pass `"skip"` to disable query subscription |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the `"skip"` option for `useQuery` added in PR #373.

### Changes

**`apps/docs/clients/react.mdx`**:
- Added a "Skipping queries" subsection under `useQuery` with an explanation and a practical code example showing conditional query execution.
- Added a row to the "Differences from vanilla Convex hooks" comparison table noting that `"skip"` works identically in both vanilla Convex and Confect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1257472e-214d-4fd7-be09-43c1f02b67bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1257472e-214d-4fd7-be09-43c1f02b67bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

