### PR TITLE
docs: document typed function errors

### DIFF
--- a/apps/docs/clients/js/http.mdx
+++ b/apps/docs/clients/js/http.mdx
@@ -46,6 +46,34 @@ const program = Effect.gen(function* () {
 
 Each method returns an `Effect` that can fail with `HttpClientError` (wrapping transport-level errors) or `ParseResult.ParseError` (if schema encoding or decoding fails).
 
+## Typed errors
+
+When a ref's spec declares an `error` schema, the decoded error is added to the returned `Effect`'s error channel alongside `HttpClientError` and `ParseError`. See [Error Handling](/server/error-handling) for how to declare error schemas.
+
+```ts
+import { HttpClient } from "@confect/js";
+import { Effect } from "effect";
+
+import refs from "./confect/_generated/refs";
+
+const lookup = Effect.gen(function* () {
+  const client = yield* HttpClient.HttpClient;
+
+  return yield* client.query(refs.public.notes.getOrFail, { noteId });
+});
+// Effect.Effect<Note, NoteNotFound | HttpClientError | ParseError, HttpClient.HttpClient>
+```
+
+Recover from a typed failure with `Effect.catchTag` (or any other `Effect` error combinator).
+
+```ts
+lookup.pipe(
+  Effect.catchTag("NoteNotFound", (error) =>
+    Effect.succeed(`Note ${error.noteId} not found.`),
+  ),
+);
+```
+
 ## Authentication
 
 Set or clear the auth token before making authenticated requests.

--- a/apps/docs/clients/js/websocket.mdx
+++ b/apps/docs/clients/js/websocket.mdx
@@ -68,6 +68,45 @@ const program = Effect.gen(function* () {
 
 The underlying WebSocket subscription is cleaned up automatically when the stream's scope ends (for example, when the consuming Effect is interrupted or when an operator like `Stream.take` completes).
 
+## Typed errors
+
+When a ref's spec declares an `error` schema, the decoded error is added to the error channel of `query`, `mutation`, `action`, and `reactiveQuery` alongside `WebSocketClientError` and `ParseError`. See [Error Handling](/server/error-handling) for how to declare error schemas.
+
+```ts
+import { WebSocketClient } from "@confect/js";
+import { Effect } from "effect";
+
+import refs from "./confect/_generated/refs";
+
+const lookup = Effect.gen(function* () {
+  const client = yield* WebSocketClient.WebSocketClient;
+
+  return yield* client.query(refs.public.notes.getOrFail, { noteId });
+});
+// Effect.Effect<Note, NoteNotFound | WebSocketClientError | ParseError, WebSocketClient.WebSocketClient>
+```
+
+For `reactiveQuery`, a typed failure terminates the `Stream` with the decoded value in its error channel — the subscription does not stay open across failures. Recover with `Stream.catchTag` (or any other `Stream` error combinator) to keep the stream alive across typed failures.
+
+```ts
+import { WebSocketClient } from "@confect/js";
+import { Effect, Stream } from "effect";
+
+import refs from "./confect/_generated/refs";
+
+const lookups = Effect.gen(function* () {
+  const client = yield* WebSocketClient.WebSocketClient;
+
+  return client
+    .reactiveQuery(refs.public.notes.getOrFail, { noteId })
+    .pipe(
+      Stream.catchTag("NoteNotFound", (error) =>
+        Stream.succeed(`Note ${error.noteId} not found.`),
+      ),
+    );
+});
+```
+
 ## Authentication
 
 Set the authentication token provider before making authenticated requests. `setAuth` accepts an Effect-returning function that is called whenever a token is needed or expires.

--- a/apps/docs/clients/js/websocket.mdx
+++ b/apps/docs/clients/js/websocket.mdx
@@ -86,7 +86,7 @@ const lookup = Effect.gen(function* () {
 // Effect.Effect<Note, NoteNotFound | WebSocketClientError | ParseError, WebSocketClient.WebSocketClient>
 ```
 
-For `reactiveQuery`, a typed failure terminates the `Stream` with the decoded value in its error channel — the subscription does not stay open across failures. Recover with `Stream.catchTag` (or any other `Stream` error combinator) to keep the stream alive across typed failures.
+For `reactiveQuery`, a typed failure terminates the `Stream` with the decoded value in its error channel—the subscription does not stay open across failures. Recover with `Stream.catchTag` (or any other `Stream` error combinator) to keep the stream alive across typed failures.
 
 ```ts
 import { WebSocketClient } from "@confect/js";

--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -36,7 +36,7 @@ ReactDOM.createRoot(
 
 ## `useQuery`
 
-Encodes args using the spec's `args` schema, passes them to Convex, and decodes the result using the spec's `returns` schema. Returns a `QueryResult<A, E>` — a tagged union with `Loading`, `Success`, and `Failure` variants.
+Encodes args using the spec's `args` schema, passes them to Convex, and decodes the result using the spec's `returns` schema. Returns a `QueryResult<A, E>`—a tagged union with `Loading`, `Success`, and `Failure` variants.
 
 Given this spec:
 

--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -6,7 +6,7 @@ description: "Use Confect's React hooks to call your functions from the client."
 
 `@confect/react` provides drop-in replacements for Convex's React hooks. Each hook automatically encodes your args and decodes return values through the [Effect Schemas](/concepts/schema-restrictions) defined in your [function specs](/concepts/spec-impl-model). You work with the Schema `Type` (decoded) values on both sides—the hooks handle the round-trip to Convex's `Encoded` representation transparently.
 
-Functions are referenced via `refs` (from `confect/_generated/refs`) instead of Convex's `api` object. Each ref carries the `args` and `returns` schemas from the corresponding function spec, which is what enables the automatic encoding and decoding.
+Functions are referenced via `refs` (from `confect/_generated/refs`) instead of Convex's `api` object. Each ref carries the `args`, `returns`, and (optionally) `error` schemas from the corresponding function spec, which is what enables the automatic encoding and decoding.
 
 ## Setup
 
@@ -36,7 +36,7 @@ ReactDOM.createRoot(
 
 ## `useQuery`
 
-Encodes args using the spec's `args` schema, passes them to Convex, and decodes the result using the spec's `returns` schema. Returns `T | undefined` (undefined while loading), matching Convex's `useQuery`.
+Encodes args using the spec's `args` schema, passes them to Convex, and decodes the result using the spec's `returns` schema. Returns a `QueryResult<A, E>` — a tagged union with `Loading`, `Success`, and `Failure` variants.
 
 Given this spec:
 
@@ -55,35 +55,61 @@ export const notes = GroupSpec.make("notes").addFunction(
 );
 ```
 
-The hook accepts `{}` (the `Type` of `Schema.Struct({})`) as args and returns `readonly Notes.Doc["Type"][]` (the `Type` of `Schema.Array(Notes.Doc)`):
+The hook accepts `{}` (the `Type` of `Schema.Struct({})`) as args and returns a `QueryResult<readonly Notes.Doc["Type"][]>`. Match it with `QueryResult.match`:
 
 ```tsx
-import { useQuery } from "@confect/react";
+import { QueryResult, useQuery } from "@confect/react";
 import refs from "../confect/_generated/refs";
 
 const NoteList = () => {
   const notes = useQuery(refs.public.notes.list, {});
 
-  if (notes === undefined) {
-    return <p>Loading…</p>;
-  }
+  return QueryResult.match(notes, {
+    onLoading: () => <p>Loading…</p>,
+    onSuccess: (notes) => (
+      <ul>
+        {notes.map((note) => (
+          <li key={note._id}>{note.text}</li>
+        ))}
+      </ul>
+    ),
+  });
+};
+```
+
+`QueryResult` also exposes the lower-level predicates `QueryResult.isLoading`, `QueryResult.isSuccess`, and `QueryResult.isFailure` for cases where pattern matching is awkward.
+
+### Typed errors
+
+When the ref's spec declares an `error` schema, `useQuery` returns `QueryResult<A, E>` and `QueryResult.match` requires an `onFailure` handler that receives the decoded typed error. See [Error Handling](/server/error-handling) for how to declare error schemas.
+
+```tsx
+import { QueryResult, useQuery } from "@confect/react";
+import refs from "../confect/_generated/refs";
+
+const NoteLookup = ({ noteId }: { noteId: string }) => {
+  const lookup = useQuery(refs.public.notes.getOrFail, { noteId });
 
   return (
-    <ul>
-      {notes.map((note) => (
-        <li key={note._id}>{note.text}</li>
-      ))}
-    </ul>
+    <div>
+      {QueryResult.match(lookup, {
+        onLoading: () => "Looking up…",
+        onSuccess: (note) => `Found: ${note.text}`,
+        onFailure: (error) => `Note ${error.noteId} not found.`,
+      })}
+    </div>
   );
 };
 ```
 
+Failures that are not declared in the `error` schema are not surfaced as `Failure`. They propagate the same way they do with `convex/react`'s `useQuery` (typically reaching the nearest [error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)).
+
 ### Skipping queries
 
-Pass `"skip"` instead of args to disable the query subscription. The hook returns `undefined` when skipped, just as it does while loading. This is useful for conditional queries where a prerequisite value may not yet be available.
+Pass `"skip"` instead of args to disable the query subscription. The hook returns a `Loading` variant whose `skipped` flag is `true`, which lets you distinguish a query that is genuinely in flight from one sitting idle because no args have been provided.
 
 ```tsx
-import { useQuery } from "@confect/react";
+import { QueryResult, useQuery } from "@confect/react";
 import refs from "../confect/_generated/refs";
 
 const NoteDetail = ({
@@ -96,21 +122,22 @@ const NoteDetail = ({
     selectedId !== undefined ? { id: selectedId } : "skip",
   );
 
-  if (note === undefined) {
-    return (
-      <p>{selectedId === undefined ? "Select a note" : "Loading…"}</p>
-    );
-  }
-
-  return <p>{note.text}</p>;
+  return QueryResult.match(note, {
+    onLoading: (skipped) => (
+      <p>{skipped ? "Select a note" : "Loading…"}</p>
+    ),
+    onSuccess: (note) => <p>{note.text}</p>,
+  });
 };
 ```
 
 ## `useMutation`
 
-Returns a function that encodes args using the spec's `args` schema, calls the Convex mutation, and decodes the result using the spec's `returns` schema. Returns `(args) => Promise<T>`, matching Convex's `useMutation`.
+Returns a function that encodes args using the spec's `args` schema, calls the Convex mutation, and decodes the result using the spec's `returns` schema. The returned promise's shape depends on whether the spec declares an `error` schema.
 
-Given this spec:
+### Without an `error` schema
+
+The function returns `Promise<A>`, matching `convex/react`'s `useMutation`. Undeclared failures still reject the promise.
 
 ```ts confect/notes.spec.ts
 FunctionSpec.publicMutation({
@@ -119,8 +146,6 @@ FunctionSpec.publicMutation({
   returns: GenericId.GenericId("notes"),
 });
 ```
-
-The returned function accepts `{ text: string }` (the `Type` of the `args` schema) and returns a `Promise<GenericId<"notes">>` (the `Type` of the `returns` schema):
 
 ```tsx
 import { useMutation } from "@confect/react";
@@ -137,11 +162,42 @@ const InsertNote = () => {
 };
 ```
 
+### With an `error` schema
+
+When the spec declares an `error` schema, the function returns `Promise<Either<A, E>>`. Unwrap with `Either.match` (or another `Either` combinator) to handle both branches. Undeclared failures still reject the promise.
+
+```ts confect/notes.spec.ts
+FunctionSpec.publicMutation({
+  name: "deleteOrFail",
+  args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
+  returns: Schema.Null,
+  error: Schema.Union(NoteNotFound, Forbidden),
+});
+```
+
+```tsx
+import { useMutation } from "@confect/react";
+import { Either } from "effect";
+import refs from "../confect/_generated/refs";
+
+const DeleteNote = ({ noteId }: { noteId: string }) => {
+  const deleteOrFail = useMutation(refs.public.notes.deleteOrFail);
+
+  const handleClick = async () => {
+    const result = await deleteOrFail({ noteId });
+    Either.match(result, {
+      onLeft: (error) => console.error(error._tag, error),
+      onRight: () => console.log("deleted"),
+    });
+  };
+
+  return <button onClick={handleClick}>Delete</button>;
+};
+```
+
 ## `useAction`
 
-Same pattern as `useMutation`: encodes args via the spec's `args` schema, calls the Convex action, and decodes the result via the spec's `returns` schema. Returns `(args) => Promise<T>`.
-
-Given this spec:
+Same shape as `useMutation`: returns `Promise<A>` when the ref has no `error` schema, and `Promise<Either<A, E>>` when it does.
 
 ```ts confect/random.spec.ts
 FunctionSpec.publicAction({
@@ -150,8 +206,6 @@ FunctionSpec.publicAction({
   returns: Schema.Number,
 });
 ```
-
-The returned function accepts `{}` and returns a `Promise<number>`:
 
 ```tsx
 import { useAction } from "@confect/react";
@@ -175,4 +229,7 @@ const RandomNumber = () => {
 | Functions referenced via `api.module.fn` | Functions referenced via `refs` |
 | Args passed directly to Convex as-is | Args are schema-encoded from `Type` to `Encoded` before sending to Convex |
 | Return values received directly from Convex as-is | Return values are schema-decoded from `Encoded` to `Type` before returning |
+| `useQuery` returns `T \| undefined` | `useQuery` returns `QueryResult<A, E>` |
+| Cannot distinguish loading from skipped | `Loading` carries a `skipped: boolean` flag |
+| `useMutation`/`useAction` always return `Promise<T>` | Refs with an `error` schema return `Promise<Either<A, E>>`; refs without one still return `Promise<A>` |
 | Pass `"skip"` to disable query subscription | Same—pass `"skip"` to disable query subscription |

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -55,6 +55,7 @@
         "group": "Server",
         "pages": [
           "server/functions",
+          "server/error-handling",
           "server/plain-convex-functions",
           "server/node-actions",
           {

--- a/apps/docs/guides/testing.mdx
+++ b/apps/docs/guides/testing.mdx
@@ -98,6 +98,35 @@ Effect.gen(function* () {
 });
 ```
 
+## Typed errors
+
+When a ref's spec declares an `error` schema, the decoded error is added to the error channel of `query`, `mutation`, and `action` alongside `ParseError`. See [Error Handling](/server/error-handling) for how to declare error schemas.
+
+```ts
+import { describe, it } from "@effect/vitest";
+import { assertLeft } from "@effect/vitest/utils";
+import { Effect } from "effect";
+
+import refs from "./confect/_generated/refs";
+import * as TestConfect from "./TestConfect";
+
+describe("notes", () => {
+  it.effect("returns NoteNotFound for a missing id", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      const result = yield* c
+        .query(refs.public.notes.getOrFail, {
+          noteId: "missing" as GenericId<"notes">,
+        })
+        .pipe(Effect.either);
+
+      assertLeft(result, new NoteNotFound({ noteId: "missing" }));
+    }).pipe(Effect.provide(TestConfect.layer())),
+  );
+});
+```
+
 ## Running setup code
 
 Use `run` to execute arbitrary code with mutation-context services (like `DatabaseWriter`) for test setup. When the handler returns a value, pass a `Schema` as the second argument for decoding.

--- a/apps/docs/server/error-handling.mdx
+++ b/apps/docs/server/error-handling.mdx
@@ -1,0 +1,132 @@
+---
+icon: "octagon-alert"
+title: "Error Handling"
+description: "Declare typed errors on Confect functions and consume them at every call site."
+---
+
+A Confect function can declare a typed error in its spec. When the handler fails with a value matching that schema, the error travels across the function boundary and surfaces — already decoded — at every call site (React hooks, JS clients, and tests).
+
+Typed errors are transported as Convex's native [`ConvexError`](https://docs.convex.dev/functions/error-handling/application-errors#throwing-application-errors), with the encoded error stored in `ConvexError.data`. The `returns` channel is left untouched, and non-Confect callers of the same Convex API see ordinary `ConvexError`s. For mutations, throwing a `ConvexError` triggers Convex's transaction rollback as usual.
+
+Error schemas are optional. When omitted, the error type defaults to `never` and every call site keeps its prior shape.
+
+## Declaring an error schema
+
+Add an `error` field to any `FunctionSpec` constructor. The schema is an ordinary Effect `Schema`, so a `Schema.TaggedError` class works well for a single failure mode.
+
+```ts confect/notes.spec.ts
+import { FunctionSpec, GenericId, GroupSpec } from "@confect/core";
+import { Schema } from "effect";
+
+import { Notes } from "./tables/Notes";
+
+export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
+  "NoteNotFound",
+  { noteId: GenericId.GenericId("notes") },
+) {}
+
+export const notes = GroupSpec.make("notes").addFunction(
+  FunctionSpec.publicQuery({
+    name: "getOrFail",
+    args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
+    returns: Notes.Doc,
+    error: NoteNotFound,
+  }),
+);
+```
+
+To declare more than one failure mode, combine them with `Schema.Union`.
+
+```ts
+import { Schema } from "effect";
+
+export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
+  "NoteNotFound",
+  { noteId: GenericId.GenericId("notes") },
+) {}
+
+export class Forbidden extends Schema.TaggedError<Forbidden>()(
+  "Forbidden",
+  {},
+) {}
+
+FunctionSpec.publicMutation({
+  name: "deleteOrFail",
+  args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
+  returns: Schema.Null,
+  error: Schema.Union(NoteNotFound, Forbidden),
+});
+```
+
+## Failing from a handler
+
+When a spec declares an `error` schema, the corresponding `FunctionImpl` handler's `Effect` error channel is typed as that schema's `Type`. Use `Effect.fail` (or `Effect.mapError`) to fail with any value matching the schema.
+
+```ts confect/notes.impl.ts
+import { FunctionImpl } from "@confect/server";
+import { Effect } from "effect";
+
+import api from "./_generated/api";
+import { DatabaseReader } from "./_generated/services";
+import { NoteNotFound } from "./notes.spec";
+
+const getOrFail = FunctionImpl.make(
+  api,
+  "notes",
+  "getOrFail",
+  ({ noteId }) =>
+    Effect.gen(function* () {
+      const reader = yield* DatabaseReader;
+
+      return yield* reader
+        .table("notes")
+        .get(noteId)
+        .pipe(Effect.mapError(() => new NoteNotFound({ noteId })));
+    }),
+);
+```
+
+Without an `error` schema, the handler's error channel is `never` and any unmapped failure must still be cleared (typically with `Effect.orDie`). With one, declared failures travel through, and any other failure (a defect) still rejects/dies as before.
+
+## Consuming typed errors
+
+The decoded error is surfaced at every call site. The exact shape depends on the client.
+
+### `@confect/react`
+
+- **`useQuery`** returns a `QueryResult<A, E>`. Match it with `QueryResult.match`, where `onFailure` is required when the ref declares an `error` schema.
+- **`useMutation`** and **`useAction`** return `Promise<Either<A, E>>` when the ref declares an `error` schema (and `Promise<A>` otherwise).
+
+See [React](/clients/react) for full examples.
+
+```tsx
+import { QueryResult, useQuery } from "@confect/react";
+import refs from "../confect/_generated/refs";
+
+const lookup = useQuery(refs.public.notes.getOrFail, { noteId });
+
+QueryResult.match(lookup, {
+  onLoading: (skipped) => (skipped ? null : "Looking up…"),
+  onSuccess: (note) => `Found: ${note.text}`,
+  onFailure: (error) => `Note ${error.noteId} not found.`,
+});
+```
+
+### `@confect/js`
+
+Both `HttpClient` and `WebSocketClient` add the decoded error to the returned `Effect`'s error channel, alongside the existing transport error and `ParseError`.
+
+```ts
+HttpClient.query(refs.public.notes.getOrFail, { noteId });
+// Effect.Effect<Note, NoteNotFound | HttpClientError | ParseError>
+```
+
+`WebSocketClient.reactiveQuery` carries typed errors too: when the subscribed query fails with a typed error, the returned `Stream` terminates with the decoded value in its error channel. See [HTTP](/clients/js/http) and [WebSocket](/clients/js/websocket).
+
+### `@confect/test`
+
+`TestConfect`'s `query`, `mutation`, and `action` decode typed errors into the `Effect` error channel, so test bridges see the same shape as the JS clients. See [Testing](/guides/testing).
+
+## Non-typed failures
+
+Failures that are not declared in the `error` schema are not silently swallowed. They propagate through Convex's normal failure path: they reject promises in `@convex/react`, fail `Effect`s with `HttpClientError`/`WebSocketClientError` in `@confect/js`, and surface as defects (cause) in `TestConfect`. Use a typed `error` schema for failures you want callers to handle, and let everything else die.

--- a/apps/docs/server/error-handling.mdx
+++ b/apps/docs/server/error-handling.mdx
@@ -4,7 +4,7 @@ title: "Error Handling"
 description: "Declare typed errors on Confect functions and consume them at every call site."
 ---
 
-A Confect function can declare a typed error in its spec. When the handler fails with a value matching that schema, the error travels across the function boundary and surfaces — already decoded — at every call site (React hooks, JS clients, and tests).
+A Confect function can declare a typed error in its spec. When the handler fails with a value matching that schema, the error travels across the function boundary and surfaces—already decoded—at every call site (React hooks, JS clients, and tests).
 
 Typed errors are transported as Convex's native [`ConvexError`](https://docs.convex.dev/functions/error-handling/application-errors#throwing-application-errors), with the encoded error stored in `ConvexError.data`. The `returns` channel is left untouched, and non-Confect callers of the same Convex API see ordinary `ConvexError`s. For mutations, throwing a `ConvexError` triggers Convex's transaction rollback as usual.
 

--- a/apps/docs/server/functions.mdx
+++ b/apps/docs/server/functions.mdx
@@ -46,6 +46,29 @@ import { notes } from "./notes.spec";
 export default Spec.make().add(notes);
 ```
 
+### Typed errors
+
+A spec can also declare an optional `error` schema. When it does, the corresponding handler's `Effect` error channel is typed as that schema, and the failure is decoded for callers at every call site (React hooks, JS clients, and tests). See [Error Handling](/server/error-handling) for the full walkthrough.
+
+```ts
+import { FunctionSpec, GenericId } from "@confect/core";
+import { Schema } from "effect";
+
+import { Notes } from "./tables/Notes";
+
+class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
+  "NoteNotFound",
+  { noteId: GenericId.GenericId("notes") },
+) {}
+
+FunctionSpec.publicQuery({
+  name: "getOrFail",
+  args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
+  returns: Notes.Doc,
+  error: NoteNotFound,
+});
+```
+
 ## Implementing functions
 
 Each function impl contains a handler that implements the function's logic. Function impls are composed into group impls using Effect layers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents the typed function errors feature shipped in #379.

## What's new

- **`apps/docs/server/error-handling.mdx`** (new) — canonical page covering motivation, declaring an `error` schema (single + `Schema.Union`), failing from a `FunctionImpl` handler, and consuming typed errors from each client. Notes that typed errors travel as `ConvexError` and that mutation rollback is preserved.
- **`apps/docs/server/functions.mdx`** — adds a brief "Typed errors" subsection introducing the optional `error` field with a link to the new page.
- **`apps/docs/clients/react.mdx`** — substantial rewrite reflecting the new `@confect/react` shape:
  - `useQuery` now returns `QueryResult<A, E>`; documents `QueryResult.match`, the `skipped` flag on `Loading`, and that `onFailure` is required when an `error` schema is declared.
  - `useMutation`/`useAction` return `Promise<A>` for refs without an `error` schema (unchanged) and `Promise<Either<A, E>>` when one is declared, with an `Either.match` example.
  - Refreshes the "Differences from vanilla Convex hooks" table.
- **`apps/docs/clients/js/http.mdx`** — adds a "Typed errors" subsection showing the decoded error in the `Effect` error channel and an `Effect.catchTag` recovery example.
- **`apps/docs/clients/js/websocket.mdx`** — same as HTTP, plus documents that `reactiveQuery`'s `Stream` error channel now carries the decoded typed error (the subscription terminates on failure), with a `Stream.catchTag` recovery example.
- **`apps/docs/guides/testing.mdx`** — adds a "Typed errors" subsection showing `TestConfect.query` surfacing the decoded error in the `Effect` error channel.
- **`apps/docs/docs.json`** — registers the new page after `server/functions`.

## Testing

- ✅ `pnpm format` (in `apps/docs`)
- ✅ `pnpm lint` (in `apps/docs`)
- ✅ `npx mintlify broken-links` (in `apps/docs`) — no broken links

Documentation-only change; no source modifications and no changeset.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cd6a327-01f7-4c21-b3ef-e79706e43590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cd6a327-01f7-4c21-b3ef-e79706e43590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

