### PR TITLE
Fix spec basename collision in codegen

### DIFF
--- a/.changeset/unique-spec-import-bindings.md
+++ b/.changeset/unique-spec-import-bindings.md
@@ -1,0 +1,9 @@
+---
+"@confect/cli": patch
+---
+
+Generate a unique import binding per spec leaf in `_generated/spec.ts`, even when sibling `*.spec.ts` files share a basename across directories.
+
+Previously, codegen keyed import bindings by file basename (the filename minus `.spec.ts`). When two leaves shared a basename they collapsed to a single binding, last write wins. Every `addGroupAt(...)` site that should have referenced any of the colliding leaves ended up referencing the same survivor, and every impl whose sibling spec was dropped failed `validateImpl` with `Could not resolve group path for the provided GroupSpec.` because the assembled tree no longer contained that spec object's identity.
+
+Each binding now carries its own `localName` derived from the leaf's full path segments (e.g. `scripts_operational_seed_mutations`), used both as the imported identifier and at the matching `addGroupAt` site. Top-level leaves with single-segment paths are unchanged (`env`, `notes`, etc.).

--- a/packages/cli/src/SpecAssemblyNode.ts
+++ b/packages/cli/src/SpecAssemblyNode.ts
@@ -4,6 +4,7 @@ import { Array, Option, Order, pipe, Record } from "effect";
 export interface SpecImportBinding {
   readonly importPath: string;
   readonly exportName: string;
+  readonly localName: string;
 }
 
 export interface SpecAssemblyNode {
@@ -15,6 +16,7 @@ export interface SpecAssemblyNode {
 const importBindingFromLeaf = (leaf: LeafModule): SpecImportBinding => ({
   importPath: leaf.specImportPath,
   exportName: leaf.exportName,
+  localName: leaf.pathSegments.join("_"),
 });
 
 const assemblyNodesAtDepth = (
@@ -75,8 +77,8 @@ export const collectImportBindings = (
   pipe(
     Array.flatMap(nodes, importBindingsForNode),
     (bindings) =>
-      Record.fromIterableBy(bindings, (binding) => binding.exportName),
+      Record.fromIterableBy(bindings, (binding) => binding.importPath),
     Record.toEntries,
-    Array.sortBy(Order.mapInput(Order.string, ([exportName]) => exportName)),
     Array.map(([, binding]) => binding),
+    Array.sortBy(Order.mapInput(Order.string, (binding) => binding.localName)),
   );

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -415,7 +415,7 @@ const writeGroupAssembly: (
     onNone: () => writeGroupFactoryCall(cbw, node, groupFactory),
     onSome: (binding) =>
       Effect.gen(function* () {
-        yield* cbw.write(binding.exportName);
+        yield* cbw.write(binding.localName);
         yield* Effect.forEach(node.children, (child) =>
           writeChildAddGroupAt(cbw, child, groupFactory),
         );
@@ -460,7 +460,7 @@ export const assembledSpec = ({
 
     yield* Effect.forEach(collectImportBindings(nodes), (binding) =>
       cbw.writeLine(
-        `import ${binding.exportName} from "${binding.importPath}";`,
+        `import ${binding.localName} from "${binding.importPath}";`,
       ),
     );
 

--- a/packages/cli/test/SpecAssemblyNode.test.ts
+++ b/packages/cli/test/SpecAssemblyNode.test.ts
@@ -32,10 +32,13 @@ describe("SpecAssemblyNode", () => {
 
       expect(contents).toContain('import env from "../env.spec";');
       expect(contents).toContain(
-        'import notes from "../notesAndRandom/notes.spec";',
+        'import notesAndRandom_notes from "../notesAndRandom/notes.spec";',
       );
       expect(contents).toContain(
-        'GroupSpec.makeAt("notesAndRandom").addGroupAt("notes", notes).addGroupAt("random", random)',
+        'import notesAndRandom_random from "../notesAndRandom/random.spec";',
+      );
+      expect(contents).toContain(
+        'GroupSpec.makeAt("notesAndRandom").addGroupAt("notes", notesAndRandom_notes).addGroupAt("random", notesAndRandom_random)',
       );
       expect(contents).toContain('.addAt("env", env)');
     }),
@@ -56,10 +59,10 @@ describe("SpecAssemblyNode", () => {
 
         expect(contents).toContain('import notes from "../notes.spec";');
         expect(contents).toContain(
-          'import archived from "../notes/archived.spec";',
+          'import notes_archived from "../notes/archived.spec";',
         );
         expect(contents).toContain(
-          '.addAt("notes", notes.addGroupAt("archived", archived))',
+          '.addAt("notes", notes.addGroupAt("archived", notes_archived))',
         );
         expect(contents).not.toContain('GroupSpec.makeAt("notes")');
       }),
@@ -106,7 +109,88 @@ describe("SpecAssemblyNode", () => {
           'import { GroupSpec, Spec } from "@confect/core";',
         );
         expect(contents).toContain(
-          '.addAt("notes", notes.addGroupAt("archived", GroupSpec.makeAt("archived").addGroupAt("legacy", legacy)))',
+          '.addAt("notes", notes.addGroupAt("archived", GroupSpec.makeAt("archived").addGroupAt("legacy", notes_archived_legacy)))',
+        );
+      }),
+  );
+
+  it.effect(
+    "assembledSpec gives every leaf a unique import binding when sibling specs share a basename",
+    () =>
+      Effect.gen(function* () {
+        const leaves = [
+          leaf("scripts/operational/inviteUser/mutations.spec.ts", [
+            "scripts",
+            "operational",
+            "inviteUser",
+            "mutations",
+          ]),
+          leaf("scripts/operational/inviteUser/queries.spec.ts", [
+            "scripts",
+            "operational",
+            "inviteUser",
+            "queries",
+          ]),
+          leaf("scripts/operational/seed/mutations.spec.ts", [
+            "scripts",
+            "operational",
+            "seed",
+            "mutations",
+          ]),
+          leaf("scripts/operational/seedTestUser/mutations.spec.ts", [
+            "scripts",
+            "operational",
+            "seedTestUser",
+            "mutations",
+          ]),
+          leaf("scripts/operational/seedTestUser/queries.spec.ts", [
+            "scripts",
+            "operational",
+            "seedTestUser",
+            "queries",
+          ]),
+        ];
+        const nodes = assemblyNodesFromLeaves(leaves);
+        const contents = yield* templates.assembledSpec({
+          nodes,
+          runtime: "Convex",
+        });
+
+        expect(contents).toContain(
+          'import scripts_operational_inviteUser_mutations from "../scripts/operational/inviteUser/mutations.spec";',
+        );
+        expect(contents).toContain(
+          'import scripts_operational_inviteUser_queries from "../scripts/operational/inviteUser/queries.spec";',
+        );
+        expect(contents).toContain(
+          'import scripts_operational_seed_mutations from "../scripts/operational/seed/mutations.spec";',
+        );
+        expect(contents).toContain(
+          'import scripts_operational_seedTestUser_mutations from "../scripts/operational/seedTestUser/mutations.spec";',
+        );
+        expect(contents).toContain(
+          'import scripts_operational_seedTestUser_queries from "../scripts/operational/seedTestUser/queries.spec";',
+        );
+
+        const importLines = contents
+          .split("\n")
+          .filter((line) => line.startsWith("import ") && line.includes(".spec"));
+        expect(importLines).toHaveLength(leaves.length);
+
+        expect(contents).toContain(
+          '.addGroupAt("mutations", scripts_operational_inviteUser_mutations)',
+        );
+        expect(contents).toContain(
+          '.addGroupAt("queries", scripts_operational_inviteUser_queries)',
+        );
+        expect(contents).toContain(
+          '.addGroupAt("mutations", scripts_operational_seed_mutations)',
+        );
+        expect(contents).toContain(
+          '.addGroupAt("mutations", scripts_operational_seedTestUser_mutations)',
+        );
+        expect(contents).toContain(
+          '.addGroupAt("queries", scripts_operational_seedTestUser_queries)',
         );
       }),
   );

--- a/packages/cli/test/SpecAssemblyNode.test.ts
+++ b/packages/cli/test/SpecAssemblyNode.test.ts
@@ -174,7 +174,9 @@ describe("SpecAssemblyNode", () => {
 
         const importLines = contents
           .split("\n")
-          .filter((line) => line.startsWith("import ") && line.includes(".spec"));
+          .filter(
+            (line) => line.startsWith("import ") && line.includes(".spec"),
+          );
         expect(importLines).toHaveLength(leaves.length);
 
         expect(contents).toContain(

--- a/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
@@ -1,5 +1,5 @@
 import { GroupSpec, Spec } from "@confect/core";
-import cacheControl from "../groups/cacheControl.spec";
-import cacheStubbed from "../groups/cacheStubbed.spec";
+import groups_cacheControl from "../groups/cacheControl.spec";
+import groups_cacheStubbed from "../groups/cacheStubbed.spec";
 
-export default Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", cacheControl).addGroupAt("cacheStubbed", cacheStubbed));
+export default Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed));

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
@@ -1,8 +1,8 @@
 import { GroupSpec, Spec } from "@confect/core";
 import databaseReader from "../databaseReader.spec";
-import notes from "../groups/notes.spec";
-import random from "../groups/random.spec";
-import runners from "../groups/runners.spec";
-import typedErrors from "../groups/typedErrors.spec";
+import groups_notes from "../groups/notes.spec";
+import groups_random from "../groups/random.spec";
+import groups_runners from "../groups/runners.spec";
+import groups_typedErrors from "../groups/typedErrors.spec";
 
-export default Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("notes", notes).addGroupAt("random", random).addGroupAt("runners", runners).addGroupAt("typedErrors", typedErrors));
+export default Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors));


### PR DESCRIPTION
## Summary

`SpecImportBinding.exportName` (the file basename without `.spec`) was overloaded as both the dedup key in `collectImportBindings` and the JS identifier emitted in `_generated/spec.ts`'s `import` lines and `addGroupAt(...)` references. When two leaves shared a basename — the natural layout when mirroring a Convex tree that uses `mutations.ts`/`queries.ts`/`actions.ts` under multiple parents — `Record.fromIterableBy` collapsed them to a single binding, and every colliding `addGroupAt` site referenced the surviving leaf. Each impl whose sibling spec was dropped then failed `validateImpl` with `Could not resolve group path for the provided GroupSpec` because the assembled tree no longer contained that spec object's identity.

This PR splits the two roles by adding a `localName` field to `SpecImportBinding`, derived from `leaf.pathSegments.join("_")`:

- `collectImportBindings` now dedupes by the unique `importPath` and sorts by `localName`.
- `templates.assembledSpec` and `writeGroupAssembly` emit `localName` for both the import statement and the assembly-site reference.
- Top-level single-segment leaves (`env`, `notes`) keep their original names; nested leaves get path-derived names like `notesAndRandom_notes` or `scripts_operational_seed_mutations`.

### Out of scope

`toNodeRegistryLeaf` flattens node leaves' `pathSegments` to `[exportName]` before assembly, so colliding node-leaf basenames would still collapse at the assembly-tree level (one step earlier than this PR's binding logic). That is a separate latent issue with a different fix and is left out of scope here.

## Test plan

- [x] Updated existing assertions in `packages/cli/test/SpecAssemblyNode.test.ts` to expect path-derived local names.
- [x] Added a new test in the same file covering the bug's reproduction (multiple sibling specs sharing a basename in different directories), asserting each leaf produces its own import line and is referenced at the matching `addGroupAt` site.
- [x] `pnpm test:cli` passes (68 tests, including the new collision test, plus typecheck).

Made with [Cursor](https://cursor.com)