### PR TITLE
Externalize bare specifiers in codegen bundler

### DIFF
--- a/.changeset/externalize-bare-specifiers.md
+++ b/.changeset/externalize-bare-specifiers.md
@@ -1,0 +1,19 @@
+---
+"@confect/cli": patch
+---
+
+Externalize every bare-specifier dependency during codegen bundling instead of inlining third-party packages.
+
+### Why
+
+Since `9.0.0-next.0`, codegen bundles each `*.impl.ts` with esbuild so it can load the default-exported `Layer` and read the snapshotted function names from a `Finalized` `GroupImpl`. The bundler only marked `@confect/core`, `@confect/server`, `effect`, and `@effect/*` as external — every other dependency, including all of `node_modules` and every `node:*` built-in reached through inlined CJS source, was bundled into the output. With `format: "esm"`, esbuild rewrites any CJS `require(...)` in that inlined source to a runtime shim that throws `Dynamic require of "<id>" is not supported`, so any impl importing a third-party package (`sharp`, `luxon`, `@clerk/backend`, `jsonwebtoken`, `openai`, etc.) failed during `validateImpl`.
+
+### What changed
+
+- `@confect/cli/Bundler`'s `absoluteExternalsPlugin` now externalizes every bare specifier (anything not starting with `./`, `../`, or `/`), resolving each to an absolute file URL via the user's `node_modules`. `node:*` built-ins pass through unchanged.
+- The `EXTERNAL_PACKAGES` allow-list is removed; relative imports continue to be bundled so the user's own source is still transpiled together.
+- `@confect/cli/confect/dev` drops the redundant `external: EXTERNAL_PACKAGES` esbuild option — the plugin handles externalization for both codegen and dev-mode watchers.
+
+### Fixes
+
+This restores `confect codegen` for impls that import any non-`@confect/*` / `effect` / `@effect/*` library, fixing the regression introduced in `9.0.0-next.0`.

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -24,9 +24,7 @@ const packageNameFromSpecifier = (specifier: string) => {
       return specifier;
     }
     const subpathStart = specifier.indexOf("/", scopeEnd + 1);
-    return subpathStart === -1
-      ? specifier
-      : specifier.slice(0, subpathStart);
+    return subpathStart === -1 ? specifier : specifier.slice(0, subpathStart);
   }
   const slash = specifier.indexOf("/");
   return slash === -1 ? specifier : specifier.slice(0, slash);

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -1,4 +1,6 @@
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Path } from "@effect/platform";
 import { Array, Effect, Option, pipe } from "effect";
@@ -15,6 +17,87 @@ const isRelativeOrAbsolutePath = (importPath: string) =>
   importPath.startsWith("../") ||
   importPath.startsWith("/");
 
