### PR TITLE
Preserve parent spec functions in assembled spec

### DIFF
--- a/.changeset/preserve-parent-leaf-in-assembled-spec.md
+++ b/.changeset/preserve-parent-leaf-in-assembled-spec.md
@@ -1,0 +1,11 @@
+---
+"@confect/cli": patch
+---
+
+Allow a `confect/{path}.spec.ts` file to declare functions even when a sibling `confect/{path}/` subdirectory contains further specs.
+
+Previously, every function on the parent spec silently disappeared from the generated api and refs in this layout: `refs.{path}.{fn}` was not defined, while `refs.{path}.{child}.{fn}` (from the subdirectory specs) worked. The parent's `*.impl.ts` continued to type-check on its own, so the missing functions only showed up when something tried to call them.
+
+Both `confect codegen` and `confect dev` now generate the parent's functions and the subdirectory's groups side by side, as `refs.{path}.{fn}` and `refs.{path}.{child}.{fn}`.
+
+Codegen also now reports a clear error when the parent spec declares a function or subgroup whose name matches one of the subdirectory's child segments, rather than letting the conflict turn into a runtime refs collision. `confect codegen` exits non-zero on this error; `confect dev` logs it and keeps watching so the next save can recover.

--- a/.cursor/agents/create-changeset.md
+++ b/.cursor/agents/create-changeset.md
@@ -92,6 +92,33 @@ Lead with the API the consumer recognises, not the internal symbol that implemen
 
 If a refactor only changes how a public API is implemented (no surface change, no behavior change), say so in patch-level prose without naming the internal moving parts.
 
+### Behavior, not mechanics
+
+"Naming things" above keeps internal classes out of summaries; this rule extends past identifiers to the _shape_ of the entry. Even with public API names in backticks, an entry that narrates _how_ a fix was implemented — the pipeline step that changed, the internal exception class that was renamed, the intermediate representation that's now built differently — is still implementation-facing. Frame entries entirely around **what the user authors, what they get back, and what they see on stdout/stderr.**
+
+In practice:
+
+- **Layouts the user writes** (e.g. `confect/notes.spec.ts` next to a sibling `confect/notes/` subdirectory), not the pipeline's internal model of them (import bindings, assembly chains, `_generated/*` artifacts they never import by name).
+- **Refs, hooks, types, and CLI commands the user calls** (`refs.notes.list`, `useQuery(refs.notes.list)`, `confect codegen`, `confect dev`), not the internal builders that produce them (`writeGroupAssembly`, `Refs.make`, `GroupSpec`).
+- **Error messages the user reads in their terminal**, not the internal exception class. The formatted message ("child segment `notes` collides with a function on the parent spec") is what the user sees; an internal name like `` `ParentChildNameCollisionError` `` only appears in maintainer-facing stack traces and does not belong in a changelog.
+- **CLI subcommand behavioral splits** when they're user-visible — whether `confect codegen` exits non-zero versus `confect dev` logs and keeps watching determines whether someone's CI will catch a regression. State both, in the user's command-line terms.
+
+**Bad — internal symbols and pipeline mechanics:**
+
+```md
+Fix `writeGroupAssembly` losing the parent's `FunctionSpec` entries when a leaf module also has child groups. The assembly now starts from the leaf's import binding and chains `.addGroupAt(...)` for each child, so `Refs.make` no longer drops the parent's functions from `_generated/spec.ts`. Codegen also throws a new `ParentChildNameCollisionError` when a child segment shadows a parent function.
+```
+
+**Good — authored layout, resulting refs, observed CLI behavior:**
+
+```md
+Allow a `confect/{path}.spec.ts` file to declare functions even when a sibling `confect/{path}/` subdirectory contains further specs.
+
+Previously, every function on the parent spec silently disappeared from the generated api and refs in this layout: `refs.{path}.{fn}` was not defined, while `refs.{path}.{child}.{fn}` (from the subdirectory specs) worked.
+
+Both `confect codegen` and `confect dev` now generate the parent's functions and the subdirectory's groups side by side, as `refs.{path}.{fn}` and `refs.{path}.{child}.{fn}`. Codegen also reports a clear error when the parent spec declares a function or subgroup whose name matches one of the subdirectory's child segments — `confect codegen` exits non-zero, while `confect dev` logs it and keeps watching.
+```
+
 ### Code and API references
 
 - **Backtick every symbol the user might search for**—types, functions, classes, hooks, module names, flag names, environment variables, file paths.

