### PR TITLE
fix: stop forced major bumps from sibling peer dep cascade

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/peer-deps-workspace-caret.md
+++ b/.changeset/peer-deps-workspace-caret.md
@@ -1,0 +1,14 @@
+---
+"@confect/cli": minor
+"@confect/core": patch
+"@confect/js": patch
+"@confect/react": patch
+"@confect/server": patch
+"@confect/test": patch
+---
+
+Switch sibling `@confect/*` peer-dependency specifiers from `workspace:*` to `workspace:^`. Published peer ranges are now caret-based (e.g. `^7.0.0`) instead of exact-pinned, so non-major upgrades of one `@confect/*` package no longer fall out of range for its peer dependents.
+
+Paired with the Changesets `onlyUpdatePeerDependentsWhenOutOfRange` flag, this prevents the entire `@confect/*` family from being promoted to a major bump on every release when only minor/patch changes are present.
+
+`@confect/cli` additionally moves `@effect/platform` from `peerDependencies` to `dependencies`, since the CLI consumes it as an internal implementation detail (for `FileSystem`/`Path`) rather than exposing it in its public API. Consumers no longer need to install `@effect/platform` themselves to use the CLI.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
   "license": "ISC",
   "dependencies": {
     "@effect/cli": "^0.75.1",
+    "@effect/platform": "0.96.1",
     "@effect/platform-node": "0.106.0",
     "@effect/platform-node-shared": "0.59.0",
     "@effect/printer": "^0.49.0",
@@ -60,7 +61,6 @@
   },
   "devDependencies": {
     "@effect/language-service": "0.86.1",
-    "@effect/platform": "0.96.1",
     "@effect/vitest": "0.29.0",
     "@eslint/js": "10.0.1",
     "@types/node": "25.3.3",
@@ -76,8 +76,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "@confect/core": "workspace:*",
-    "@effect/platform": "^0.96.1",
+    "@confect/core": "workspace:^",
     "effect": "^3.21.2"
   },
   "engines": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -58,7 +58,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "@confect/core": "workspace:*",
+    "@confect/core": "workspace:^",
     "convex": "^1.30.0",
     "effect": "^3.21.2"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,7 +64,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "@confect/core": "workspace:*",
+    "@confect/core": "workspace:^",
     "convex": "^1.30.0",
     "effect": "^3.21.2",
     "react": "^18.0.0 || ^19.0.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -84,7 +84,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "@confect/core": "workspace:*",
+    "@confect/core": "workspace:^",
     "@effect/platform": "^0.96.1",
     "@effect/platform-node": "^0.106.0",
     "convex": "^1.30.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -61,8 +61,8 @@
     "effect": "3.21.2"
   },
   "peerDependencies": {
-    "@confect/core": "workspace:*",
-    "@confect/server": "workspace:*",
+    "@confect/core": "workspace:^",
+    "@confect/server": "workspace:^",
     "convex": "^1.30.0",
     "convex-test": "^0.0.50",
     "effect": "^3.21.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,11 +169,14 @@ importers:
   packages/cli:
     dependencies:
       '@confect/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@effect/cli':
         specifier: ^0.75.1
         version: 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform':
+        specifier: 0.96.1
+        version: 0.96.1(effect@3.21.2)
       '@effect/platform-node':
         specifier: 0.106.0
         version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -196,9 +199,6 @@ importers:
       '@effect/language-service':
         specifier: 0.86.1
         version: 0.86.1
-      '@effect/platform':
-        specifier: 0.96.1
-        version: 0.96.1(effect@3.21.2)
       '@effect/vitest':
         specifier: 0.29.0
         version: 0.29.0(effect@3.21.2)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.6.0))
@@ -285,7 +285,7 @@ importers:
   packages/js:
     dependencies:
       '@confect/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       convex:
         specifier: 1.33.1
@@ -325,7 +325,7 @@ importers:
   packages/react:
     dependencies:
       '@confect/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       react:
         specifier: 19.2.4
@@ -371,7 +371,7 @@ importers:
   packages/server:
     dependencies:
       '@confect/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@effect/platform-node':
         specifier: ^0.106.0
@@ -462,10 +462,10 @@ importers:
   packages/test:
     dependencies:
       '@confect/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@confect/server':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../server
       convex:
         specifier: 1.33.1


