### PR TITLE
Fix: Convex query cache busted by Effect's internal clock access

### DIFF
--- a/packages/server/src/RegisteredConvexFunction.ts
+++ b/packages/server/src/RegisteredConvexFunction.ts
@@ -106,19 +106,22 @@ export const make = <Api_ extends Api.AnyWithPropsWithRuntime<"Convex">>(
 //
 // Users who explicitly want the real timestamp can still reach it via Effect's
 // Clock service (Clock.currentTimeMillis/Clock.currentTimeNanos). We provide
-// a Clock layer whose methods close over the *original* Date.now, so opting in
-// to Clock is an opt-in to worse caching—but caching is not broken by default.
+// a Clock whose user-facing Effects call realDateNow (Convex's tracker) directly,
+// making Clock an explicit opt-in to cache invalidation. The unsafe methods used
+// internally by Effect (logging, span events) return constants so they never
+// touch the tracker—caching is not broken by default.
+//
+// _defaultClock is created at module load time, before Convex installs its
+// Date.now wrapper, so its unsafeCurrentTimeNanos uses process.hrtime safely.
+const _defaultClock = Clock.make();
 const unpatchedClock = (realDateNow: () => number): Clock.Clock => {
   const bigint1e6 = BigInt(1_000_000);
-  const unsafeCurrentTimeMillis = () => realDateNow();
-  const unsafeCurrentTimeNanos = () => BigInt(realDateNow()) * bigint1e6;
-  const defaultClock = Clock.make();
   return {
-    ...defaultClock,
-    unsafeCurrentTimeMillis,
-    unsafeCurrentTimeNanos,
-    currentTimeMillis: Effect.sync(unsafeCurrentTimeMillis),
-    currentTimeNanos: Effect.sync(unsafeCurrentTimeNanos),
+    ..._defaultClock,
+    unsafeCurrentTimeMillis: () => 0,
+    unsafeCurrentTimeNanos: () => _defaultClock.unsafeCurrentTimeNanos(),
+    currentTimeMillis: Effect.sync(() => realDateNow()),
+    currentTimeNanos: Effect.sync(() => BigInt(realDateNow()) * bigint1e6),
   };
 };
 


### PR DESCRIPTION
## Problem
`unpatchedClock` wired both `unsafeCurrentTimeMillis` and `currentTimeMillis` through `realDateNow`. `realDateNow = Date.now` is captured after Convex has already set up reactivity tracking on `Date.now`, so calling `realDateNow()` later still triggers that tracking. Effect's internal logging path calls `clock.unsafeCurrentTimeMillis()` during fiber execution, which hit `realDateNow()` and busted the cache even when user code never touched the Clock service.

## Fix
Separate the two concerns:
- `unsafeCurrentTimeMillis` / `unsafeCurrentTimeNanos` — return constants (`0` / hrtime). Effect's internals use these and must not trigger Convex's reactivity tracking.
- `currentTimeMillis` / `currentTimeNanos` — call `realDateNow()` via `Effect.sync`. Explicit user opt-in to real time and cache invalidation, unchanged in behavior.

`_defaultClock` is also lifted to module level so it's created before Convex sets up its `Date.now` tracking.

## Confirmed
- Default queries: cache never busts
- `yield* Clock.currentTimeMillis`: returns real time, cache invalidated as documented