### PR TITLE
Fix name field inference with optional ids

### DIFF
--- a/.changeset/fix-name-optional-id-index.md
+++ b/.changeset/fix-name-optional-id-index.md
@@ -3,4 +3,4 @@
 "@confect/server": patch
 ---
 
-Fix table field path inference when a schema has a `name` field and an optional Convex id or bytes field.
+Fix table field path inference when a schema has a `name` field and an optional Convex ID or bytes field.

--- a/.changeset/fix-name-optional-id-index.md
+++ b/.changeset/fix-name-optional-id-index.md
@@ -1,0 +1,6 @@
+---
+"@confect/core": patch
+"@confect/server": patch
+---
+
+Fix table field path inference when a schema has a `name` field and an optional Convex id.

--- a/.changeset/fix-name-optional-id-index.md
+++ b/.changeset/fix-name-optional-id-index.md
@@ -3,4 +3,4 @@
 "@confect/server": patch
 ---
 
-Fix table field path inference when a schema has a `name` field and an optional Convex id.
+Fix table field path inference when a schema has a `name` field and an optional Convex id or bytes field.

--- a/packages/core/src/Types.ts
+++ b/packages/core/src/Types.ts
@@ -58,7 +58,7 @@ export type IsRecord<T> = [T] extends [never]
 export type DeepMutable<T> =
   IsAny<T> extends true
     ? any
-    : T extends Brand.Brand<any> | GenericId<any>
+    : T extends NonRecursiveLeaf
       ? T
       : T extends ReadonlyMap<infer K, infer V>
         ? Map<DeepMutable<K>, DeepMutable<V>>
@@ -74,11 +74,13 @@ export type TypeDefect<Message extends string, T = never> = [Message, T];
 
 export type IsRecursive<T> = true extends DetectCycle<T> ? true : false;
 
+type NonRecursiveLeaf = Brand.Brand<any> | GenericId<any> | ArrayBuffer;
+
 type DetectCycle<T, Cache extends any[] = []> =
   IsAny<T> extends true
     ? false
     : [T] extends [any]
-      ? T extends Brand.Brand<any> | GenericId<any>
+      ? T extends NonRecursiveLeaf
         ? false
         : T extends Cache[number]
           ? true

--- a/packages/core/src/Types.ts
+++ b/packages/core/src/Types.ts
@@ -78,21 +78,23 @@ type DetectCycle<T, Cache extends any[] = []> =
   IsAny<T> extends true
     ? false
     : [T] extends [any]
-      ? T extends Cache[number]
-        ? true
-        : T extends Array<infer U>
-          ? DetectCycle<U, [...Cache, T]>
-          : T extends Map<infer _U, infer V>
-            ? DetectCycle<V, [...Cache, T]>
-            : T extends Set<infer U>
-              ? DetectCycle<U, [...Cache, T]>
-              : T extends object
-                ? true extends {
-                    [K in keyof T]: DetectCycle<T[K], [...Cache, T]>;
-                  }[keyof T]
-                  ? true
+      ? T extends Brand.Brand<any> | GenericId<any>
+        ? false
+        : T extends Cache[number]
+          ? true
+          : T extends Array<infer U>
+            ? DetectCycle<U, [...Cache, T]>
+            : T extends Map<infer _U, infer V>
+              ? DetectCycle<V, [...Cache, T]>
+              : T extends Set<infer U>
+                ? DetectCycle<U, [...Cache, T]>
+                : T extends object
+                  ? true extends {
+                      [K in keyof T]: DetectCycle<T[K], [...Cache, T]>;
+                    }[keyof T]
+                    ? true
+                    : false
                   : false
-                : false
       : never;
 
 //////////////////////////////////

--- a/packages/core/test/Types.test.ts
+++ b/packages/core/test/Types.test.ts
@@ -145,6 +145,10 @@ describe("DeepMutable", () => {
 
     expectTypeOf<Actual>().toEqualTypeOf<Expected>();
   });