### PR DESCRIPTION
## Summary

Closes the loop on the issue surfaced by #398, where every `Version Packages` PR has been bumping the entire `@confect/*` family to a new **major** even when all changesets declared only `minor` or `patch`.

### Root cause

Two interacting Changesets defaults:

1. Sibling `@confect/*` packages declare each other as `peerDependencies` (correctly — `@confect/core` carries `Schema` and `Spec` instances that must be a singleton across module boundaries). Changesets' default rule promotes any peer dependent to a **major** bump whenever its peer dep changes.
2. The `fixed: [["@confect/*"]]` group then aligns every package in the family at that major.

Net effect: one minor changeset → entire family bumped to a new major. PR #398 (Effect ecosystem bump, all `minor`) ends up as `8.0.0` across the board.

### Fix

Mirror the **TanStack Query** recipe (the closest production analog: `fixed` group + sibling peer deps):

- Switch sibling `@confect/*` peer specifiers from `workspace:*` to `workspace:^`, so published peer ranges are caret-based (`^7.0.0`) rather than exact-pinned (`7.0.0`). A minor bump of one sibling now stays within the declared range of the others.
- Enable Changesets' experimental `onlyUpdatePeerDependentsWhenOutOfRange` flag in `.changeset/config.json`. With caret peer ranges in place, this flag becomes a no-op for in-range minor/patch bumps — exactly what we want.

### Verification

`changeset status --verbose` confirms the fix works correctly:

- With **only** `bump-effect-platform.md` + this PR's `peer-deps-workspace-caret.md` (both all-`minor`/`patch`): family bumps to `7.1.0` as a **minor**. Previously this would have produced `8.0.0` as a major.
- With `break-cli-server-cycle.md` (which legitimately declares `@confect/server: major` because #404 renamed `isSchema` → `isDatabaseSchema`): family bumps to `8.0.0` as a **major**. This is correct behavior — there's an actual breaking API change, so a major is warranted. The `fixed` group correctly aligns everyone at that level.

The Changesets bot comment on this PR shows "Major" for the same reason: it reflects the true combined release plan including #404's legitimate major. That is the post-fix correct behavior, not a regression.

### Additional cleanup

While auditing peer deps, found that `@confect/cli` declared `@effect/platform` as a peer dependency, but it's only used as a CLI-internal implementation detail (for `FileSystem`/`Path`) and is never part of the CLI's public surface. Moved it to regular `dependencies`, matching the existing treatment of `@effect/platform-node` in the same package. Consumers no longer need to install `@effect/platform` to use the CLI.

The audit verified that all other peer-dependency declarations across the six `@confect/*` packages are correctly classified.

### Ecosystem precedent

Research into how other Changesets-using monorepos handle this:

| Project | `fixed`/`linked` | Sibling peer deps | Workspace specifier | Experimental flag |
| --- | --- | --- | --- | --- |
| TanStack Query | `fixed` | yes | `workspace:^` (peer) | **yes** |
| `Effect-TS/effect-smol` | `fixed` | yes | `workspace:^` | no (beta) |
| `Effect-TS/effect` | none | yes | `workspace:^` | no |
| Emotion | `linked` | yes | `^11.x.y` literal | **yes** |
| XState | none | yes | + custom range-bump script | **yes** |
| Preact Signals | none | yes | `workspace:*` | **yes** |
| Radix UI | none | minimal | n/a | no |

Every project that combines a version group with sibling peer deps uses the experimental flag. The TanStack Query setup is the most direct match for Confect's existing `fixed` group.

### What this does *not* change

- Versioning model is still `fixed` (all `@confect/*` packages release together at the same version).
- Peer-dep classification is unchanged for every package except `@confect/cli` (where `@effect/platform` is now a regular dep, per the audit).
- Existing changesets are untouched.

## Test plan

- [x] `pnpm install` — lockfile updates cleanly.
- [x] `pnpm build` — all packages build.
- [x] `pnpm typecheck` — passes across all packages and `apps/example`.
- [x] `pnpm changeset status --verbose` — with only `bump-effect-platform.md` + this PR's changeset, reports `Packages to be bumped at minor: ... 7.1.0` (previously showed all at `major: ... 8.0.0`).
- [x] CI green.