--- a/packages/cli/src/CodegenError.ts
+++ b/packages/cli/src/CodegenError.ts
@@ -75,6 +75,16 @@ export class SchemaInvalidDefaultExportError extends Schema.TaggedError<SchemaIn
   },
 ) {}
 
+export class ParentChildNameCollisionError extends Schema.TaggedError<ParentChildNameCollisionError>()(
+  "ParentChildNameCollisionError",
+  {
+    parentSpecPath: Schema.String,
+    childSpecPath: Schema.String,
+    collisionName: Schema.String,
+    collisionKind: Schema.Literal("function", "group"),
+  },
+) {}
+
 export class MissingSchemaFileError extends Schema.TaggedError<MissingSchemaFileError>()(
   "MissingSchemaFileError",
   {
@@ -94,6 +104,7 @@ export const CodegenError = Schema.Union(
   ImplMissingFunctionsError,
   SchemaInvalidDefaultExportError,
   MissingSchemaFileError,
+  ParentChildNameCollisionError,
 );
 export type CodegenError = typeof CodegenError.Type;
 
@@ -246,6 +257,21 @@ const renderMissingSchemaFileError = (
     ),
   );
 
+const renderParentChildNameCollisionError = (
+  error: ParentChildNameCollisionError,
+): AnsiDoc.AnsiDoc =>
+  singleLine(
+    AnsiDoc.text("Spec "),
+    formatPathDoc(error.parentSpecPath),
+    AnsiDoc.text(
+      ` declares a ${error.collisionKind} \`${error.collisionName}\` whose name collides with the sibling subdirectory spec `,
+    ),
+    formatPathDoc(error.childSpecPath),
+    AnsiDoc.text(
+      `. Rename one of them so the assembled spec has a unique key at this path.`,
+    ),
+  );
+
 /**
  * Render any {@link CodegenError} into a styled, ready-to-print string.
  * Single-error variants render to a one-line `✘`-prefixed message;
@@ -303,6 +329,12 @@ export const renderCodegenError = (error: CodegenError): string => {
     Match.tag("MissingSchemaFileError", (e) =>
       pipe(
         renderMissingSchemaFileError(e),
+        AnsiDoc.render({ style: "pretty" }),
+      ),
+    ),
+    Match.tag("ParentChildNameCollisionError", (e) =>
+      pipe(
+        renderParentChildNameCollisionError(e),
         AnsiDoc.render({ style: "pretty" }),
       ),
     ),

--- a/packages/cli/src/LeafModule.ts
+++ b/packages/cli/src/LeafModule.ts
@@ -194,7 +194,9 @@ const absoluteModulePath = (relativePath: string) =>
 /**
  * Validate that the leaf's spec file default-exports a `GroupSpec` whose
  * runtime matches the leaf's location (`Convex` for files outside
- * `confect/node/`, `Node` for files inside it).
+ * `confect/node/`, `Node` for files inside it). Returns the validated
+ * `GroupSpec` so callers can avoid re-bundling for later inspection (e.g.
+ * parent/child name-collision checks at codegen time).
  */
 export const validateSpec = (leaf: LeafModule) =>
   Effect.gen(function* () {
@@ -218,6 +220,8 @@ export const validateSpec = (leaf: LeafModule) =>
         actualRuntime: groupSpec.runtime,
       });
     }
