### PR TITLE
chore: ignore server test fixtures in Changesets config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": ["@confect/server-*-fixtures"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Excludes `@confect/server` test fixture packages from Changesets versioning.

The local-backend and mock-backend fixture projects are internal test harnesses listed in `pnpm-workspace.yaml` for dependency resolution, but they are not published packages. Because their names match the `@confect/*` fixed-version group glob, Changesets was treating them as release targets — bumping versions, generating changelogs, and listing them in release PRs (e.g. #398).

## Change

Add `@confect/server-*-fixtures` to the `ignore` array in `.changeset/config.json`. This keeps the `@confect/*` fixed group intact for the six real packages while excluding fixture packages from versioning.

## Verification

`changeset status` no longer lists `@confect/server-local-backend-fixtures` or `@confect/server-mock-backend-fixtures`.

## Follow-up

After this merges, the next Changesets release PR should no longer touch the fixture directories. The spurious version bumps and changelogs already on the `changeset-release/main` branch from #398 can be reverted when that release PR is regenerated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ee6b8f-31a6-44b1-91a1-e0c5f88e0dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ee6b8f-31a6-44b1-91a1-e0c5f88e0dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

