### PR TITLE
refactor: break @confect/cli ↔ @confect/server workspace cycle

### DIFF
--- a/.changeset/break-cli-server-cycle.md
+++ b/.changeset/break-cli-server-cycle.md
@@ -1,0 +1,7 @@
+---
+"@confect/server": major
+---
+
+Renamed `DatabaseSchema.isSchema` to `DatabaseSchema.isDatabaseSchema` for consistency with the `is<TypeName>` predicate convention used elsewhere (e.g. `Spec.isSpec`). `TypeId` and `Any` are now defined in `@confect/core/DatabaseSchema` and re-exported from `@confect/server`; the underlying brand string is unchanged, so existing schema values continue to be recognized. Migration: replace `DatabaseSchema.isSchema(x)` with `DatabaseSchema.isDatabaseSchema(x)`.
+
+Internally, this removes a cyclic workspace dependency between `@confect/cli` and `@confect/server` that triggered a pnpm install warning. `@confect/cli` no longer peer-depends on `@confect/server`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,6 @@
   },
   "peerDependencies": {
     "@confect/core": "workspace:*",
-    "@confect/server": "workspace:*",
     "@effect/platform": "^0.96.1",
     "effect": "^3.21.2"
   },

--- a/packages/cli/src/confect/codegen.ts
+++ b/packages/cli/src/confect/codegen.ts
@@ -1,5 +1,4 @@
-import { Spec } from "@confect/core";
-import { DatabaseSchema } from "@confect/server";
+import { DatabaseSchema, Spec } from "@confect/core";
 import { Command } from "@effect/cli";
 import { FileSystem, Path } from "@effect/platform";
 import { Effect, Match, Option } from "effect";
@@ -192,7 +191,7 @@ const generateSchema = Effect.gen(function* () {
     Effect.andThen((schemaModule) => {
       const defaultExport = schemaModule.default;
 
-      return DatabaseSchema.isSchema(defaultExport)
+      return DatabaseSchema.isDatabaseSchema(defaultExport)
         ? Effect.succeed(defaultExport)
         : Effect.die("Invalid schema module");
     }),

--- a/packages/core/src/DatabaseSchema.ts
+++ b/packages/core/src/DatabaseSchema.ts
@@ -1,0 +1,11 @@
+import { Predicate } from "effect";
+
+export const TypeId = "@confect/server/DatabaseSchema";
+export type TypeId = typeof TypeId;
+
+export interface Any {
+  readonly [TypeId]: TypeId;
+}
+
+export const isDatabaseSchema = (u: unknown): u is Any =>
+  Predicate.hasProperty(u, TypeId);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * as DatabaseSchema from "./DatabaseSchema";
 export * as FunctionProvenance from "./FunctionProvenance";
 export * as FunctionSpec from "./FunctionSpec";
 export * as GenericId from "./GenericId";

--- a/packages/server/src/DatabaseSchema.ts
+++ b/packages/server/src/DatabaseSchema.ts
@@ -3,14 +3,15 @@ import {
   defineSchema as defineConvexSchema,
   type SchemaDefinition,
 } from "convex/server";
-import { Array, pipe, Predicate, Record } from "effect";
+import { Array, pipe, Record } from "effect";
 import * as Table from "./Table";
+import { TypeId } from "@confect/core/DatabaseSchema";
 
-export const TypeId = "@confect/server/DatabaseSchema";
-export type TypeId = typeof TypeId;
-
-export const isSchema = (u: unknown): u is Any =>
-  Predicate.hasProperty(u, TypeId);
+export {
+  type Any,
+  isDatabaseSchema,
+  TypeId,
+} from "@confect/core/DatabaseSchema";
 
 /**
  * A schema definition tracks the schema and its Convex schema definition.
@@ -29,10 +30,6 @@ export interface DatabaseSchema<Tables_ extends Table.AnyWithProps = never> {
   addTable<TableDef extends Table.AnyWithProps>(
     table: TableDef,
   ): DatabaseSchema<Tables_ | TableDef>;
-}
-
-export interface Any {
-  readonly [TypeId]: TypeId;
 }
 
 export interface AnyWithProps {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,9 +171,6 @@ importers:
       '@confect/core':
         specifier: workspace:*
         version: link:../core
-      '@confect/server':
-        specifier: workspace:*
-        version: link:../server
       '@effect/cli':
         specifier: ^0.75.1
         version: 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)


### PR DESCRIPTION
Move the `DatabaseSchema` brand tag, `Any` interface, and predicate into `@confect/core/DatabaseSchema` and re-export them from `@confect/server`. `@confect/cli` now imports the predicate from `@confect/core` and no longer peer-depends on `@confect/server`, eliminating the cyclic workspace dependency warning emitted by pnpm install.

Also renames `DatabaseSchema.isSchema` to `DatabaseSchema.isDatabaseSchema` to match the `is<TypeName>` convention used elsewhere in the codebase. The underlying brand string is unchanged, so existing schema values continue to be recognized.