### PR TITLE
fix: Query handlers bypass Convex's reactive cache

### DIFF
--- a/.changeset/fix-query-date-now-cache.md
+++ b/.changeset/fix-query-date-now-cache.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": patch
+---
+
+Fix Confect-wrapped Convex queries so internal Effect runtime calls to `Date.now()` no longer invalidate Convex's reactive query cache. Query handlers now stub `Date.now()` by default while preserving real-time access through Effect's `Clock` service for callers that intentionally opt in.

--- a/apps/docs/server/database/reading.mdx
+++ b/apps/docs/server/database/reading.mdx
@@ -138,3 +138,28 @@ Get a `Stream` of documents matching the query.
 ```ts
 reader.table("notes").index("by_creation_time").stream();
 ```
+
+### Accessing the current time
+
+Convex queries are cached based on the data they read. Calling `Date.now()` directly in a query reads real wall-clock time, which [invalidates the cache](https://docs.convex.dev/production/best-practices/) and causes unnecessary re-execution — Convex's own best practices advise against it.
+
+To keep queries cacheable by default, confect stubs `Date.now()` to return `0` for the span of a query handler. If you need the current time inside a query, reach for Effect's `Clock` service instead:
+
+```ts
+import { Clock, Effect } from "effect";
+import { DatabaseReader } from "./confect/_generated/services";
+
+Effect.gen(function* () {
+  const reader = yield* DatabaseReader;
+  const rows = yield* reader.table("notes").index("by_creation_time").collect();
+  const fetchedAt = yield* Clock.currentTimeMillis;
+
+  return { fetchedAt, rows };
+});
+```
+
+Reading `Clock.currentTimeMillis` (or `Clock.currentTimeNanos`) returns the real timestamp. Note that this is an **opt-in to cache invalidation**: any query that reads the clock will frequently bust the cache and be re-executed, rather than reliably served from cache. This matches Convex's behavior for any query that observes real time.
+
+If you don't actually need sub-second accuracy, prefer Convex's [recommended patterns](https://docs.convex.dev/production/best-practices/) — passing a coarse timestamp as a query argument, or maintaining a boolean/status field updated by a scheduled function — to preserve caching.
+
+Mutations and actions are unaffected: `Date.now()` works as expected there, and the `Clock` service returns the real timestamp without any caching concerns.

--- a/apps/docs/server/database/reading.mdx
+++ b/apps/docs/server/database/reading.mdx
@@ -151,7 +151,10 @@ import { DatabaseReader } from "./confect/_generated/services";
 
 Effect.gen(function* () {
   const reader = yield* DatabaseReader;
-  const rows = yield* reader.table("notes").index("by_creation_time").collect();
+  const rows = yield* reader
+    .table("notes")
+    .index("by_creation_time")
+    .collect();
   const fetchedAt = yield* Clock.currentTimeMillis;
 
   return { fetchedAt, rows };

--- a/packages/server/src/RegisteredConvexFunction.ts
+++ b/packages/server/src/RegisteredConvexFunction.ts
@@ -10,7 +10,7 @@ import {
   mutationGeneric,
   queryGeneric,
 } from "convex/server";
-import { Effect, Layer, Match, pipe, Schema } from "effect";
+import { Clock, Effect, Layer, Match, pipe, Schema } from "effect";
 import type * as Api from "./Api";
 import * as Auth from "./Auth";
 import * as ConvexConfigProvider from "./ConvexConfigProvider";
@@ -92,12 +92,40 @@ export const make = <Api_ extends Api.AnyWithPropsWithRuntime<"Convex">>(
     Match.exhaustive,
   );
 
+// Convex's query cache is invalidated by any Date.now() call during handler
+// execution. Effect's unsafeFork calls Date.now() when constructing a
+// FiberId.Runtime, which trips the cache for every confect-wrapped query. We
+// stub Date.now to 0 for the span of the handler; queries are forbidden from
+// relying on real time for correctness anyway.
+//
+// Users who explicitly want the real timestamp can still reach it via Effect's
+// Clock service (Clock.currentTimeMillis / Clock.currentTimeNanos). We provide
+// a Clock layer whose methods close over the *original* Date.now, so opting in
+// to Clock is an opt-in to worse caching — but caching is not broken by default.
 const zeroNow = () => 0;
-const withStubbedDateNow = async <T>(fn: () => Promise<T>): Promise<T> => {
+
+const unpatchedClock = (realNow: () => number): Clock.Clock => {
+  const bigint1e6 = BigInt(1_000_000);
+  const unsafeCurrentTimeMillis = () => realNow();
+  const unsafeCurrentTimeNanos = () => BigInt(realNow()) * bigint1e6;
+  const defaultClock = Clock.make();
+  return {
+    ...defaultClock,
+    unsafeCurrentTimeMillis,
+    unsafeCurrentTimeNanos,
+    currentTimeMillis: Effect.sync(unsafeCurrentTimeMillis),
+    currentTimeNanos: Effect.sync(unsafeCurrentTimeNanos),
+  };
+};
+
+const withStubbedDateNow = async <T>(
+  fn: (clock: Clock.Clock) => Promise<T>,
+): Promise<T> => {
   const orig = Date.now;
+  const clock = unpatchedClock(orig);
   Date.now = zeroNow;
   try {
-    return await fn();
+    return await fn(clock);
   } finally {
     Date.now = orig;
   }
@@ -142,7 +170,7 @@ const queryFunction = <
     >,
     actualArgs: ConvexArgs,
   ): Promise<ConvexReturns> =>
-    withStubbedDateNow(() =>
+    withStubbedDateNow((clock) =>
       pipe(
         actualArgs,
         Schema.decode(args),
@@ -170,6 +198,7 @@ const queryFunction = <
         Effect.andThen((convexReturns) =>
           Schema.encodeUnknown(returns)(convexReturns),
         ),
+        Effect.withClock(clock),
         Effect.runPromise,
       ),
     ),

--- a/packages/server/src/RegisteredConvexFunction.ts
+++ b/packages/server/src/RegisteredConvexFunction.ts
@@ -92,6 +92,17 @@ export const make = <Api_ extends Api.AnyWithPropsWithRuntime<"Convex">>(
     Match.exhaustive,
   );
 
+const zeroNow = () => 0;
+const withStubbedDateNow = async <T>(fn: () => Promise<T>): Promise<T> => {
+  const orig = Date.now;
+  Date.now = zeroNow;
+  try {
+    return await fn();
+  } finally {
+    Date.now = orig;
+  }
+};
+
 const queryFunction = <
   DatabaseSchema_ extends DatabaseSchema.AnyWithProps,
   Args,
@@ -131,34 +142,36 @@ const queryFunction = <
     >,
     actualArgs: ConvexArgs,
   ): Promise<ConvexReturns> =>
-    pipe(
-      actualArgs,
-      Schema.decode(args),
-      Effect.orDie,
-      Effect.andThen((decodedArgs) =>
-        pipe(
-          handler(decodedArgs),
-          Effect.provide(
-            Layer.mergeAll(
-              DatabaseReader.layer(databaseSchema, ctx.db),
-              Auth.layer(ctx.auth),
-              StorageReader.layer(ctx.storage),
-              QueryRunner.layer(ctx.runQuery),
-              Layer.succeed(
-                QueryCtx.QueryCtx<
-                  DataModel.ToConvex<DataModel.FromSchema<DatabaseSchema_>>
-                >(),
-                ctx,
+    withStubbedDateNow(() =>
+      pipe(
+        actualArgs,
+        Schema.decode(args),
+        Effect.orDie,
+        Effect.andThen((decodedArgs) =>
+          pipe(
+            handler(decodedArgs),
+            Effect.provide(
+              Layer.mergeAll(
+                DatabaseReader.layer(databaseSchema, ctx.db),
+                Auth.layer(ctx.auth),
+                StorageReader.layer(ctx.storage),
+                QueryRunner.layer(ctx.runQuery),
+                Layer.succeed(
+                  QueryCtx.QueryCtx<
+                    DataModel.ToConvex<DataModel.FromSchema<DatabaseSchema_>>
+                  >(),
+                  ctx,
+                ),
+                Layer.setConfigProvider(ConvexConfigProvider.make()),
               ),
-              Layer.setConfigProvider(ConvexConfigProvider.make()),
             ),
           ),
         ),
+        Effect.andThen((convexReturns) =>
+          Schema.encodeUnknown(returns)(convexReturns),
+        ),
+        Effect.runPromise,
       ),
-      Effect.andThen((convexReturns) =>
-        Schema.encodeUnknown(returns)(convexReturns),
-      ),
-      Effect.runPromise,
     ),
 });
 

--- a/packages/server/src/RegisteredConvexFunction.ts
+++ b/packages/server/src/RegisteredConvexFunction.ts
@@ -102,12 +102,10 @@ export const make = <Api_ extends Api.AnyWithPropsWithRuntime<"Convex">>(
 // Clock service (Clock.currentTimeMillis / Clock.currentTimeNanos). We provide
 // a Clock layer whose methods close over the *original* Date.now, so opting in
 // to Clock is an opt-in to worse caching — but caching is not broken by default.
-const zeroNow = () => 0;
-
-const unpatchedClock = (realNow: () => number): Clock.Clock => {
+const unpatchedClock = (realDateNow: () => number): Clock.Clock => {
   const bigint1e6 = BigInt(1_000_000);
-  const unsafeCurrentTimeMillis = () => realNow();
-  const unsafeCurrentTimeNanos = () => BigInt(realNow()) * bigint1e6;
+  const unsafeCurrentTimeMillis = () => realDateNow();
+  const unsafeCurrentTimeNanos = () => BigInt(realDateNow()) * bigint1e6;
   const defaultClock = Clock.make();
   return {
     ...defaultClock,
@@ -119,15 +117,15 @@ const unpatchedClock = (realNow: () => number): Clock.Clock => {
 };
 
 const withStubbedDateNow = async <T>(
-  fn: (clock: Clock.Clock) => Promise<T>,
+  queryHandler: (clock: Clock.Clock) => Promise<T>,
 ): Promise<T> => {
-  const orig = Date.now;
-  const clock = unpatchedClock(orig);
-  Date.now = zeroNow;
+  const realDateNow = Date.now;
+  const clock = unpatchedClock(realDateNow);
+  Date.now = () => 0;
   try {
-    return await fn(clock);
+    return await queryHandler(clock);
   } finally {
-    Date.now = orig;
+    Date.now = realDateNow;
   }
 };
 


### PR DESCRIPTION
# Issue

Confect-wrapped Convex query functions are intermittently re-executed against the database instead of being served from Convex's reactive cache. 

Equivalent hand-written native Convex queries on the same table cache 100% after the first call, so this is specific to confect's wrapper.

This makes confect impractical for read-heavy queries: the reactive cache is central to Convex's cost/latency story, and confect silently opts out of it intermittently.

## Cause

`Effect.runPromise` invokes `unsafeFork`, which constructs a `FiberId.Runtime(id, Date.now())`. Convex's query runtime treats any `Date.now()` call during handler execution as a cache-invalidating observation, so every confect query handler is flagged.

## Reproduction

On a static table (no writes):
```ts
// Hits cache 100% of time after first call
export const control = query({
  args: {},
  handler: async (ctx) => {
    const rows = await ctx.db.query("regions").collect();
    return rows
  },
});

// intermittent cache misses
export const listConfect = FunctionImpl.make(api, "regions", "listConfect", {
  args: Schema.Struct({}),
  returns: Schema.Array(RegionDoc),
  handler: () => Effect.gen(function* () {
    const reader = yield* DatabaseReader;
    return yield* reader.table("regions").index("by_creation_time").collect();
  }),
});
```

Call each 10 times and compare success Xms vs success (cached) in the Convex dashboard.

## Fix

Stub `Date.now` for the span of the query handler, and route Effect's `Clock` service through the captured original `Date.now` via `Effect.withClock`. Applied only to `queryFunction` — `mutationFunction` and `convexActionFunction` are untouched.

In Convex queries, calling `Date.now()` (or anything that reads real wall time) invalidates the query cache. Convex's own [[best practices](https://docs.convex.dev/production/best-practices/)](https://docs.convex.dev/production/best-practices/) advise against using `Date.now()` in queries for exactly this reason — it causes unnecessary cache churn and extra DB load.

The problem: Effect's `unsafeFork` calls `Date.now()` internally when constructing a `FiberId.Runtime`. Every confect-wrapped query handler was triggering this on every invocation, silently invalidating the cache even when the user's handler never touched time.

Stubbing `Date.now` to `() => 0` for the span of the query handler makes confect queries cacheable by default. Since the Convex docs already tell users not to rely on `Date.now()` in queries, no legitimate pattern is broken — any code that was calling `Date.now()` in a query was already cache-invalidating itself.

Mutations and actions run in contexts where `Date.now()` returns real time and user code is allowed to depend on it (e.g. writing `createdAt: Date.now()` into a row, or timestamping an API call in an action). Stubbing `Date.now` there would silently corrupt user data.

### Opting in to real time

Caching-preserving behavior is the **default**. Handlers that need a timestamp can **opt in** by reading through Effect's `Clock` service, which is provided with an implementation that closes over the captured original `Date.now`:

```ts
// Default: 100% cached after first call.
export const listRegions = FunctionImpl.make(api, "regions", "listRegions", {
  args: Schema.Struct({}),
  returns: Schema.Array(RegionDoc),
  handler: () =>
    Effect.gen(function* () {
      const reader = yield* DatabaseReader;
      return yield* reader.table("regions").index("by_creation_time").collect();
    }),
});

// Opt-in: reads the original Date.now via Clock → cache invalidated on every call.
export const listRegionsWithStamp = FunctionImpl.make(
  api,
  "regions",
  "listRegionsWithStamp",
  {
    args: Schema.Struct({}),
    returns: Schema.Struct({
      fetchedAt: Schema.Number,
      rows: Schema.Array(RegionDoc),
    }),
    handler: () =>
      Effect.gen(function* () {
        const reader = yield* DatabaseReader;
        const rows = yield* reader.table("regions").index("by_creation_time").collect();
        const fetchedAt = yield* Clock.currentTimeMillis;
        return { fetchedAt, rows };
      }),
  },
);
```

Raw `Date.now()` in handler code returns `0`; `Clock.currentTimeMillis` / `Clock.currentTimeNanos` return the real timestamp (and invalidate the cache as a consequence, which matches Convex's behavior for real-time reads).

## Verification

Applied the patch to `@confect/server` in `node_modules` and called confect queries that were previously missing cache 10+ times from the Convex dashboard as well as from `useQuery`.

- **Before the patch:** cached / uncached hits interleaved (~1-in-3 to 1-in-5 fresh DB hits).
- **After the patch (default):** `success Xms` on the first call, `success (cached)` on every subsequent call.
- **After the patch (opting in via `Clock.currentTimeMillis`):** `fetchedAt` returns the real timestamp; query is re-executed each call as expected for the opt-in.