+
+  test("ArrayBuffer", () => {
+    expectTypeOf<DeepMutable<ArrayBuffer>>().toEqualTypeOf<ArrayBuffer>();
+  });
 });
 
 describe("IsValueLiteral", () => {
@@ -441,6 +445,10 @@ describe("IsRecursive", () => {
 
     test("primitive", () => {
       expectTypeOf<IsRecursive<number>>().toEqualTypeOf<false>();
+    });
+
+    test("ArrayBuffer", () => {
+      expectTypeOf<IsRecursive<ArrayBuffer>>().toEqualTypeOf<false>();
     });
 
     test("branded string", () => {

--- a/packages/core/test/Types.test.ts
+++ b/packages/core/test/Types.test.ts
@@ -1,6 +1,7 @@
 import type { Brand } from "effect";
 import type { ReadonlyRecord } from "effect/Record";
 import { describe, expectTypeOf, test } from "vitest";
+import type { GenericId } from "../src/GenericId";
 
 import type {
   DeepMutable,
@@ -440,6 +441,15 @@ describe("IsRecursive", () => {
 
     test("primitive", () => {
       expectTypeOf<IsRecursive<number>>().toEqualTypeOf<false>();
+    });
+
+    test("branded string", () => {
+      type BrandedString = string & Brand.Brand<"BrandedString">;
+      expectTypeOf<IsRecursive<BrandedString>>().toEqualTypeOf<false>();
+    });
+
+    test("GenericId", () => {
+      expectTypeOf<IsRecursive<GenericId<"users">>>().toEqualTypeOf<false>();
     });
 
     test("empty object", () => {

--- a/packages/server/test/SchemaToValidator.test.ts
+++ b/packages/server/test/SchemaToValidator.test.ts
@@ -1251,6 +1251,21 @@ describe("ValueToValidator", () => {
       expectTypeOf<CompiledValidator>().toEqualTypeOf<ExpectedValidator>();
     });
 
+    test("{ name: string; bytes?: ArrayBuffer | undefined }", () => {
+      const _expectedValidator = v.object({
+        name: v.string(),
+        bytes: v.optional(v.bytes()),
+      });
+      type ExpectedValidator = typeof _expectedValidator;
+
+      type CompiledValidator = ValueToValidator<{
+        name: string;
+        bytes?: ArrayBuffer | undefined;
+      }>;
+
+      expectTypeOf<CompiledValidator>().toEqualTypeOf<ExpectedValidator>();
+    });
+
     test("{ name: string; userId?: GenericId<'users'> | undefined }", () => {
       const _expectedValidator = v.object({
         name: v.string(),
@@ -1366,6 +1381,23 @@ describe(compileTableSchema, () => {
     const expectedValidator = v.object({
       name: v.string(),
       userId: v.optional(v.id("users")),
+    });
+
+    expectTypeOf(compiledValidator).toEqualTypeOf(expectedValidator);
+    expect(compiledValidator).toStrictEqual(expectedValidator);
+  });
+
+  test("succeeds if provided Schema has a name field and optional bytes", () => {
+    const compiledValidator = compileTableSchema(
+      Schema.Struct({
+        name: Schema.String,
+        bytes: Schema.optional(Schema.instanceOf(ArrayBuffer)),
+      }),
+    );
+
+    const expectedValidator = v.object({
+      name: v.string(),
+      bytes: v.optional(v.bytes()),
     });
 
     expectTypeOf(compiledValidator).toEqualTypeOf(expectedValidator);

--- a/packages/server/test/SchemaToValidator.test.ts
+++ b/packages/server/test/SchemaToValidator.test.ts
@@ -1370,7 +1370,7 @@ describe(compileTableSchema, () => {
     expect(compiledValidator).toStrictEqual(expectedValidator);
   });
 
-  test("succeeds if provided Schema has a name field and optional id", () => {
+  test("succeeds if provided Schema has a name field and optional ID", () => {
     const compiledValidator = compileTableSchema(
       Schema.Struct({
         name: Schema.String,

--- a/packages/server/test/SchemaToValidator.test.ts
+++ b/packages/server/test/SchemaToValidator.test.ts
@@ -1250,6 +1250,21 @@ describe("ValueToValidator", () => {
 
       expectTypeOf<CompiledValidator>().toEqualTypeOf<ExpectedValidator>();
     });
+
+    test("{ name: string; userId?: GenericId<'users'> | undefined }", () => {
+      const _expectedValidator = v.object({
+        name: v.string(),
+        userId: v.optional(v.id("users")),
+      });
+      type ExpectedValidator = typeof _expectedValidator;
+
+      type CompiledValidator = ValueToValidator<{
+        name: string;
+        userId?: GenericId<"users"> | undefined;
+      }>;
+
+      expectTypeOf<CompiledValidator>().toEqualTypeOf<ExpectedValidator>();
+    });
   });
 
   describe("recursive", () => {
@@ -1333,6 +1348,23 @@ describe(compileTableSchema, () => {
 
     const expectedValidator = v.object({
       text: v.string(),
+      userId: v.optional(v.id("users")),
+    });
+
+    expectTypeOf(compiledValidator).toEqualTypeOf(expectedValidator);
+    expect(compiledValidator).toStrictEqual(expectedValidator);
+  });
+
+  test("succeeds if provided Schema has a name field and optional id", () => {
+    const compiledValidator = compileTableSchema(
+      Schema.Struct({
+        name: Schema.String,
+        userId: Schema.optional(GenericId("users")),
+      }),
+    );
+
+    const expectedValidator = v.object({
+      name: v.string(),
       userId: v.optional(v.id("users")),
     });
 

--- a/packages/server/test/Table.test.ts
+++ b/packages/server/test/Table.test.ts
@@ -84,4 +84,32 @@ describe("Table", () => {
       confectNotesTableDefinition,
     );
   });
+
+  it("supports indexes on name fields when the schema includes an optional id", () => {
+    const confectOrganizationsTableDefinition = Table.make(
+      "organizations",
+      Schema.Struct({
+        name: Schema.String,
+        description: Schema.optional(Schema.String),
+        createdBy: Schema.optional(GenericId.GenericId("users")),
+      }),
+    )
+      .index("by_name", ["name"])
+      .searchIndex("search_name", { searchField: "name" }).tableDefinition;
+
+    const convexOrganizationsTableDefinition = defineTable({
+      name: v.string(),
+      description: v.optional(v.string()),
+      createdBy: v.optional(v.id("users")),
+    })
+      .index("by_name", ["name"])
+      .searchIndex("search_name", { searchField: "name" });
+
+    expectTypeOf(confectOrganizationsTableDefinition).toEqualTypeOf(
+      convexOrganizationsTableDefinition,
+    );
+    expect(convexOrganizationsTableDefinition).toStrictEqual(
+      confectOrganizationsTableDefinition,
+    );
+  });
 });

--- a/packages/server/test/Table.test.ts
+++ b/packages/server/test/Table.test.ts
@@ -85,7 +85,7 @@ describe("Table", () => {
     );
   });
 
-  it("supports indexes on name fields when the schema includes an optional id", () => {
+  it("supports indexes on name fields when the schema includes an optional ID", () => {
     const confectOrganizationsTableDefinition = Table.make(
       "organizations",
       Schema.Struct({

--- a/packages/server/test/Table.test.ts
+++ b/packages/server/test/Table.test.ts
@@ -112,4 +112,26 @@ describe("Table", () => {
       confectOrganizationsTableDefinition,
     );
   });
+
+  it("supports indexes on name fields when the schema includes optional bytes", () => {
+    const confectImagesTableDefinition = Table.make(
+      "images",
+      Schema.Struct({
+        name: Schema.String,
+        bytes: Schema.optional(Schema.instanceOf(ArrayBuffer)),
+      }),
+    ).index("by_name", ["name"]).tableDefinition;
+
+    const convexImagesTableDefinition = defineTable({
+      name: v.string(),
+      bytes: v.optional(v.bytes()),
+    }).index("by_name", ["name"]);
+
+    expectTypeOf(confectImagesTableDefinition).toEqualTypeOf(
+      convexImagesTableDefinition,
+    );
+    expect(convexImagesTableDefinition).toStrictEqual(
+      confectImagesTableDefinition,
+    );
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Treat branded scalar types, Convex `GenericId`, and `ArrayBuffer` bytes as non-recursive leaves in the shared type recursion detector.
- Add regression coverage for schemas with a `name` field and optional ID or bytes fields at validator conversion and table index/search APIs.
- Add a patch changeset for `@confect/core` and `@confect/server`.

### Root cause
`Table.make` derives valid index/search field paths from `TableSchemaToTableValidator`, which is produced by the type-level `ValueToValidator<TableSchema["Encoded"]>` conversion. That conversion intentionally falls back to `VAny` for recursive encoded value types, and table schemas reject `VAny`, which collapses the table validator to `never`. Once that happened, `ExtractFieldPaths` could only see Convex system fields like `_creationTime`, so user fields such as `name` failed index/search type checking.

The recursive-type detector was too structural for scalar-ish branded values. Convex IDs are represented as branded strings (`string & { __tableName: TableName }`). When an object had a required `name: string` field and an optional ID field, the detector walked into the branded string as though it were an object. TypeScript string/function members include structural shapes with a `name` property, and those shapes were assignable to the cached outer object shape because the ID field was optional. That looked like a recursive cycle even though the data was just a flat object with a scalar ID.

A related issue exists for bytes: `ArrayBuffer` is a valid Convex scalar, but TypeScript models it as an object with self-returning methods such as `slice(): ArrayBuffer`. Walking it structurally can also create false recursion signals in optional object fields.

### Fix
The fix defines these scalar-like values as explicit non-recursive leaves before the detector compares against previously seen structural shapes. This matches the existing intent in `DeepMutable` and prevents branded IDs and bytes from being widened to `VAny` during schema-to-validator conversion. The added tests verify the behavior at the utility layer (`IsRecursive`/`DeepMutable`), the conversion layer (`ValueToValidator`/`compileTableSchema`), and the public table API (`index`/`searchIndex`).

### Testing
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test:core`
- `CI=true pnpm test:server`
- `CI=true pnpm --filter @confect/server exec vitest run --config vitest.config.ts test/Table.test.ts test/SchemaToValidator.test.ts`
- Temporary exact repro of the issue reporter's added `Table.test.ts` cases passed and was removed after verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef77bac7-d1a1-4ec9-b656-61e3edc6035a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef77bac7-d1a1-4ec9-b656-61e3edc6035a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

