### PR TITLE
Adopt bundle-require for codegen bundling

### DIFF
--- a/.changeset/bundle-require.md
+++ b/.changeset/bundle-require.md
@@ -1,0 +1,20 @@
+---
+"@confect/cli": patch
+---
+
+Switch the codegen bundler to [`bundle-require`](https://github.com/egoist/bundle-require).
+
+### Why
+
+`9.0.0-next.4`'s `absoluteExternalsPlugin` externalized every bare-specifier import and rewrote it to a `file://` URL because the bundle was loaded via a parent-less `data:` URL. esbuild's resolver honors `tsconfig.json#compilerOptions.paths`, so a `~/src/foo`-style alias resolved to a local `.ts` file and got externalized as `file:///…/foo.ts` — which Node ESM cannot import (`ERR_UNKNOWN_FILE_EXTENSION`). The codegen bundler hand-rolled a third reimplementation of "load a TypeScript config file at runtime"; each iteration introduced a new bug.
+
+### What changed
+
+- `@confect/cli/Bundler` now delegates to `bundle-require`, the library `tsup`, `unbuild`, `vite`, `vitest`, and `vuepress` use for this exact problem. `bundle-require` writes a temp `.mjs` next to the source, `import()`s it, and deletes it — so bare-specifier externals (third-party packages, workspace deps) resolve through Node's normal `node_modules` walk and tsconfig `paths` aliases stay inside the bundle.
+- `@confect/cli/confect/dev`'s watcher swaps `absoluteExternalsPlugin` for `bundle-require`'s `externalPlugin`, fed the project's `tsconfig.json#paths` via `loadTsConfig` so dev-mode rebuilds also bundle aliased local source instead of erroring on it.
+- The `absoluteExternalsPlugin` export is removed from `@confect/cli/Bundler`.
+
+### Fixes
+
+- Restores `confect codegen` for any project that uses `tsconfig.json` `paths` aliases (e.g. `~/*`, `@/*`, `@app/*`) for its own source.
+- As a side benefit, `__dirname`, `__filename`, and `import.meta.url` inside bundled impls now resolve to the original source path instead of the temporary bundle URL (`bundle-require`'s built-in injection).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@effect/platform-node-shared": "0.59.0",
     "@effect/printer": "^0.49.0",
     "@effect/printer-ansi": "^0.49.0",
+    "bundle-require": "^5.1.0",
     "code-block-writer": "^13.0.3",
     "esbuild": "^0.27.3"
   },

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -1,7 +1,8 @@
-import { pathToFileURL } from "node:url";
+import { dirname, isAbsolute, resolve } from "node:path";
 import { Path } from "@effect/platform";
+import { bundleRequire } from "bundle-require";
 import { Array, Effect, Option, pipe } from "effect";
-import * as esbuild from "esbuild";
+import type * as esbuild from "esbuild";
 import { BundlerError } from "./BuildError";
 
 export interface Bundled {
@@ -9,108 +10,84 @@ export interface Bundled {
   readonly metafile: esbuild.Metafile;
 }
 
-const isRelativeOrAbsolutePath = (importPath: string) =>
-  importPath.startsWith("./") ||
-  importPath.startsWith("../") ||
-  importPath.startsWith("/");
-
-// Recursion guard for `absoluteExternalsPlugin`. When the plugin asks esbuild
-// to resolve a bare specifier via `build.resolve(...)`, esbuild invokes every
-// registered `onResolve` hook again for that same specifier — including this
-// one. The flag (carried through the recursive call via `pluginData`) tells
-// the recursive invocation to skip rewriting and fall through to esbuild's
-// built-in resolver, which is what we wanted from `build.resolve` in the
-// first place.
-const PLUGIN_DATA_SKIP = Symbol("absolute-externals.skip");
-
 /**
- * Mark every bare-specifier import as external and rewrite it to an absolute
- * `file://` URL. Resolution is delegated to esbuild's own resolver via
- * `build.resolve(...)`, which honors each package's `exports` map (preferring
- * the `import` condition under `format: "esm"`) and falls back to
- * `module`/`main` exactly the way Node's ESM resolution algorithm does.
- *
- * Bundles produced with this plugin are loaded via a data URL `import(...)`
- * (see {@link bundle}); rewriting bare externals to absolute file URLs is what
- * makes them resolvable at runtime, since a data URL has no parent file from
- * which a bare specifier could be resolved.
- *
- * Relative/absolute-path imports are left to esbuild to bundle as usual, and
- * `node:*` built-ins are passed through unchanged.
+ * `bundle-require` sets `absWorkingDir: cwd` on the underlying esbuild build,
+ * so the metafile's input keys (and each input's `imports[].path`) are stored
+ * relative to that cwd. Callers reach for the metafile with absolute paths
+ * (e.g. {@link directlyImports}), so we normalize every key/import path to
+ * absolute up front. That way the lookup logic stays oblivious to whatever
+ * cwd was used during bundling.
  */
-export const absoluteExternalsPlugin: esbuild.Plugin = {
-  name: "absolute-externals",
-  setup(build) {
-    build.onResolve({ filter: /.*/ }, async (args) => {
-      if (args.pluginData?.[PLUGIN_DATA_SKIP]) return;
-      if (args.kind !== "import-statement" && args.kind !== "dynamic-import")
-        return;
-      if (isRelativeOrAbsolutePath(args.path)) return;
-      if (args.path.startsWith("node:")) {
-        return { path: args.path, external: true };
-      }
-
-      const resolved = await build.resolve(args.path, {
-        kind: args.kind,
-        resolveDir: args.resolveDir,
-        pluginData: { [PLUGIN_DATA_SKIP]: true },
-      });
-
-      if (resolved.errors.length > 0) {
-        return { errors: resolved.errors, warnings: resolved.warnings };
-      }
-
-      return {
-        path: pathToFileURL(resolved.path).href,
-        external: true,
-      };
-    });
-  },
-};
-
-const buildEntry = (entryPoint: string) =>
-  Effect.tryPromise({
-    try: () =>
-      esbuild.build({
-        entryPoints: [entryPoint],
-        bundle: true,
-        write: false,
-        platform: "node",
-        format: "esm",
-        logLevel: "silent",
-        metafile: true,
-        plugins: [absoluteExternalsPlugin],
-      }),
-    catch: (cause) => new BundlerError({ cause }),
-  });
-
-const importBundledModule = (result: esbuild.BuildResult) => {
-  const code = result.outputFiles![0]!.text;
-  const dataUrl =
-    "data:text/javascript;base64," + Buffer.from(code).toString("base64");
-  return import(dataUrl);
+const absolutizeMetafile = (
+  metafile: esbuild.Metafile,
+  cwd: string,
+): esbuild.Metafile => {
+  const absolutize = (p: string) => (isAbsolute(p) ? p : resolve(cwd, p));
+  const inputs: esbuild.Metafile["inputs"] = {};
+  for (const [key, value] of Object.entries(metafile.inputs)) {
+    inputs[absolutize(key)] = {
+      ...value,
+      imports: value.imports.map((i) => ({ ...i, path: absolutize(i.path) })),
+    };
+  }
+  const outputs: esbuild.Metafile["outputs"] = {};
+  for (const [key, value] of Object.entries(metafile.outputs)) {
+    outputs[absolutize(key)] = value;
+  }
+  return { inputs, outputs };
 };
 
 /**
- * Bundle a TypeScript entry point with esbuild and import the result via a
- * data URL. This handles extensionless `.ts` imports regardless of whether
- * the user's project sets `"type": "module"` in package.json. The returned
- * pair carries both the imported module and the esbuild metafile so callers
- * can inspect the import graph (see {@link directlyImports}).
+ * Bundle a TypeScript entry point with esbuild via {@link bundleRequire} and
+ * import the result. `bundle-require` writes a temp `.mjs` next to the source,
+ * `import()`s it, and deletes it — so bare-specifier externals (third-party
+ * packages, workspace deps) resolve through the user's normal `node_modules`
+ * walk, and tsconfig `paths` aliases stay inside the bundle.
+ *
+ * `cwd` is set to the entry's directory so `bundle-require`'s `tsconfig.json`
+ * discovery (which walks upward from `cwd`) lands on the project's tsconfig
+ * regardless of where `confect codegen` was invoked from, and so esbuild
+ * resolves relative imports against the entry's location.
+ *
+ * The returned pair carries both the imported module and the esbuild metafile
+ * so callers can inspect the import graph (see {@link directlyImports}); the
+ * metafile is captured via a small `onEnd` plugin because `bundle-require`
+ * itself only exposes a flat `dependencies: string[]`.
  */
 export const bundle = (
   entryPoint: string,
 ): Effect.Effect<Bundled, BundlerError> =>
   Effect.gen(function* () {
-    const result = yield* buildEntry(entryPoint);
-    const module = yield* Effect.tryPromise({
-      try: () => importBundledModule(result),
+    let metafile: esbuild.Metafile | undefined;
+    const captureMetafile: esbuild.Plugin = {
+      name: "confect:capture-metafile",
+      setup(build) {
+        build.onEnd((result) => {
+          metafile = result.metafile;
+        });
+      },
+    };
+
+    const cwd = dirname(entryPoint);
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        bundleRequire({
+          filepath: entryPoint,
+          cwd,
+          format: "esm",
+          esbuildOptions: {
+            plugins: [captureMetafile],
+            logLevel: "silent",
+          },
+        }),
       catch: (cause) => new BundlerError({ cause }),
     });
-    if (!result.metafile) {
+
+    if (!metafile) {
       return yield* Effect.dieMessage("esbuild metafile missing");
     }
-    return { module, metafile: result.metafile };
+
+    return { module: result.mod, metafile: absolutizeMetafile(metafile, cwd) };
   });
 
 const findMetafileInputKey = (

--- a/packages/cli/src/confect/dev.ts
+++ b/packages/cli/src/confect/dev.ts
@@ -22,9 +22,13 @@ import {
   Stream,
   String,
 } from "effect";
+import {
+  externalPlugin,
+  loadTsConfig,
+  tsconfigPathsToRegExp,
+} from "bundle-require";
 import * as esbuild from "esbuild";
 import { logCoalescedBuildErrors } from "../BuildError";
-import { absoluteExternalsPlugin } from "../Bundler";
 import * as CodegenError from "../CodegenError";
 import { ConfectDirectory } from "../ConfectDirectory";
 import { ConvexDirectory } from "../ConvexDirectory";
@@ -430,6 +434,7 @@ const discoverEntryPoints = Effect.gen(function* () {
 
 const esbuildOptions = (
   entry: EntryPoint,
+  notExternal: ReadonlyArray<RegExp>,
   signal: Queue.Queue<void>,
   pendingRef: Ref.Ref<Pending>,
   watcherErrorsRef: Ref.Ref<WatcherErrors>,
@@ -451,7 +456,7 @@ const esbuildOptions = (
     format: "esm" as const,
     logLevel: "silent" as const,
     plugins: [
-      absoluteExternalsPlugin,
+      externalPlugin({ notExternal: [...notExternal] }),
       {
         name: "notify-rebuild",
         setup(build: esbuild.PluginBuild) {
@@ -489,6 +494,7 @@ const esbuildOptions = (
 
 const createEntryPointWatcher = (
   entry: EntryPoint,
+  notExternal: ReadonlyArray<RegExp>,
   signal: Queue.Queue<void>,
   pendingRef: Ref.Ref<Pending>,
   watcherErrorsRef: Ref.Ref<WatcherErrors>,
@@ -496,7 +502,13 @@ const createEntryPointWatcher = (
   Effect.acquireRelease(
     Effect.promise(async () => {
       const ctx = await esbuild.context(
-        esbuildOptions(entry, signal, pendingRef, watcherErrorsRef),
+        esbuildOptions(
+          entry,
+          notExternal,
+          signal,
+          pendingRef,
+          watcherErrorsRef,
+        ),
       );
       await ctx.watch();
       return ctx;
@@ -534,6 +546,17 @@ const entryPointsWatcher = (
   Effect.gen(function* () {
     const parentScope = yield* Effect.scope;
     const scopesRef = yield* Ref.make(new Map<string, Scope.CloseableScope>());
+    const projectRoot = yield* ProjectRoot.get;
+    // Discover the user's `tsconfig.json#paths` once at watcher startup so
+    // `~/...`-style aliases pointing into the user's source tree get bundled
+    // by esbuild instead of externalized via `bundle-require`'s `node_modules`
+    // heuristic. `loadTsConfig` walks up from `projectRoot` to find a
+    // `tsconfig.json`; if none exists, `paths` is empty and `notExternal` is
+    // `[]`, leaving the externalization rule unchanged.
+    const tsconfig = loadTsConfig(projectRoot);
+    const notExternal = tsconfigPathsToRegExp(
+      tsconfig?.data.compilerOptions?.paths ?? {},
+    );
 
     const sync = Effect.gen(function* () {
       const desired = yield* discoverEntryPoints;
@@ -569,6 +592,7 @@ const entryPointsWatcher = (
           );
           yield* createEntryPointWatcher(
             entry,
+            notExternal,
             signal,
             pendingRef,
             watcherErrorsRef,

--- a/packages/cli/test/Bundler.test.ts
+++ b/packages/cli/test/Bundler.test.ts
@@ -1,0 +1,64 @@
+import { pathToFileURL } from "node:url";
+import { FileSystem, Path } from "@effect/platform";
+import { NodeFileSystem, NodePath } from "@effect/platform-node";
+import { expect, layer } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import * as Bundler from "../src/Bundler";
+
+const BundlerLayer = Layer.mergeAll(NodePath.layer, NodeFileSystem.layer);
+
+const tsconfigContents = JSON.stringify(
+  {
+    compilerOptions: {
+      moduleResolution: "Bundler",
+      paths: { "~/*": ["./*"] },
+    },
+  },
+  null,
+  2,
+);
+
+layer(BundlerLayer)("bundle", (it) => {
+  it.effect(
+    "bundles imports that resolve through tsconfig path aliases (regression for 9.0.0-next.4)",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped();
+
+        yield* fs.writeFileString(
+          path.join(tempDir, "tsconfig.json"),
+          tsconfigContents,
+        );
+        yield* fs.writeFileString(
+          path.join(tempDir, "sibling.ts"),
+          `export const value = "bundled";\n`,
+        );
+        const entry = path.join(tempDir, "entry.ts");
+        yield* fs.writeFileString(
+          entry,
+          `import { value } from "~/sibling";\nexport default value;\n`,
+        );
+
+        const bundled = yield* Bundler.bundle(entry);
+        expect(bundled.module.default).toBe("bundled");
+      }).pipe(Effect.scoped),
+  );
+
+  it.effect(
+    "rewrites import.meta.url inside the bundle to the original source path",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const tempDir = yield* fs.makeTempDirectoryScoped();
+
+        const entry = path.join(tempDir, "entry.ts");
+        yield* fs.writeFileString(entry, `export default import.meta.url;\n`);
+
+        const bundled = yield* Bundler.bundle(entry);
+        expect(bundled.module.default).toBe(pathToFileURL(entry).href);
+      }).pipe(Effect.scoped),
+  );
+});

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/aliasImporter.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/aliasImporter.ts
@@ -1,0 +1,5 @@
+import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";
+import api from "../../api";
+import aliasImporter from "../../../groups/aliasImporter.impl";
+
+export default RegisteredFunctions.buildForGroup(api, "groups.aliasImporter", aliasImporter, RegisteredConvexFunction.make);

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
@@ -1,9 +1,10 @@
 import { GroupSpec, Spec } from "@confect/core";
 import databaseReader from "../databaseReader.spec";
+import groups_aliasImporter from "../groups/aliasImporter.spec";
 import groups_cjsImporter from "../groups/cjsImporter.spec";
 import groups_notes from "../groups/notes.spec";
 import groups_random from "../groups/random.spec";
 import groups_runners from "../groups/runners.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 
-export default Spec.make().addPath(databaseReader, "databaseReader").addPath(groups_cjsImporter, "groups.cjsImporter").addPath(groups_notes, "groups.notes").addPath(groups_random, "groups.random").addPath(groups_runners, "groups.runners").addPath(groups_typedErrors, "groups.typedErrors").addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors));
+export default Spec.make().addPath(databaseReader, "databaseReader").addPath(groups_aliasImporter, "groups.aliasImporter").addPath(groups_cjsImporter, "groups.cjsImporter").addPath(groups_notes, "groups.notes").addPath(groups_random, "groups.random").addPath(groups_runners, "groups.runners").addPath(groups_typedErrors, "groups.typedErrors").addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors));

--- a/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.impl.ts
@@ -1,0 +1,13 @@
+import { FunctionImpl, GroupImpl } from "@confect/server";
+import { Effect, Layer } from "effect";
+import api from "../_generated/api";
+import aliasImporter from "~/groups/aliasImporter.spec";
+
+const echo = FunctionImpl.make(api, aliasImporter, "echo", () =>
+  Effect.succeed("aliased"),
+);
+
+export default GroupImpl.make(api, aliasImporter).pipe(
+  Layer.provide(echo),
+  GroupImpl.finalize,
+);

--- a/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.spec.ts
@@ -1,0 +1,10 @@
+import { FunctionSpec, GroupSpec } from "@confect/core";
+import { Schema } from "effect";
+
+export default GroupSpec.make().addFunction(
+  FunctionSpec.publicQuery({
+    name: "echo",
+    args: Schema.Struct({}),
+    returns: Schema.String,
+  }),
+);

--- a/packages/server/test/mock-backend/fixtures/confect/tsconfig.json
+++ b/packages/server/test/mock-backend/fixtures/confect/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": { "~/*": ["./*"] }
+  }
+}

--- a/packages/server/test/mock-backend/fixtures/convex/groups/aliasImporter.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/groups/aliasImporter.ts
@@ -1,0 +1,3 @@
+import registeredFunctions from "../../confect/_generated/registeredFunctions/groups/aliasImporter";
+
+export const echo = registeredFunctions.echo;

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -10,7 +10,11 @@
     "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "moduleResolution": "Bundler",
-    "module": "ESNext"
+    "module": "ESNext",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./test/mock-backend/fixtures/confect/*"]
+    }
   },
   "exclude": ["coverage", "dist", "node_modules"],
   "extends": ["../../tsconfig.base.json"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@effect/printer-ansi':
         specifier: ^0.49.0
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
+      bundle-require:
+        specifier: ^5.1.0
+        version: 5.1.0(esbuild@0.27.3)
       code-block-writer:
         specifier: ^13.0.3
         version: 13.0.3
@@ -3118,6 +3121,12 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4688,6 +4697,10 @@ packages:
 
   load-plugin@6.0.3:
     resolution: {integrity: sha512-kc0X2FEUZr145odl68frm+lMJuQ23+rTXYmR6TImqPtbpmXC4vVXbWKDQ9IzndA0HfyQamWfKLhzsqGSTxE63w==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -9644,6 +9657,11 @@ snapshots:
       '@oven/bun-windows-x64': 1.3.10
       '@oven/bun-windows-x64-baseline': 1.3.10
 
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -11470,6 +11488,8 @@ snapshots:
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - bluebird
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Switches `@confect/cli`'s codegen bundler from a hand-rolled data-URL strategy to [`bundle-require`](https://github.com/egoist/bundle-require), fixing the `9.0.0-next.4` regression where `tsconfig.json#paths` aliases (e.g. `~/src/foo`) were externalized as `file:///…/foo.ts` and failed at runtime with `ERR_UNKNOWN_FILE_EXTENSION`.
- Replaces `absoluteExternalsPlugin` in dev-mode with `bundle-require`'s `externalPlugin`, fed `notExternal` from `loadTsConfig` + `tsconfigPathsToRegExp`, so incremental rebuilds also bundle aliased local source instead of erroring on it.
- Side benefit: `__dirname`, `__filename`, and `import.meta.url` inside bundled impls now resolve to the original source path (via `bundle-require`'s `injectFileScopePlugin`).

## Why this approach

Three bugs in three releases all map to behaviors `bundle-require` already handles:

- `9.0.0-next.0`: third-party CJS deps were inlined as ESM → `Dynamic require of "X" not supported`.
- pre-`9.0.0-next.4`: hand-rolled `package.json#exports` parser missed subpath patterns and conditional fallback arrays.
- `9.0.0-next.4` (this PR): tsconfig path aliases externalized as `file:///…/.ts` URLs.

The root cause was the **data-URL** output: a data URL has no parent file, so externals had to be rewritten to absolute `file://` URLs, forcing per-specifier resolution decisions. `bundle-require` writes a temp `.mjs` next to the source, `import()`s it, and deletes it — so externals resolve through Node's normal `node_modules` walk and the data-URL hack disappears entirely. It's the library `tsup`, `unbuild`, `vite`, `vitest`, and `vuepress` use for this exact problem.

## Notable bits

- `directlyImports` keeps working via a small `onEnd` plugin that captures the metafile (`bundle-require` only exposes a flat `dependencies: string[]`). Metafile input keys are normalized to absolute paths up front so the lookup stays oblivious to the bundle's cwd.
- `absoluteExternalsPlugin` is removed from `@confect/cli/Bundler`'s public surface.
- `cwd` for `bundle-require` is set to the entry's directory so `loadTsConfig` discovery walks up from the entry's location regardless of where `confect codegen` was invoked.

## Test plan

- [x] `pnpm test:cli` — 70 existing tests stay green; 2 new `Bundler.test.ts` tests cover the alias regression and `import.meta.url` injection.
- [x] `pnpm test:server` and `pnpm test:mock-backend` — new `aliasImporter.{spec,impl}.ts` fixture under `mock-backend/fixtures/confect/` exercises a `~/`-aliased import through the full codegen pipeline. Re-running `pnpm confect codegen` against the fixture is a no-op.
- [x] `pnpm test:core`, `pnpm test:js`.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm build`.

## Changeset

Patch to `@confect/cli` — see `.changeset/bundle-require.md`.


Made with [Cursor](https://cursor.com)