+const packageNameFromSpecifier = (specifier: string) => {
+  if (specifier.startsWith("@")) {
+    const scopeEnd = specifier.indexOf("/", 1);
+    if (scopeEnd === -1) {
+      return specifier;
+    }
+    const subpathStart = specifier.indexOf("/", scopeEnd + 1);
+    return subpathStart === -1
+      ? specifier
+      : specifier.slice(0, subpathStart);
+  }
+  const slash = specifier.indexOf("/");
+  return slash === -1 ? specifier : specifier.slice(0, slash);
+};
+
+const exportSubpathFromSpecifier = (specifier: string) => {
+  const packageName = packageNameFromSpecifier(specifier);
+  if (specifier === packageName) {
+    return ".";
+  }
+  return `.${specifier.slice(packageName.length)}`;
+};
+
+const readExportTarget = (
+  entry: unknown,
+  condition: "import" | "require",
+): string | undefined => {
+  if (typeof entry === "string") {
+    return entry;
+  }
+  if (!entry || typeof entry !== "object") {
+    return undefined;
+  }
+  const conditions = entry as Record<string, unknown>;
+  const primary = conditions[condition];
+  if (typeof primary === "string") {
+    return primary;
+  }
+  if (primary && typeof primary === "object") {
+    const nested = primary as Record<string, unknown>;
+    const nestedTarget = nested[condition];
+    if (typeof nestedTarget === "string") {
+      return nestedTarget;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Resolve a bare specifier to an absolute file URL suitable for `import()` from
+ * a bundled ESM data URL. Prefer each package's ESM `import` export condition
+ * so dual-package CJS/ESM deps like `convex/server` keep their named exports.
+ * Fall back to CommonJS resolution for packages without an ESM entry (e.g.
+ * `luxon`).
+ */
+const resolveBareSpecifierToFileUrl = (
+  specifier: string,
+  resolveDir: string,
+) => {
+  const parentFile = pathToFileURL(`${resolveDir}/_`).href;
+  const require_ = createRequire(parentFile);
+  const packageName = packageNameFromSpecifier(specifier);
+  const subpath = exportSubpathFromSpecifier(specifier);
+  const pkgJsonPath = require_.resolve(`${packageName}/package.json`);
+  const pkgDir = dirname(pkgJsonPath);
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+    exports?: Record<string, unknown>;
+    module?: string;
+  };
+
+  const exportsEntry = pkg.exports?.[subpath];
+  const importTarget =
+    readExportTarget(exportsEntry, "import") ??
+    (subpath === "." ? pkg.module : undefined);
+  const resolvedPath = importTarget
+    ? join(pkgDir, importTarget)
+    : require_.resolve(specifier);
+
+  return pathToFileURL(resolvedPath).href;
+};
+
 export const absoluteExternalsPlugin: esbuild.Plugin = {
   name: "absolute-externals",
   setup(build) {
@@ -25,17 +108,10 @@ export const absoluteExternalsPlugin: esbuild.Plugin = {
       if (args.path.startsWith("node:")) {
         return { path: args.path, external: true };
       }
-      // `import.meta.resolve`'s second argument is silently ignored in modern
-      // Node, so resolution would always walk up from the CLI's bundled file
-      // (`packages/cli/dist/utils.mjs`) instead of from the user's project.
-      // Use `createRequire` keyed on the importing file's directory so we
-      // resolve out of *their* `node_modules`. The synthetic filename is just
-      // a CommonJS resolution anchor; the file does not need to exist.
-      const parentFile = pathToFileURL(args.resolveDir + "/_").href;
-      const require_ = createRequire(parentFile);
-      const resolvedPath = require_.resolve(args.path);
-      const resolved = pathToFileURL(resolvedPath).href;
-      return { path: resolved, external: true };
+      return {
+        path: resolveBareSpecifierToFileUrl(args.path, args.resolveDir),
+        external: true,
+      };
     });
   },
 };

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Path } from "@effect/platform";
 import { Array, Effect, Option, pipe } from "effect";
@@ -17,97 +14,54 @@ const isRelativeOrAbsolutePath = (importPath: string) =>
   importPath.startsWith("../") ||
   importPath.startsWith("/");
 
-const packageNameFromSpecifier = (specifier: string) => {
-  if (specifier.startsWith("@")) {
-    const scopeEnd = specifier.indexOf("/", 1);
-    if (scopeEnd === -1) {
-      return specifier;
-    }
-    const subpathStart = specifier.indexOf("/", scopeEnd + 1);
-    return subpathStart === -1 ? specifier : specifier.slice(0, subpathStart);
-  }
-  const slash = specifier.indexOf("/");
-  return slash === -1 ? specifier : specifier.slice(0, slash);
-};
-
-const exportSubpathFromSpecifier = (specifier: string) => {
-  const packageName = packageNameFromSpecifier(specifier);
-  if (specifier === packageName) {
-    return ".";
-  }
-  return `.${specifier.slice(packageName.length)}`;
-};
-
-const readExportTarget = (
-  entry: unknown,
-  condition: "import" | "require",
-): string | undefined => {
-  if (typeof entry === "string") {
-    return entry;
-  }
-  if (!entry || typeof entry !== "object") {
-    return undefined;
-  }
-  const conditions = entry as Record<string, unknown>;
-  const primary = conditions[condition];
-  if (typeof primary === "string") {
-    return primary;
-  }
-  if (primary && typeof primary === "object") {
-    const nested = primary as Record<string, unknown>;
-    const nestedTarget = nested[condition];
-    if (typeof nestedTarget === "string") {
-      return nestedTarget;
-    }
-  }
-  return undefined;
-};
+// Recursion guard for `absoluteExternalsPlugin`. When the plugin asks esbuild
+// to resolve a bare specifier via `build.resolve(...)`, esbuild invokes every
+// registered `onResolve` hook again for that same specifier — including this
+// one. The flag (carried through the recursive call via `pluginData`) tells
+// the recursive invocation to skip rewriting and fall through to esbuild's
+// built-in resolver, which is what we wanted from `build.resolve` in the
+// first place.
+const PLUGIN_DATA_SKIP = Symbol("absolute-externals.skip");
 
 /**
- * Resolve a bare specifier to an absolute file URL suitable for `import()` from
- * a bundled ESM data URL. Prefer each package's ESM `import` export condition
- * so dual-package CJS/ESM deps like `convex/server` keep their named exports.
- * Fall back to CommonJS resolution for packages without an ESM entry (e.g.
- * `luxon`).
+ * Mark every bare-specifier import as external and rewrite it to an absolute
+ * `file://` URL. Resolution is delegated to esbuild's own resolver via
+ * `build.resolve(...)`, which honors each package's `exports` map (preferring
+ * the `import` condition under `format: "esm"`) and falls back to
+ * `module`/`main` exactly the way Node's ESM resolution algorithm does.
+ *
+ * Bundles produced with this plugin are loaded via a data URL `import(...)`
+ * (see {@link bundle}); rewriting bare externals to absolute file URLs is what
+ * makes them resolvable at runtime, since a data URL has no parent file from
+ * which a bare specifier could be resolved.
+ *
+ * Relative/absolute-path imports are left to esbuild to bundle as usual, and
+ * `node:*` built-ins are passed through unchanged.
  */
