### PR TITLE
Loosen and align dependency ranges

### DIFF
--- a/.changeset/loose-convex-peer-ranges.md
+++ b/.changeset/loose-convex-peer-ranges.md
@@ -1,0 +1,15 @@
+---
+"@confect/cli": patch
+"@confect/core": patch
+"@confect/js": patch
+"@confect/react": patch
+"@confect/server": patch
+"@confect/test": patch
+---
+
+Loosen and align dependency ranges across all packages:
+
+- The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
+- `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
+- `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
+- `@confect/test` now accepts any `convex-test` release in `>=0.0.50 <0.1.0` instead of exactly 0.0.50.

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -60,6 +60,19 @@
       "dependencyTypes": ["dev"]
     },
     {
+      "label": "External dependencies shared across @confect/* packages must use the same range in prod/peer",
+      "packages": ["@confect/*"],
+      "dependencies": [
+        "convex",
+        "convex-test",
+        "effect",
+        "@effect/platform",
+        "@effect/platform-node"
+      ],
+      "dependencyTypes": ["prod", "peer"],
+      "policy": "sameRange"
+    },
+    {
       "label": "External prod/peer dependencies may use any version style",
       "dependencyTypes": ["prod", "peer"],
       "isIgnored": true

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -8,7 +8,7 @@
     "@confect/server": "workspace:*",
     "@convex-dev/workpool": "0.4.6",
     "@effect/platform": "0.96.1",
-    "convex": "1.39.1",
+    "convex": "1.40.0",
     "convex-helpers": "0.1.118",
     "effect": "3.21.2",
     "react": "19.2.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,9 +11,8 @@
   },
   "dependencies": {
     "@effect/cli": "^0.75.1",
-    "@effect/platform": "0.96.1",
-    "@effect/platform-node": "0.106.0",
-    "@effect/platform-node-shared": "0.59.0",
+    "@effect/platform": "^0.96.1",
+    "@effect/platform-node": "^0.106.0",
     "@effect/printer": "^0.49.0",
     "@effect/printer-ansi": "^0.49.0",
     "bundle-require": "^5.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "peerDependencies": {
-    "convex": "1.39.1",
+    "convex": "^1.32.0",
     "effect": "^3.21.2"
   },
   "repository": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -42,7 +42,7 @@
   "module": "./dist/index.js",
   "peerDependencies": {
     "@confect/core": "workspace:^",
-    "convex": "1.39.1",
+    "convex": "^1.32.0",
     "effect": "^3.21.2"
   },
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
     "@types/node": "25.3.3",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "convex": "1.39.1",
