### PR TITLE
Move opensrc docs to a skill and upgrade opensrc CLI

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -11,7 +11,7 @@
     "beforeShellExecution": [
       {
         "type": "prompt",
-        "prompt": "Disallow this command if it is trying to read or search dependency source code inside `node_modules` or `.pnpm-store` (e.g. `cat`, `head`, `tail`, `grep`, `rg`, `find` targeting source files in those directories). Allow maintenance commands (`rm`, `du`, `ls`, `install`, `pnpm`, `npm`) and commands that merely mention `node_modules` in flags or output paths. If you reject this command, tell the agent that it must use the `opensrc` tool to fetch the dependency source code into `opensrc/` instead.",
+        "prompt": "Disallow this command if it is trying to read or search dependency source code inside `node_modules` or `.pnpm-store` (e.g. `cat`, `head`, `tail`, `grep`, `rg`, `find` targeting source files in those directories). Allow maintenance commands (`rm`, `du`, `ls`, `install`, `pnpm`, `npm`) and commands that merely mention `node_modules` in flags or output paths. If you reject this command, tell the agent it must use `pnpm exec opensrc path <package>` so source is fetched into the global opensrc cache (`~/.opensrc/`), then read from the path that command prints.",
         "matcher": "node_modules|.pnpm-store|.pnpm",
         "timeout": 10
       }

--- a/.cursor/hooks/redirect-to-opensrc.ts
+++ b/.cursor/hooks/redirect-to-opensrc.ts
@@ -88,15 +88,15 @@ const program = Effect.gen(function* () {
       JSON.stringify({
         permission: "deny",
         user_message:
-          "Use `pnpm opensrc <package>` instead of reading from `node_modules` or `.pnpm-store`.",
+          "Use `pnpm exec opensrc path <package>` instead of reading from `node_modules` or `.pnpm-store`.",
         agent_message: Array.join(
           [
             "Do not read source code from `node_modules` or `.pnpm-store`.",
-            "Use the opensrc tool to fetch dependency source code into `opensrc/` instead.",
+            "Use the opensrc CLI (cached under `~/.opensrc/`) to fetch dependency source instead.",
             "",
-            "1. Check `opensrc/sources.json` to see if the package was already fetched.",
-            "2. If not, run: `pnpm opensrc <package-name>`",
-            "3. Then read from `opensrc/<package-name>/`.",
+            "1. Run `pnpm exec opensrc list --json` (or read `~/.opensrc/sources.json`) to see what is already cached.",
+            "2. If needed, run: `pnpm exec opensrc path <package-name>` — it prints the absolute source directory.",
+            "3. Read files under that printed path.",
           ],
           "\n",
         ),

--- a/.cursor/skills/opensrc/SKILL.md
+++ b/.cursor/skills/opensrc/SKILL.md
@@ -41,7 +41,15 @@ pnpm exec opensrc path owner/repo#main
 
 ### Version resolution
 
-For npm packages, opensrc detects the installed version from lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`). Point at another project with `--cwd`:
+For npm packages, opensrc resolves the version in this order:
+
+1. `node_modules/<pkg>/package.json`
+2. `package-lock.json`
+3. `pnpm-lock.yaml`
+4. `yarn.lock`
+5. Registry `latest`
+
+Point at another project with `--cwd`:
 
 ```bash
 pnpm exec opensrc path zod --cwd /path/to/project

--- a/.cursor/skills/opensrc/SKILL.md
+++ b/.cursor/skills/opensrc/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: opensrc
+description: Fetch dependency source code to give AI agents deeper implementation context. Use when the agent needs to understand how a library works internally, read source code for a package, fetch implementation details for a dependency, or explore how an npm/PyPI/crates.io package is built. Triggers include "fetch source for", "read the source of", "how does X work internally", "get the implementation of", "opensrc path", or any task requiring access to dependency source code beyond types and docs.
+---
+
+# Source code with opensrc
+
+The `opensrc` dev dependency resolves packages to git repositories, shallow-clones at the right tag, and caches source globally under `~/.opensrc/` (override with `OPENSRC_HOME`). Metadata is tracked in `~/.opensrc/sources.json`. This CLI does **not** write an `opensrc/` directory in the repo or modify `AGENTS.md`.
+
+In this monorepo, invoke the CLI with **`pnpm exec opensrc`** from the workspace root (or `pnpm --dir /path/to/project exec opensrc` when resolving versions from another project).
+
+## Core pattern
+
+```bash
+rg "parse" "$(pnpm exec opensrc path zod)"
+cat "$(pnpm exec opensrc path zod)/src/types.ts"
+find "$(pnpm exec opensrc path zod)" -name "*.test.ts"
+```
+
+`pnpm exec opensrc path <pkg>` prints the absolute path to cached source on stdout (stderr is progress). Subshells and `$(...)` work as shown.
+
+## Fetching source
+
+```bash
+pnpm exec opensrc path zod
+pnpm exec opensrc path pypi:requests
+pnpm exec opensrc path crates:serde
+pnpm exec opensrc path facebook/react
+
+# Multiple packages
+pnpm exec opensrc path zod react next
+pnpm exec opensrc path pypi:requests pypi:flask
+pnpm exec opensrc path crates:serde crates:tokio
+
+# Specific versions
+pnpm exec opensrc path zod@3.22.0
+pnpm exec opensrc path pypi:flask@3.0.0
+pnpm exec opensrc path owner/repo@v1.0.0
+pnpm exec opensrc path owner/repo#main
+```
+
+### Version resolution
+
+For npm packages, opensrc detects the installed version from lockfiles (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`). Point at another project with `--cwd`:
+
+```bash
+pnpm exec opensrc path zod --cwd /path/to/project
+```
+
+For PyPI and crates.io, use an explicit version or latest. For repos, use `@ref` or `#ref` for a branch, tag, or commit.
+
+## Managing the cache
+
+```bash
+pnpm exec opensrc list
+pnpm exec opensrc list --json
+
+pnpm exec opensrc remove zod
+pnpm exec opensrc remove facebook/react
+
+pnpm exec opensrc clean
+pnpm exec opensrc clean --npm
+pnpm exec opensrc clean --pypi
+pnpm exec opensrc clean --crates
+pnpm exec opensrc clean --packages
+pnpm exec opensrc clean --repos
+```
+
+## When to fetch source
+
+Fetch when you need implementation behavior that types or docs do not spell out (debugging, edge cases, internal patterns). Skip it for straightforward API questions answerable from documentation or signatures.

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ coverage/
 dist/
 node-compile-cache/
 node_modules/
-opensrc/
+/opensrc/
 tsconfig.vitest-temp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,5 @@
 # AGENTS.md
 
-<!-- opensrc:start -->
-
-## Source Code Reference
-
-Source code for dependencies is available in `opensrc/` for deeper understanding of implementation details.
-
-See `opensrc/sources.json` for the list of available packages and their versions.
-
-Use this source code when you need to understand how a package works internally, not just its types/interface.
-
-### Fetching Additional Source Code
-
-To fetch source code for a package or repository you need to understand, run:
-
-```bash
-npx opensrc <package>           # npm package (e.g., npx opensrc zod)
-npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
-npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
-npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
-```
-
-<!-- opensrc:end -->
-
 ## Cursor Cloud specific instructions
 
 ### Running the example app

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "effect": "3.19.19",
     "eslint": "10.0.2",
     "eslint-plugin-mdx": "3.7.0",
-    "opensrc": "^0.6.0",
+    "opensrc": "^0.7.1",
     "prettier": "3.8.1",
     "tsdown": "0.20.3",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: 3.7.0
         version: 3.7.0(eslint@10.0.2(jiti@2.5.1))
       opensrc:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.1
+        version: 0.7.1
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -1541,12 +1541,6 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
-
-  '@kwsites/file-exists@1.1.1':
-    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
-
-  '@kwsites/promise-deferred@1.1.1':
-    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3236,10 +3230,6 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -5113,9 +5103,8 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
-  opensrc@0.6.0:
-    resolution: {integrity: sha512-6LMcKaqz/s5wHlEY+fFERkbHhC1qYqhCucaYTcez9IAGlPW4+aYtptY3H9orAT1hp90pv6hABAlfrmsybtngwg==}
-    engines: {node: '>=18.0.0'}
+  opensrc@0.7.1:
+    resolution: {integrity: sha512-Dah1lZtpOckjJt4yHwTK2/VwMQX6WRoaWzsMc11OzS+EjyETUvdLqEEYqRBSaOd+uDZ3EQcxl2UeYl2AdCnpLw==}
     hasBin: true
 
   optionator@0.9.4:
@@ -5797,9 +5786,6 @@ packages:
   simple-eval@1.0.1:
     resolution: {integrity: sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==}
     engines: {node: '>=12'}
-
-  simple-git@3.32.3:
-    resolution: {integrity: sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -7647,14 +7633,6 @@ snapshots:
   '@jsep-plugin/ternary@1.1.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
-
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@kwsites/promise-deferred@1.1.1': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -9739,8 +9717,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
-
-  commander@12.1.0: {}
 
   commander@2.20.3: {}
 
@@ -12176,12 +12152,7 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
-  opensrc@0.6.0:
-    dependencies:
-      commander: 12.1.0
-      simple-git: 3.32.3
-    transitivePeerDependencies:
-      - supports-color
+  opensrc@0.7.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -13066,14 +13037,6 @@ snapshots:
   simple-eval@1.0.1:
     dependencies:
       jsep: 1.4.0
-
-  simple-git@3.32.3:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   simple-swizzle@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 onlyBuiltDependencies:
   - bun
+  - opensrc
   - sharp
 
 packageExtensions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removed the `<!-- opensrc:start -->` … `<!-- opensrc:end -->` block from `AGENTS.md` and moved equivalent guidance into `.cursor/skills/opensrc/SKILL.md`, using **`pnpm exec opensrc`** (no `npx` / `npm` in that content).
- Upgraded the `opensrc` dev dependency from **0.6.x** (Node CLI that rewrote `AGENTS.md`) to **0.7.x** (Rust CLI). That version does not inject or update an opensrc section in `AGENTS.md`, so running the CLI no longer regenerates that content. Verified with `pnpm exec opensrc list` after copying `AGENTS.md` aside.
- Added `opensrc` to `onlyBuiltDependencies` in `pnpm-workspace.yaml` so `pnpm install` runs the package postinstall and downloads the native binary (otherwise pnpm skipped the build script).
- Fixed `.gitignore`: `opensrc/` was matching **any** path segment named `opensrc`, which hid `.cursor/skills/opensrc/`. It is now anchored as `/opensrc/` so only the repo-root cache directory stays ignored.
- Updated `.cursor/hooks/redirect-to-opensrc.ts` and `.cursor/hooks.json` copy to describe the global cache (`~/.opensrc/`) and `pnpm exec opensrc path …` instead of the old in-repo `opensrc/` workflow.

## Testing

- `pnpm lint`
- Manual: `cmp` on `AGENTS.md` before/after `pnpm exec opensrc list`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcbf62dc-6dda-4de3-aa4e-e94b7df8ab6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcbf62dc-6dda-4de3-aa4e-e94b7df8ab6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

