### PR TITLE
Add docs release workflow for deploying without version bumps

### DIFF
--- a/.claude/commands/release-docs.md
+++ b/.claude/commands/release-docs.md
@@ -1,0 +1,26 @@
+---
+description: Deploy docs for the current release by updating the release branch, without publishing a new version
+allowed-tools: Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(gh workflow run:*), Bash(gh run list:*), Bash(gh run watch:*)
+---
+
+Deploy the docs on `main` (or the ref given in $ARGUMENTS, if any) by triggering
+the "Docs Release" workflow (`.github/workflows/docs-release.yml`), which
+force-pushes that ref to the `release` branch. Mintlify deploys docs from
+`release`, so this publishes docs updates without cutting a new npm release.
+
+Follow these steps:
+
+1. Run `git fetch origin main release` and show what would be deployed:
+   - Docs changes: `git log --oneline origin/release..<ref> -- apps/docs`
+   - Everything else: `git log --oneline origin/release..<ref> -- ':!apps/docs'`
+2. If there are no commits between `origin/release` and the ref, tell me the
+   release branch is already up to date and stop.
+3. If any of the non-docs commits look like unreleased package changes (e.g.
+   changes under `packages/` or pending changesets in `.changeset/`), point
+   them out and warn me that any docs written for those unreleased changes
+   would go live too. Ask me to confirm before proceeding.
+4. Trigger the workflow: `gh workflow run docs-release.yml --ref <ref>`
+   (default ref: `main`).
+5. Watch it to completion (`gh run list --workflow=docs-release.yml`, then
+   `gh run watch <run-id>`) and report whether the `release` branch was
+   updated successfully.

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,0 +1,30 @@
+name: Docs Release
+
+# Manually force-pushes a ref to the `release` branch, which Mintlify deploys
+# docs from. The Release workflow does this automatically when a new version is
+# published; use this workflow to deploy docs updates for the currently
+# released version without publishing a new release.
+#
+# Note that this deploys everything on the chosen ref, so make sure it doesn't
+# contain docs for unreleased changes.
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}
+
+jobs:
+  update-docs-branch:
+    name: Update docs deployment branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Update docs deployment branch
+        run: |
+          git fetch origin release || true
+          git push --force-with-lease origin HEAD:refs/heads/release


### PR DESCRIPTION
## Summary
This PR adds a new workflow and Claude command to enable deploying documentation updates without publishing a new npm release. This allows docs to be updated for the currently released version independently of package version changes.

## Key Changes
- **New GitHub Actions workflow** (`.github/workflows/docs-release.yml`): A manually-triggered workflow that force-pushes a specified ref to the `release` branch, which Mintlify uses for docs deployment
- **New Claude command** (`.claude/commands/release-docs.md`): A helper command that:
  - Validates what would be deployed by comparing commits between `origin/release` and the target ref
  - Warns about any unreleased package changes that would inadvertently go live
  - Triggers the workflow and monitors its completion

## Implementation Details
- The workflow uses `workflow_dispatch` to allow manual triggering with an optional ref parameter
- It uses `git push --force-with-lease` to safely update the release branch while preventing accidental overwrites
- The Claude command includes safety checks to prevent accidentally deploying unreleased changes by examining commits in `packages/` and `.changeset/`
- Concurrency is set to the workflow name to prevent simultaneous runs

https://claude.ai/code/session_015hioecS8yUSjpKj9D3LNkp