### PR TITLE
chore: hoist vite-tsconfig-paths to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "tsdown": "0.20.3",
     "typescript": "5.9.3",
     "typescript-eslint": "8.56.1",
+    "vite-tsconfig-paths": "6.1.1",
     "vitest": "3.2.4"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       typescript-eslint:
         specifier: 8.56.1
         version: 8.56.1(eslint@10.0.2(jiti@1.21.7))(typescript@5.9.3)
+      vite-tsconfig-paths:
+        specifier: 6.1.1
+        version: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.6.0))
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.6.0)
@@ -3372,15 +3375,6 @@ packages:
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -9784,10 +9778,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -13696,7 +13686,7 @@ snapshots:
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.6.0)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.3.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.6.0)


### PR DESCRIPTION
## Summary

Fixes the Vitest VSCode/Cursor extension failing to start with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite-tsconfig-paths' imported from /workspaces/confect/node_modules/.vite-temp/vitest.config.ts.timestamp-*.mjs
```

When the extension launches Vitest from the workspace root, Vite bundles each project's config into a timestamped temp file inside the root's `node_modules/.vite-temp/`. Bare imports in that temp file resolve from the root `node_modules/`. Because `vite-tsconfig-paths` was declared only as a dev dependency of `@confect/server` and `@confect/cli`, pnpm's isolated `node_modules` layout meant it wasn't present at the root, so resolution failed.

Adding `vite-tsconfig-paths` to the root `devDependencies` (matching the existing `6.1.1` pin in the packages) makes it resolvable from the temp file.

CLI runs (`pnpm test:server`, `pnpm test:cli`) were unaffected because they execute with the project's directory as cwd.

## Test plan

- [x] Reload the Cursor window and confirm the Vitest extension starts without `ERR_MODULE_NOT_FOUND`
- [x] Confirm `pnpm test:server` and `pnpm test:cli` still pass from the CLI

Made with [Cursor](https://cursor.com)