-const resolveBareSpecifierToFileUrl = (
-  specifier: string,
-  resolveDir: string,
-) => {
-  const parentFile = pathToFileURL(`${resolveDir}/_`).href;
-  const require_ = createRequire(parentFile);
-  const packageName = packageNameFromSpecifier(specifier);
-  const subpath = exportSubpathFromSpecifier(specifier);
-  const pkgJsonPath = require_.resolve(`${packageName}/package.json`);
-  const pkgDir = dirname(pkgJsonPath);
-  const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
-    exports?: Record<string, unknown>;
-    module?: string;
-  };
-
-  const exportsEntry = pkg.exports?.[subpath];
-  const importTarget =
-    readExportTarget(exportsEntry, "import") ??
-    (subpath === "." ? pkg.module : undefined);
-  const resolvedPath = importTarget
-    ? join(pkgDir, importTarget)
-    : require_.resolve(specifier);
-
-  return pathToFileURL(resolvedPath).href;
-};
-
 export const absoluteExternalsPlugin: esbuild.Plugin = {
   name: "absolute-externals",
   setup(build) {
     build.onResolve({ filter: /.*/ }, async (args) => {
+      if (args.pluginData?.[PLUGIN_DATA_SKIP]) return;
       if (args.kind !== "import-statement" && args.kind !== "dynamic-import")
         return;
       if (isRelativeOrAbsolutePath(args.path)) return;
       if (args.path.startsWith("node:")) {
         return { path: args.path, external: true };
       }
+
+      const resolved = await build.resolve(args.path, {
+        kind: args.kind,
+        resolveDir: args.resolveDir,
+        pluginData: { [PLUGIN_DATA_SKIP]: true },
+      });
+
+      if (resolved.errors.length > 0) {
+        return { errors: resolved.errors, warnings: resolved.warnings };
+      }
+
       return {
-        path: resolveBareSpecifierToFileUrl(args.path, args.resolveDir),
+        path: pathToFileURL(resolved.path).href,
         external: true,
       };
     });

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -10,20 +10,10 @@ export interface Bundled {
   readonly metafile: esbuild.Metafile;
 }
 
-export const EXTERNAL_PACKAGES = [
-  "@confect/core",
-  "@confect/server",
-  "effect",
-  "@effect/*",
-];
-
-const isExternalImport = (path: string) =>
-  EXTERNAL_PACKAGES.some((p) => {
-    if (p.endsWith("/*")) {
-      return path.startsWith(p.slice(0, -1));
-    }
-    return path === p || path.startsWith(p + "/");
-  });
+const isRelativeOrAbsolutePath = (importPath: string) =>
+  importPath.startsWith("./") ||
+  importPath.startsWith("../") ||
+  importPath.startsWith("/");
 
 export const absoluteExternalsPlugin: esbuild.Plugin = {
   name: "absolute-externals",
@@ -31,7 +21,10 @@ export const absoluteExternalsPlugin: esbuild.Plugin = {
     build.onResolve({ filter: /.*/ }, async (args) => {
       if (args.kind !== "import-statement" && args.kind !== "dynamic-import")
         return;
-      if (!isExternalImport(args.path)) return;
+      if (isRelativeOrAbsolutePath(args.path)) return;
+      if (args.path.startsWith("node:")) {
+        return { path: args.path, external: true };
+      }
       // `import.meta.resolve`'s second argument is silently ignored in modern
       // Node, so resolution would always walk up from the CLI's bundled file
       // (`packages/cli/dist/utils.mjs`) instead of from the user's project.

--- a/packages/cli/src/confect/dev.ts
+++ b/packages/cli/src/confect/dev.ts
@@ -24,7 +24,7 @@ import {
 } from "effect";
 import * as esbuild from "esbuild";
 import { logCoalescedBuildErrors } from "../BuildError";
-import { absoluteExternalsPlugin, EXTERNAL_PACKAGES } from "../Bundler";
+import { absoluteExternalsPlugin } from "../Bundler";
 import * as CodegenError from "../CodegenError";
 import { ConfectDirectory } from "../ConfectDirectory";
 import { ConvexDirectory } from "../ConvexDirectory";
@@ -450,7 +450,6 @@ const esbuildOptions = (
     platform: "node" as const,
     format: "esm" as const,
     logLevel: "silent" as const,
-    external: EXTERNAL_PACKAGES,
     plugins: [
       absoluteExternalsPlugin,
       {

--- a/packages/cli/test/LeafModule.test.ts
+++ b/packages/cli/test/LeafModule.test.ts
@@ -232,6 +232,13 @@ layer(LeafModuleLayer)("validateImpl", (it) => {
     }),
   );
 
+  it.effect("accepts a leaf impl that imports a CJS package", () =>
+    Effect.gen(function* () {
+      const leaf = yield* toLeafModule("groups/cjsImporter.spec.ts");
+      yield* validateImpl(leaf);
+    }),
+  );
+
   it.effect("rejects impl that does not directly import the sibling spec", () =>
     Effect.gen(function* () {
       const result = yield* Effect.either(

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/cjsImporter.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/cjsImporter.ts
@@ -1,0 +1,5 @@
+import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";
+import api from "../../api";
+import cjsImporter from "../../../groups/cjsImporter.impl";
+
+export default RegisteredFunctions.buildForGroup(api, "groups.cjsImporter", cjsImporter, RegisteredConvexFunction.make);

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
@@ -1,8 +1,9 @@
 import { GroupSpec, Spec } from "@confect/core";
 import databaseReader from "../databaseReader.spec";
+import groups_cjsImporter from "../groups/cjsImporter.spec";
 import groups_notes from "../groups/notes.spec";
 import groups_random from "../groups/random.spec";
 import groups_runners from "../groups/runners.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 
-export default Spec.make().addPath(databaseReader, "databaseReader").addPath(groups_notes, "groups.notes").addPath(groups_random, "groups.random").addPath(groups_runners, "groups.runners").addPath(groups_typedErrors, "groups.typedErrors").addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors));
+export default Spec.make().addPath(databaseReader, "databaseReader").addPath(groups_cjsImporter, "groups.cjsImporter").addPath(groups_notes, "groups.notes").addPath(groups_random, "groups.random").addPath(groups_runners, "groups.runners").addPath(groups_typedErrors, "groups.typedErrors").addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors));

--- a/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.impl.ts
@@ -5,7 +5,7 @@ import api from "../_generated/api";
 import cjsImporter from "./cjsImporter.spec";
 
 const now = FunctionImpl.make(api, cjsImporter, "now", () =>
-  Effect.sync(() => DateTime.now().toISO()),
+  Effect.sync(() => DateTime.now().toISO() ?? ""),
 );
 
 export default GroupImpl.make(api, cjsImporter).pipe(

--- a/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.impl.ts
@@ -1,0 +1,14 @@
+import { FunctionImpl, GroupImpl } from "@confect/server";
+import { DateTime } from "luxon";
+import { Effect, Layer } from "effect";
+import api from "../_generated/api";
+import cjsImporter from "./cjsImporter.spec";
+
+const now = FunctionImpl.make(api, cjsImporter, "now", () =>
+  Effect.sync(() => DateTime.now().toISO()),
+);
+
+export default GroupImpl.make(api, cjsImporter).pipe(
+  Layer.provide(now),
+  GroupImpl.finalize,
+);

--- a/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.spec.ts
@@ -1,0 +1,10 @@
+import { FunctionSpec, GroupSpec } from "@confect/core";
+import { Schema } from "effect";
+
+export default GroupSpec.make().addFunction(
+  FunctionSpec.publicQuery({
+    name: "now",
+    args: Schema.Struct({}),
+    returns: Schema.String,
+  }),
+);

--- a/packages/server/test/mock-backend/fixtures/convex/groups/cjsImporter.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/groups/cjsImporter.ts
@@ -1,0 +1,3 @@
+import registeredFunctions from "../../confect/_generated/registeredFunctions/groups/cjsImporter";
+
+export const now = registeredFunctions.now;

--- a/packages/server/test/mock-backend/fixtures/luxon.d.ts
+++ b/packages/server/test/mock-backend/fixtures/luxon.d.ts
@@ -1,0 +1,6 @@
+declare module "luxon" {
+  export class DateTime {
+    static now(): DateTime;
+    toISO(): string | null;
+  }
+}

--- a/packages/server/test/mock-backend/fixtures/luxon.d.ts
+++ b/packages/server/test/mock-backend/fixtures/luxon.d.ts
@@ -1,6 +1,0 @@
-declare module "luxon" {
-  export class DateTime {
-    static now(): DateTime;
-    toISO(): string | null;
-  }
-}

--- a/packages/server/test/mock-backend/fixtures/package.json
+++ b/packages/server/test/mock-backend/fixtures/package.json
@@ -8,7 +8,8 @@
     "@confect/core": "workspace:*",
     "@confect/server": "workspace:*",
     "convex": "*",
-    "effect": "*"
+    "effect": "*",
+    "luxon": "^3.7.1"
   },
   "devDependencies": {
     "@confect/cli": "workspace:*"

--- a/packages/server/test/mock-backend/fixtures/package.json
+++ b/packages/server/test/mock-backend/fixtures/package.json
@@ -12,6 +12,7 @@
     "luxon": "^3.7.1"
   },
   "devDependencies": {
-    "@confect/cli": "workspace:*"
+    "@confect/cli": "workspace:*",
+    "@types/luxon": "^3.7.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,9 @@ importers:
       effect:
         specifier: 3.21.2
         version: 3.21.2
+      luxon:
+        specifier: ^3.7.1
+        version: 3.7.2
     devDependencies:
       '@confect/cli':
         specifier: workspace:*
@@ -4715,6 +4718,10 @@ packages:
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
   magic-string@0.30.21:
@@ -11483,6 +11490,8 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       '@confect/cli':
         specifier: workspace:*
         version: link:../../../../cli
+      '@types/luxon':
+        specifier: ^3.7.1
+        version: 3.7.1
 
   packages/test:
     dependencies:
@@ -2603,6 +2606,9 @@ packages:
 
   '@types/katex@0.16.7':
     resolution: {integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==}
+
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -9057,6 +9063,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/katex@0.16.7': {}
+
+  '@types/luxon@3.7.1': {}
 
   '@types/mdast@4.0.4':
     dependencies:


### PR DESCRIPTION
## Summary

- Generalize `absoluteExternalsPlugin` so codegen and dev-mode bundling externalize every bare specifier (not just `@confect/*`, `effect`, and `@effect/*`), while still bundling the user's relative source imports.
- Pass `node:*` builtins through as external imports so inlined CJS packages no longer hit esbuild's `Dynamic require of "<id>" is not supported` shim during `validateImpl`.
- Add a `cjsImporter` fixture that imports `luxon` and a regression test confirming `validateImpl` accepts impls with third-party CJS dependencies.

## Test plan

- [ ] `pnpm install` (updates lockfile for `luxon` in mock-backend fixtures)
- [ ] `pnpm build --filter @confect/cli`
- [ ] `pnpm test:cli`
- [ ] Confirm `confect codegen` succeeds on impls that import third-party packages (e.g. `luxon`, `sharp`, `@clerk/backend`)


Made with [Cursor](https://cursor.com)