### PR TITLE
Update `opensrc` integration workflow

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -11,7 +11,7 @@
     "beforeShellExecution": [
       {
         "type": "prompt",
-        "prompt": "Disallow this command if it is trying to read or search dependency source code inside `node_modules` or `.pnpm-store` (e.g. `cat`, `head`, `tail`, `grep`, `rg`, `find` targeting source files in those directories). Allow maintenance commands (`rm`, `du`, `ls`, `install`, `pnpm`, `npm`) and commands that merely mention `node_modules` in flags or output paths. If you reject this command, tell the agent that it must use the `opensrc` tool to fetch the dependency source code into `opensrc/` instead.",
+        "prompt": "Disallow this command if it is trying to read or search dependency source code inside `node_modules` or `.pnpm-store` (e.g. `cat`, `head`, `tail`, `grep`, `rg`, `find` targeting source files in those directories). Allow maintenance commands (`rm`, `du`, `ls`, `install`, `pnpm`, `npm`) and commands that merely mention `node_modules` in flags or output paths. If you reject this command, tell the agent to use `pnpm opensrc path <package>` inside the read or search command so OpenSrc resolves the cached source under `~/.opensrc/`.",
         "matcher": "node_modules|.pnpm-store|.pnpm",
         "timeout": 10
       }

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -11,7 +11,7 @@
     "beforeShellExecution": [
       {
         "type": "prompt",
-        "prompt": "Disallow this command if it is trying to read or search dependency source code inside `node_modules` or `.pnpm-store` (e.g. `cat`, `head`, `tail`, `grep`, `rg`, `find` targeting source files in those directories). Allow maintenance commands (`rm`, `du`, `ls`, `install`, `pnpm`, `npm`) and commands that merely mention `node_modules` in flags or output paths. If you reject this command, tell the agent to use `pnpm opensrc path <package>` inside the read or search command so OpenSrc resolves the cached source under `~/.opensrc/`.",
+        "prompt": "Disallow this command if it is trying to read or search dependency source code inside `node_modules` or `.pnpm-store` (e.g. `cat`, `head`, `tail`, `grep`, `rg`, `find` targeting source files in those directories). Allow maintenance commands (`rm`, `du`, `ls`, `install`, `pnpm`, `npm`) and commands that merely mention `node_modules` in flags or output paths. If you reject this command, tell the agent to use `pnpm opensrc path <package>` inside the read or search command so opensrc resolves the cached source under `~/.opensrc/`.",
         "matcher": "node_modules|.pnpm-store|.pnpm",
         "timeout": 10
       }

--- a/.cursor/hooks/redirect-to-opensrc.ts
+++ b/.cursor/hooks/redirect-to-opensrc.ts
@@ -88,15 +88,15 @@ const program = Effect.gen(function* () {
       JSON.stringify({
         permission: "deny",
         user_message:
-          "Use `pnpm opensrc <package>` instead of reading from `node_modules` or `.pnpm-store`.",
+          "Use `pnpm opensrc path <package>` instead of reading from `node_modules` or `.pnpm-store`.",
         agent_message: Array.join(
           [
             "Do not read source code from `node_modules` or `.pnpm-store`.",
-            "Use the opensrc tool to fetch dependency source code into `opensrc/` instead.",
+            "Use the opensrc tool to resolve dependency source code in the global `~/.opensrc/` cache instead.",
             "",
-            "1. Check `opensrc/sources.json` to see if the package was already fetched.",
-            "2. If not, run: `pnpm opensrc <package-name>`",
-            "3. Then read from `opensrc/<package-name>/`.",
+            "1. Run: `pnpm opensrc path <package-name>`",
+            "2. Use the returned absolute path with read or search commands.",
+            "3. Check `~/.opensrc/sources.json` to see cached packages and versions.",
           ],
           "\n",
         ),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,28 @@
 
 ## Source Code Reference
 
-Source code for dependencies is available in `opensrc/` for deeper understanding of implementation details.
+Source code for dependencies is cached at `~/.opensrc/` for deeper understanding of implementation details.
 
-See `opensrc/sources.json` for the list of available packages and their versions.
+See `~/.opensrc/sources.json` for the list of cached packages and their versions.
 
 Use this source code when you need to understand how a package works internally, not just its types/interface.
 
-### Fetching Additional Source Code
+### Reading Source Code
 
-To fetch source code for a package or repository you need to understand, run:
+Use `pnpm opensrc path` inside other commands to search, read, or explore a package's source. It fetches source code on cache miss and prints the cached absolute path to stdout.
 
 ```bash
-npx opensrc <package>           # npm package (e.g., npx opensrc zod)
-npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
-npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
-npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
+rg "pattern" $(pnpm opensrc path <package>)
+cat $(pnpm opensrc path <package>)/path/to/file
+find $(pnpm opensrc path <package>) -name "*.ts"
+```
+
+Works with any registry:
+
+```bash
+rg "pattern" $(pnpm opensrc path pypi:<package>)
+rg "pattern" $(pnpm opensrc path crates:<package>)
+rg "pattern" $(pnpm opensrc path <owner>/<repo>)
 ```
 
 <!-- opensrc:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-<!-- opensrc:start -->
-
 ## Source Code Reference
 
 Source code for dependencies is cached at `~/.opensrc/` for deeper understanding of implementation details.
@@ -27,8 +25,6 @@ rg "pattern" $(pnpm opensrc path pypi:<package>)
 rg "pattern" $(pnpm opensrc path crates:<package>)
 rg "pattern" $(pnpm opensrc path <owner>/<repo>)
 ```
-
-<!-- opensrc:end -->
 
 ## Cursor Cloud specific instructions
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "effect": "3.19.19",
     "eslint": "10.0.2",
     "eslint-plugin-mdx": "3.7.0",
-    "opensrc": "^0.6.0",
+    "opensrc": "^0.7.2",
     "prettier": "3.8.1",
     "tsdown": "0.20.3",
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: 3.7.0
         version: 3.7.0(eslint@10.0.2(jiti@2.5.1))
       opensrc:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.2
+        version: 0.7.2
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -1541,12 +1541,6 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
-
-  '@kwsites/file-exists@1.1.1':
-    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
-
-  '@kwsites/promise-deferred@1.1.1':
-    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3236,10 +3230,6 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -5113,9 +5103,8 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
-  opensrc@0.6.0:
-    resolution: {integrity: sha512-6LMcKaqz/s5wHlEY+fFERkbHhC1qYqhCucaYTcez9IAGlPW4+aYtptY3H9orAT1hp90pv6hABAlfrmsybtngwg==}
-    engines: {node: '>=18.0.0'}
+  opensrc@0.7.2:
+    resolution: {integrity: sha512-Tm0JVco91JYuaousOrWMvEhPd7cAOQuSp3v800VtUs2xRAmt60Wi431AfEKBEWpUGYCNXh25Eiod4xYS+8WAEg==}
     hasBin: true
 
   optionator@0.9.4:
@@ -5797,9 +5786,6 @@ packages:
   simple-eval@1.0.1:
     resolution: {integrity: sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==}
     engines: {node: '>=12'}
-
-  simple-git@3.32.3:
-    resolution: {integrity: sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -7647,14 +7633,6 @@ snapshots:
   '@jsep-plugin/ternary@1.1.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
-
-  '@kwsites/file-exists@1.1.1':
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@kwsites/promise-deferred@1.1.1': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -9739,8 +9717,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
-
-  commander@12.1.0: {}
 
   commander@2.20.3: {}
 
@@ -12176,12 +12152,7 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
-  opensrc@0.6.0:
-    dependencies:
-      commander: 12.1.0
-      simple-git: 3.32.3
-    transitivePeerDependencies:
-      - supports-color
+  opensrc@0.7.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -13066,14 +13037,6 @@ snapshots:
   simple-eval@1.0.1:
     dependencies:
       jsep: 1.4.0
-
-  simple-git@3.32.3:
-    dependencies:
-      '@kwsites/file-exists': 1.1.1
-      '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   simple-swizzle@0.2.2:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Upgrade `opensrc` to the current `0.7.2` CLI package.
- Refresh `AGENTS.md` opensrc guidance for `pnpm opensrc path` and the global `~/.opensrc/` cache.
- Remove the generated opensrc section markers from `AGENTS.md`.
- Align Cursor hook messages with the new opensrc path-based workflow.

### Testing
- `pnpm opensrc --version && pnpm opensrc --help && pnpm opensrc path --help`
- `pnpm opensrc path zod && rg "ZodError" $(pnpm opensrc path zod)`
- `printf ... | ./node_modules/.bin/bun .cursor/hooks/redirect-to-opensrc.ts` for denied `node_modules`, allowed `~/.opensrc`, and allowed workspace paths
- `pnpm exec prettier --check AGENTS.md .cursor/hooks/redirect-to-opensrc.ts .cursor/hooks.json package.json`
- `pnpm exec eslint .cursor/hooks/redirect-to-opensrc.ts --max-warnings=0`
- `pnpm lint`
- `rg "OpenSrc" /workspace`
- `pnpm exec prettier --check .cursor/hooks.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4fb754e-8d96-4b2a-a551-4fa3248d32ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4fb754e-8d96-4b2a-a551-4fa3248d32ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