+    "convex": "1.40.0",
     "effect": "3.21.2",
     "happy-dom": "15.11.7",
     "react": "19.2.4",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
   "module": "./dist/index.js",
   "peerDependencies": {
     "@confect/core": "workspace:^",
-    "convex": "^1.30.0",
+    "convex": "^1.32.0",
     "effect": "^3.21.2",
     "react": "^18.0.0 || ^19.0.0"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -67,8 +67,13 @@
     "@confect/core": "workspace:^",
     "@effect/platform": "^0.96.1",
     "@effect/platform-node": "^0.106.0",
-    "convex": "1.39.1",
+    "convex": "^1.32.0",
     "effect": "^3.21.2"
+  },
+  "peerDependenciesMeta": {
+    "@effect/platform-node": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -47,8 +47,8 @@
   "peerDependencies": {
     "@confect/core": "workspace:^",
     "@confect/server": "workspace:^",
-    "convex": "1.39.1",
-    "convex-test": "^0.0.50",
+    "convex": "^1.32.0",
+    "convex-test": ">=0.0.50 <0.1.0",
     "effect": "^3.21.2"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  convex: 1.39.1
+  convex: 1.40.0
   effect: 3.21.2
   '@effect/typeclass': 0.40.0
   react: 19.2.4
@@ -103,16 +103,16 @@ importers:
         version: link:../../packages/server
       '@convex-dev/workpool':
         specifier: 0.4.6
-        version: 0.4.6(convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.39.1(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(convex@1.39.1(react@19.2.4))
+        version: 0.4.6(convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(convex@1.40.0(react@19.2.4))
       '@effect/platform':
         specifier: 0.96.1
         version: 0.96.1(effect@3.21.2)
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
       convex-helpers:
         specifier: 0.1.118
-        version: 0.1.118(@standard-schema/spec@1.1.0)(convex@1.39.1(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 0.1.118(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       effect:
         specifier: 3.21.2
         version: 3.21.2
@@ -212,8 +212,8 @@ importers:
   packages/core:
     dependencies:
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
     devDependencies:
       '@ark/attest':
         specifier: 0.56.0
@@ -246,8 +246,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
     devDependencies:
       '@effect/vitest':
         specifier: 0.29.0
@@ -290,8 +290,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
       effect:
         specifier: 3.21.2
         version: 3.21.2
@@ -326,8 +326,8 @@ importers:
         specifier: ^0.106.0
         version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
     devDependencies:
       '@ark/attest':
         specifier: 0.56.0
@@ -364,7 +364,7 @@ importers:
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.6.0))
       convex-test:
         specifier: 0.0.50
-        version: 0.0.50(convex@1.39.1(react@19.2.4))
+        version: 0.0.50(convex@1.40.0(react@19.2.4))
       dotenv:
         specifier: 17.3.1
         version: 17.3.1
@@ -399,8 +399,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
       effect:
         specifier: 3.21.2
         version: 3.21.2
@@ -418,8 +418,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
       effect:
         specifier: 3.21.2
         version: 3.21.2
@@ -443,11 +443,11 @@ importers:
         specifier: workspace:^
         version: link:../server
       convex:
-        specifier: 1.39.1
-        version: 1.39.1(react@19.2.4)
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
       convex-test:
         specifier: '>=0.0.50 <0.1.0'
-        version: 0.0.50(convex@1.39.1(react@19.2.4))
+        version: 0.0.50(convex@1.40.0(react@19.2.4))
     devDependencies:
       '@types/node':
         specifier: 25.3.3
@@ -685,7 +685,7 @@ packages:
   '@convex-dev/workpool@0.4.6':
     resolution: {integrity: sha512-e+cIgQePx5rrGizvzaYocWQCsDFbFlYqR1ZbtFPLa909izwc5GvoasPJPANeFhHRWaA5NBipNVqNtfHySi7Ldw==}
     peerDependencies:
-      convex: 1.39.1
+      convex: 1.40.0
       convex-helpers: ^0.1.94
 
   '@effect/cli@0.75.1':
@@ -3722,7 +3722,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@standard-schema/spec': ^1.0.0
-      convex: 1.39.1
+      convex: 1.40.0
       hono: ^4.0.5
       react: 19.2.4
       typescript: ^5.5 || ^6.0.0
@@ -3742,10 +3742,10 @@ packages:
   convex-test@0.0.50:
     resolution: {integrity: sha512-rMNfrgcKJGToYDqNns2n1AO9KUP1NyC/AF9ldYEuWwTfRbgC9RQiHjlZsZQ/sOjLIVPUyKKIjoI/fNJUzy1urw==}
     peerDependencies:
-      convex: 1.39.1
+      convex: 1.40.0
 
-  convex@1.39.1:
-    resolution: {integrity: sha512-W+gVXA7BpRF1xLlS1kGTtKVaqd5yonqbGESKiPtIUXjV744GdDz8IG7RVsSY5KzHbgxuJBHKaJYk+92OIHTskQ==}
+  convex@1.40.0:
+    resolution: {integrity: sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -6963,8 +6963,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6975,8 +6975,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7440,10 +7440,10 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@convex-dev/workpool@0.4.6(convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.39.1(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(convex@1.39.1(react@19.2.4))':
+  '@convex-dev/workpool@0.4.6(convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(convex@1.40.0(react@19.2.4))':
     dependencies:
-      convex: 1.39.1(react@19.2.4)
-      convex-helpers: 0.1.118(@standard-schema/spec@1.1.0)(convex@1.39.1(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      convex: 1.40.0(react@19.2.4)
+      convex-helpers: 0.1.118(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
 
   '@effect/cli@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
@@ -10284,23 +10284,23 @@ snapshots:
 
   convert-to-spaces@2.0.1: {}
 
-  convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.39.1(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
-      convex: 1.39.1(react@19.2.4)
+      convex: 1.40.0(react@19.2.4)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
       react: 19.2.4
       typescript: 5.9.3
 
-  convex-test@0.0.50(convex@1.39.1(react@19.2.4)):
+  convex-test@0.0.50(convex@1.40.0(react@19.2.4)):
     dependencies:
-      convex: 1.39.1(react@19.2.4)
+      convex: 1.40.0(react@19.2.4)
 
-  convex@1.39.1(react@19.2.4):
+  convex@1.40.0(react@19.2.4):
     dependencies:
       esbuild: 0.27.0
       prettier: 3.8.1
-      ws: 8.18.0
+      ws: 8.20.1
     optionalDependencies:
       react: 19.2.4
     transitivePeerDependencies:
@@ -14437,9 +14437,9 @@ snapshots:
 
   ws@8.17.1: {}
 
-  ws@8.18.0: {}
-
   ws@8.18.3: {}
+
+  ws@8.20.1: {}
 
   xml2js@0.6.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,14 +157,11 @@ importers:
         specifier: ^0.75.1
         version: 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform':
-        specifier: 0.96.1
+        specifier: ^0.96.1
         version: 0.96.1(effect@3.21.2)
       '@effect/platform-node':
-        specifier: 0.106.0
+        specifier: ^0.106.0
         version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
-      '@effect/platform-node-shared':
-        specifier: 0.59.0
-        version: 0.59.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/printer':
         specifier: ^0.49.0
         version: 0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2)
@@ -449,7 +446,7 @@ importers:
         specifier: 1.39.1
         version: 1.39.1(react@19.2.4)
       convex-test:
-        specifier: ^0.0.50
+        specifier: '>=0.0.50 <0.1.0'
         version: 0.0.50(convex@1.39.1(react@19.2.4))
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ allowBuilds:
   sharp: true
 
 overrides:
-  convex: 1.39.1
+  convex: 1.40.0
   effect: 3.21.2
   "@effect/typeclass": 0.40.0
   react: 19.2.4


### PR DESCRIPTION
An audit of the published manifests found several versioning problems
that made the packages needlessly hard to install or prone to
duplicate-dependency bugs:

- `convex` was pinned exactly to `1.39.1` in the peerDependencies of
  core, server, js, and test, so any consumer on a newer convex (1.40.0
  is already out) would hit unmet-peer errors. Meanwhile react allowed
  `^1.30.0`, a range that was both inconsistent with the other packages
  and unsatisfiable alongside them. All five packages now declare
  `^1.32.0`, a floor verified empirically: typecheck and every test
  suite (unit + convex-test integration) pass against convex 1.32.0,
  1.39.1, and 1.40.0. Convex 1.30/1.31 pass typecheck and unit tests
  but cannot be integration-tested because `convex-test` itself
  requires convex >= 1.32, so they are excluded from the claimed range.

- `@confect/server`'s `@effect/platform-node` peer was required even
  though its only runtime use is in `RegisteredNodeFunction`, exported
  solely via the `./node` entrypoint (the `Handler.ts` import is
  type-only). It is now an optional peer, so apps that never use
  `"use node"` no longer have to install it along with its own large
  peer tree (`@effect/cluster`, `@effect/rpc`, `@effect/sql`).

- `@confect/cli` exact-pinned `@effect/platform` and
  `@effect/platform-node` while server peer-requires caret ranges of
  the same packages. Since the CLI imports `@confect/server` at
  runtime, a consumer resolving a newer patch for server's peer would
  end up with two copies of `@effect/platform` in one process — a
  classic source of Effect context mismatches. Both are now caret
  ranges. The unused `@effect/platform-node-shared` dependency (never
  imported, and already a transitive dependency of
  `@effect/platform-node`) is dropped.

- `@confect/test`'s `convex-test: ^0.0.50` only matched exactly 0.0.50
  (caret on 0.0.x pins the patch); it now uses `>=0.0.50 <0.1.0`.

To keep these from drifting again, syncpack gains a `sameRange` group
covering `convex`, `convex-test`, `effect`, `@effect/platform`, and
`@effect/platform-node` across prod/peer dependencies of the
`@confect/*` packages, replacing part of the previous blanket ignore.
The example app and test fixtures are intentionally out of scope so
they can keep exact pins and `*` ranges respectively.

https://claude.ai/code/session_019nqXYpWpEg4y34fJh2i36i