+
+    return groupSpec;
   });
 
 /**

--- a/packages/cli/src/confect/codegen.ts
+++ b/packages/cli/src/confect/codegen.ts
@@ -1,4 +1,4 @@
-import { Spec } from "@confect/core";
+import { type GroupSpec, Spec } from "@confect/core";
 import * as DatabaseSchema from "@confect/server/DatabaseSchema";
 import { Command } from "@effect/cli";
 import { FileSystem, Path } from "@effect/platform";
@@ -9,6 +9,7 @@ import {
   MissingImplFileError,
   MissingSchemaFileError,
   MissingSpecFileError,
+  ParentChildNameCollisionError,
   SchemaInvalidDefaultExportError,
 } from "../CodegenError";
 import { ConfectDirectory } from "../ConfectDirectory";
@@ -36,6 +37,7 @@ import {
 import {
   assemblyNodesFromLeaves,
   partitionByRuntime,
+  type SpecAssemblyNode,
 } from "../SpecAssemblyNode";
 import * as templates from "../templates";
 import * as Bundler from "../Bundler";
@@ -101,8 +103,10 @@ const runCodegen = Effect.gen(function* () {
   // on schema via `_generated/api.ts` and would otherwise blow up with a
   // less actionable bundler error.
   yield* validateSchema;
-  const leaves = yield* loadAndValidateLeafModules;
+  const { leaves, groupSpecsByRelativePath } =
+    yield* loadAndValidateLeafModules;
   yield* removeLegacyFiles;
+  yield* validateNoParentChildNameCollisions(leaves, groupSpecsByRelativePath);
   yield* generateAssembledSpecs(leaves);
   yield* validateImplModules(leaves);
   yield* generateGroupRegisteredFunctions(leaves);
@@ -144,10 +148,10 @@ const loadAndValidateLeafModules = Effect.gen(function* () {
   const confectDirectory = yield* ConfectDirectory.get;
   const specFiles = yield* discoverLeafSpecFiles;
 
-  const leaves = yield* Effect.forEach(specFiles, (specRelativePath) =>
+  const results = yield* Effect.forEach(specFiles, (specRelativePath) =>
     Effect.gen(function* () {
       const leaf = yield* toLeafModule(specRelativePath);
-      yield* validateSpec(leaf);
+      const groupSpec = yield* validateSpec(leaf);
 
       const implRelativePath = yield* implPathForSpec(specRelativePath);
       const implAbsolutePath = path.join(confectDirectory, implRelativePath);
@@ -158,14 +162,131 @@ const loadAndValidateLeafModules = Effect.gen(function* () {
         });
       }
 
-      return leaf;
+      return { leaf, groupSpec };
     }),
   );
 
   yield* validateOrphanImpls(specFiles);
 
-  return leaves;
+  const leaves = Array.map(results, ({ leaf }) => leaf);
+  const groupSpecsByRelativePath = new Map(
+    Array.map(results, ({ leaf, groupSpec }) => [leaf.relativePath, groupSpec]),
+  );
+
+  return { leaves, groupSpecsByRelativePath };
 });
+
+/**
+ * Walk the assembly tree and fail with a {@link ParentChildNameCollisionError}
+ * when a parent leaf declares a function or subgroup whose name matches a
+ * sibling subdirectory spec's segment. Without this check the colliding
+ * descendant would overwrite the parent's entry in the assembled
+ * `GroupSpec.groups` map at runtime, surfacing as a confusing
+ * `Refs.make` error rather than a codegen-time diagnostic.
+ */
+export const validateNoParentChildNameCollisions = (
+  leaves: ReadonlyArray<LeafModule>,
+  groupSpecsByRelativePath: ReadonlyMap<string, GroupSpec.AnyWithProps>,
+) =>
+  Effect.gen(function* () {
+    const { convex, node } = partitionByRuntime(leaves);
+    const convexNodes = assemblyNodesFromLeaves(convex);
+    const nodeNodes = assemblyNodesFromLeaves(
+      Array.map(node, toNodeRegistryLeaf),
+    );
+    yield* Effect.forEach(convexNodes, (n) =>
+      checkAssemblyNodeForCollisions(n, groupSpecsByRelativePath),
+    );
+    yield* Effect.forEach(nodeNodes, (n) =>
+      checkAssemblyNodeForCollisions(n, groupSpecsByRelativePath),
+    );
+  });
+
+const checkAssemblyNodeForCollisions = (
+  node: SpecAssemblyNode,
+  groupSpecsByRelativePath: ReadonlyMap<string, GroupSpec.AnyWithProps>,
+): Effect.Effect<void, ParentChildNameCollisionError> =>
+  Effect.gen(function* () {
+    yield* Option.match(node.importBinding, {
+      onNone: () => Effect.void,
+      onSome: (binding) =>
+        Effect.gen(function* () {
+          if (node.children.length === 0) return;
+          const parentRelativePath = bindingToRelativeSpecPath(
+            binding.importPath,
+          );
+          const parentGroupSpec =
+            groupSpecsByRelativePath.get(parentRelativePath);
+          if (parentGroupSpec === undefined) return;
+          yield* Effect.forEach(node.children, (child) => {
+            if (
+              Object.prototype.hasOwnProperty.call(
+                parentGroupSpec.functions,
+                child.segment,
+              )
+            ) {
+              return Effect.fail(
+                new ParentChildNameCollisionError({
+                  parentSpecPath: parentRelativePath,
+                  childSpecPath: childRepresentativeSpecPath(child),
+                  collisionName: child.segment,
+                  collisionKind: "function",
+                }),
+              );
+            }
+            if (
+              Object.prototype.hasOwnProperty.call(
+                parentGroupSpec.groups,
+                child.segment,
+              )
+            ) {
+              return Effect.fail(
+                new ParentChildNameCollisionError({
+                  parentSpecPath: parentRelativePath,
+                  childSpecPath: childRepresentativeSpecPath(child),
+                  collisionName: child.segment,
+                  collisionKind: "group",
+                }),
+              );
+            }
+            return Effect.void;
+          });
+        }),
+    });
+    yield* Effect.forEach(node.children, (child) =>
+      checkAssemblyNodeForCollisions(child, groupSpecsByRelativePath),
+    );
+  });
+
+/**
+ * `LeafModule.specImportPath` is the import path used from inside the
+ * generated `_generated/spec.ts` (e.g. `"../notes.spec"`). Strip the
+ * `../` prefix and re-add the `.ts` extension to recover the leaf's
+ * confect-relative spec path used as the key in
+ * `groupSpecsByRelativePath`.
+ */
+const bindingToRelativeSpecPath = (importPath: string): string => {
+  const withoutDotDot = importPath.startsWith("../")
+    ? importPath.slice(3)
+    : importPath;
+  return `${withoutDotDot}.ts`;
+};
+
+/**
+ * A child assembly node may itself be a parent without a leaf (when the
+ * actual leaves live only in deeper subdirectories). In that case we
+ * surface the first descendant leaf as a representative path so the
+ * error message points at something the user actually wrote.
+ */
+const childRepresentativeSpecPath = (node: SpecAssemblyNode): string => {
+  if (Option.isSome(node.importBinding)) {
+    return bindingToRelativeSpecPath(node.importBinding.value.importPath);
+  }
+  for (const child of node.children) {
+    return childRepresentativeSpecPath(child);
+  }
+  return node.segment;
+};
 
 const validateOrphanImpls = (specFiles: ReadonlyArray<string>) =>
   Effect.gen(function* () {

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -411,12 +411,16 @@ const writeGroupAssembly: (
   node: SpecAssemblyNode,
   groupFactory: string,
 ) => Effect.Effect<void> = (cbw, node, groupFactory) =>
-  node.children.length === 0
-    ? Option.match(node.importBinding, {
-        onNone: () => writeGroupFactoryCall(cbw, node, groupFactory),
-        onSome: (binding) => cbw.write(binding.exportName),
-      })
-    : writeGroupFactoryCall(cbw, node, groupFactory);
+  Option.match(node.importBinding, {
+    onNone: () => writeGroupFactoryCall(cbw, node, groupFactory),
+    onSome: (binding) =>
+      Effect.gen(function* () {
+        yield* cbw.write(binding.exportName);
+        yield* Effect.forEach(node.children, (child) =>
+          writeChildAddGroupAt(cbw, child, groupFactory),
+        );
+      }),
+  });
 
 const writeRootAddAt = (
   cbw: CodeBlockWriter,
@@ -443,10 +447,11 @@ export const assembledSpec = ({
   Effect.gen(function* () {
     const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    const needsGroupSpec = Array.some(
-      nodes,
-      (node) => node.children.length > 0,
-    );
+    const nodeRequiresGroupFactory = (node: SpecAssemblyNode): boolean =>
+      Option.isNone(node.importBinding) ||
+      Array.some(node.children, nodeRequiresGroupFactory);
+
+    const needsGroupSpec = Array.some(nodes, nodeRequiresGroupFactory);
     yield* cbw.writeLine(
       needsGroupSpec
         ? `import { GroupSpec, Spec } from "@confect/core";`

--- a/packages/cli/test/LeafModule.test.ts
+++ b/packages/cli/test/LeafModule.test.ts
@@ -34,10 +34,10 @@ interface TempFile {
   readonly contents: string;
 }
 
-const withTempFiles = (
+const withTempFiles = <A>(
   files: ReadonlyArray<TempFile>,
   use: Effect.Effect<
-    void,
+    A,
     CodegenError,
     ConfectDirectory | Path.Path | FileSystem.FileSystem
   >,
@@ -48,7 +48,7 @@ const withTempFiles = (
     yield* Effect.forEach(files, ({ relativePath, contents }) =>
       fs.writeFileString(path.join(fixtureConfect, relativePath), contents),
     );
-    yield* use;
+    return yield* use;
   }).pipe(
     Effect.ensuring(
       Effect.gen(function* () {
@@ -66,11 +66,11 @@ const withTempFiles = (
     ),
   );
 
-const withTempFile = (
+const withTempFile = <A>(
   relativePath: string,
   contents: string,
   use: Effect.Effect<
-    void,
+    A,
     CodegenError,
     ConfectDirectory | Path.Path | FileSystem.FileSystem
   >,

--- a/packages/cli/test/SpecAssemblyNode.test.ts
+++ b/packages/cli/test/SpecAssemblyNode.test.ts
@@ -40,4 +40,74 @@ describe("SpecAssemblyNode", () => {
       expect(contents).toContain('.addAt("env", env)');
     }),
   );
+
+  it.effect(
+    "assembledSpec preserves a parent leaf when sibling subdirectory specs exist",
+    () =>
+      Effect.gen(function* () {
+        const nodes = assemblyNodesFromLeaves([
+          leaf("notes.spec.ts", ["notes"]),
+          leaf("notes/archived.spec.ts", ["notes", "archived"]),
+        ]);
+        const contents = yield* templates.assembledSpec({
+          nodes,
+          runtime: "Convex",
+        });
+
+        expect(contents).toContain('import notes from "../notes.spec";');
+        expect(contents).toContain(
+          'import archived from "../notes/archived.spec";',
+        );
+        expect(contents).toContain(
+          '.addAt("notes", notes.addGroupAt("archived", archived))',
+        );
+        expect(contents).not.toContain('GroupSpec.makeAt("notes")');
+      }),
+  );
+
+  it.effect(
+    "assembledSpec only imports GroupSpec when at least one node lacks a leaf binding",
+    () =>
+      Effect.gen(function* () {
+        const nodes = assemblyNodesFromLeaves([
+          leaf("notes.spec.ts", ["notes"]),
+          leaf("notes/archived.spec.ts", ["notes", "archived"]),
+        ]);
+        const contents = yield* templates.assembledSpec({
+          nodes,
+          runtime: "Convex",
+        });
+
+        expect(contents).toContain('import { Spec } from "@confect/core";');
+        expect(contents).not.toContain(
+          'import { GroupSpec, Spec } from "@confect/core";',
+        );
+      }),
+  );
+
+  it.effect(
+    "assembledSpec keeps GroupSpec.makeAt when a leafless descendant has children",
+    () =>
+      Effect.gen(function* () {
+        const nodes = assemblyNodesFromLeaves([
+          leaf("notes.spec.ts", ["notes"]),
+          leaf("notes/archived/legacy.spec.ts", [
+            "notes",
+            "archived",
+            "legacy",
+          ]),
+        ]);
+        const contents = yield* templates.assembledSpec({
+          nodes,
+          runtime: "Convex",
+        });
+
+        expect(contents).toContain(
+          'import { GroupSpec, Spec } from "@confect/core";',
+        );
+        expect(contents).toContain(
+          '.addAt("notes", notes.addGroupAt("archived", GroupSpec.makeAt("archived").addGroupAt("legacy", legacy)))',
+        );
+      }),
+  );
 });

--- a/packages/cli/test/codegen.test.ts
+++ b/packages/cli/test/codegen.test.ts
@@ -1,7 +1,7 @@
 import { FunctionSpec, GroupSpec } from "@confect/core";
 import { FileSystem, Path } from "@effect/platform";
 import { NodeFileSystem, NodePath } from "@effect/platform-node";
-import { assert, describe, expect, it, layer } from "@effect/vitest";
+import { assert, expect, layer } from "@effect/vitest";
 import { Effect, Either, Layer, Schema } from "effect";
 import {
   validateNoParentChildNameCollisions,
@@ -109,7 +109,7 @@ const leaf = (
 const emptyArgs = Schema.Struct({});
 const emptyReturns = Schema.Null;
 
-describe("validateNoParentChildNameCollisions", () => {
+layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {
   it.effect("accepts non-colliding parent-with-children layouts", () =>
     Effect.gen(function* () {
       const parent = leaf("notes.spec.ts", ["notes"]);

--- a/packages/cli/test/codegen.test.ts
+++ b/packages/cli/test/codegen.test.ts
@@ -1,9 +1,14 @@
+import { FunctionSpec, GroupSpec } from "@confect/core";
 import { FileSystem, Path } from "@effect/platform";
 import { NodeFileSystem, NodePath } from "@effect/platform-node";
-import { assert, expect, layer } from "@effect/vitest";
-import { Effect, Either, Layer } from "effect";
-import { validateSchema } from "../src/confect/codegen";
+import { assert, describe, expect, it, layer } from "@effect/vitest";
+import { Effect, Either, Layer, Schema } from "effect";
+import {
+  validateNoParentChildNameCollisions,
+  validateSchema,
+} from "../src/confect/codegen";
 import { ConfectDirectory } from "../src/ConfectDirectory";
+import type { LeafModule } from "../src/LeafModule";
 
 const fixtureConfect = `${import.meta.dirname}/../../server/test/mock-backend/fixtures/confect`;
 
@@ -85,5 +90,109 @@ layer(CodegenLayer)("validateSchema", (it) => {
       assert(Either.isLeft(result));
       expect(result.left._tag).toBe("MissingSchemaFileError");
     }).pipe(Effect.scoped),
+  );
+});
+
+const leaf = (
+  relativePath: string,
+  pathSegments: [string, ...string[]],
+): LeafModule => ({
+  relativePath,
+  pathSegments,
+  groupPathDot: pathSegments.join("."),
+  registryGroupPathDot: pathSegments.join("."),
+  exportName: pathSegments[pathSegments.length - 1]!,
+  runtime: "Convex",
+  specImportPath: `../${relativePath.slice(0, -".ts".length)}`,
+});
+
+const emptyArgs = Schema.Struct({});
+const emptyReturns = Schema.Null;
+
+describe("validateNoParentChildNameCollisions", () => {
+  it.effect("accepts non-colliding parent-with-children layouts", () =>
+    Effect.gen(function* () {
+      const parent = leaf("notes.spec.ts", ["notes"]);
+      const child = leaf("notes/archived.spec.ts", ["notes", "archived"]);
+      const parentGroupSpec = GroupSpec.make().addFunction(
+        FunctionSpec.publicQuery({
+          name: "list",
+          args: emptyArgs,
+          returns: emptyReturns,
+        }),
+      );
+
+      yield* validateNoParentChildNameCollisions(
+        [parent, child],
+        new Map([[parent.relativePath, parentGroupSpec]]),
+      );
+    }),
+  );
+
+  it.effect(
+    "fails when a parent function name matches a sibling subdirectory segment",
+    () =>
+      Effect.gen(function* () {
+        const parent = leaf("notes.spec.ts", ["notes"]);
+        const child = leaf("notes/archived.spec.ts", ["notes", "archived"]);
+        const parentGroupSpec = GroupSpec.make().addFunction(
+          FunctionSpec.publicQuery({
+            name: "archived",
+            args: emptyArgs,
+            returns: emptyReturns,
+          }),
+        );
+
+        const result = yield* Effect.either(
+          validateNoParentChildNameCollisions(
+            [parent, child],
+            new Map([[parent.relativePath, parentGroupSpec]]),
+          ),
+        );
+
+        assert(Either.isLeft(result));
+        expect(result.left._tag).toBe("ParentChildNameCollisionError");
+        expect(result.left.collisionKind).toBe("function");
+        expect(result.left.collisionName).toBe("archived");
+        expect(result.left.parentSpecPath).toBe("notes.spec.ts");
+        expect(result.left.childSpecPath).toBe("notes/archived.spec.ts");
+      }),
+  );
+
+  it.effect(
+    "fails when a parent addGroupAt name matches a sibling subdirectory segment",
+    () =>
+      Effect.gen(function* () {
+        const parent = leaf("notes.spec.ts", ["notes"]);
+        const child = leaf("notes/archived.spec.ts", ["notes", "archived"]);
+        const inner = GroupSpec.makeAt("inner").addFunction(
+          FunctionSpec.publicQuery({
+            name: "list",
+            args: emptyArgs,
+            returns: emptyReturns,
+          }),
+        );
+        const parentGroupSpec = GroupSpec.make().addGroupAt("archived", inner);
+
+        const result = yield* Effect.either(
+          validateNoParentChildNameCollisions(
+            [parent, child],
+            new Map([[parent.relativePath, parentGroupSpec]]),
+          ),
+        );
+
+        assert(Either.isLeft(result));
+        expect(result.left._tag).toBe("ParentChildNameCollisionError");
+        expect(result.left.collisionKind).toBe("group");
+        expect(result.left.collisionName).toBe("archived");
+      }),
+  );
+
+  it.effect("ignores collisions when there is no parent leaf", () =>
+    Effect.gen(function* () {
+      const child = leaf("notes/archived.spec.ts", ["notes", "archived"]);
+
+      yield* validateNoParentChildNameCollisions([child], new Map());
+    }),
   );
 });


### PR DESCRIPTION
## Summary

In a layout where `confect/{path}.spec.ts` lives alongside a sibling `confect/{path}/` subdirectory containing further specs, every function declared on the parent spec was silently dropped from the generated api and refs. `refs.{path}.{fn}` was undefined; only `refs.{path}.{child}.{fn}` (from the subdirectory specs) worked. The parent's `*.impl.ts` continued to type-check on its own — impl validation reads the spec file directly rather than the assembled tree — so nothing surfaced until a caller actually tried to invoke one of the dropped functions and found it missing.

Both `confect codegen` and `confect dev` now generate the parent's functions and the subdirectory's groups side by side. Codegen also reports a clear error when the parent declares a function or subgroup whose name matches one of the subdirectory's child segments, rather than letting the conflict become a runtime refs collision. `confect codegen` exits non-zero on that error; `confect dev` logs it and keeps watching.

## Commits

- **Preserve parent spec functions in assembled spec** — the assembly emitter previously handled two of three node shapes (leaf-only and children-only) and fell through the third (leaf with children) into the children-only branch, dropping the leaf's import binding. The fix keys emission off the import binding instead of the children count, adds a codegen-time `ParentChildNameCollisionError` to catch the two new collision modes that case unlocks, and reuses the spec bundling that already runs during validation to feed the collision check.
- **Distinguish user-facing behavior from mechanics in changesets** — a side-quest from drafting the changeset for this fix. Adds a "Behavior, not mechanics" subsection to the `create-changeset` skill that extends the existing "Naming things" rule from individual identifiers to the *shape* of an entry, with a concrete Bad/Good pair drawn from this PR's changeset. Standalone improvement to the skill, included here because the motivation is fresh.

## Test plan

- [x] `pnpm test:cli` — new tests cover the parent-with-children assembly (three new cases in `SpecAssemblyNode.test.ts` for preservation, the conditional `GroupSpec` import, and a leafless descendant with children) and the collision validator (four new cases in `codegen.test.ts` for accept/function-name reject/group-name reject/no-parent-leaf early return).
- [x] `pnpm test:core` — unchanged, verified still green.
- [x] `pnpm typecheck` — all packages including `apps/example`.
- [x] `pnpm build` — all packages.
- [x] End-to-end smoke test against `apps/example` confirms the regenerated `_generated/spec.ts` correctly preserves the parent leaf when a parent spec is added next to an existing subdirectory (and reverts cleanly when removed).


Made with [Cursor](https://cursor.com)