### PR TITLE
Update changeset config to exclude private packages from versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,8 @@
   "access": "public",
   "baseBranch": "v9",
   "updateInternalDependencies": "patch",
-  "ignore": ["@confect/server-*-fixtures"],
+  "ignore": [],
+  "privatePackages": { "version": false, "tag": false },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
## Summary
Updated the changeset configuration to better handle private packages in the monorepo by removing the hardcoded ignore list and adding explicit configuration to prevent versioning and tagging of private packages.

## Key Changes
- Removed the `ignore` array that was specifically filtering out `@confect/server-*-fixtures` packages
- Added `privatePackages` configuration with `version: false` and `tag: false` to automatically exclude private packages from the release process

## Implementation Details
This change simplifies the changeset configuration by using a more declarative approach. Instead of maintaining a manual ignore list for specific private package patterns, the config now relies on the `privatePackages` setting to automatically handle any packages marked as private in their `package.json` files. This is more maintainable and scales better as the monorepo grows.

https://claude.ai/code/session_01EQ3WXB1nEczxD3NPYu9Uxi