### PR TITLE
docs: Update Effect imports to use explicit subpath imports

### DIFF
--- a/apps/docs/clients/js/http.mdx
+++ b/apps/docs/clients/js/http.mdx
@@ -12,7 +12,7 @@ Create the `HttpClient` layer by passing your Convex deployment URL.
 
 ```ts
 import { HttpClient } from "@confect/js";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 const HttpClientLive = HttpClient.layer("https://example-123.convex.cloud");
 ```
@@ -25,7 +25,7 @@ Use the `HttpClient` service inside `Effect.gen` to call your functions with ref
 
 ```ts
 import { HttpClient } from "@confect/js";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import refs from "./confect/_generated/refs";
 
@@ -50,7 +50,7 @@ When a ref's spec declares an `error` schema, the decoded error is added to the 
 
 ```ts
 import { HttpClient } from "@confect/js";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import refs from "./confect/_generated/refs";
 
@@ -94,7 +94,8 @@ Provide the `HttpClient` layer when running your program.
 
 ```ts
 import { HttpClient } from "@confect/js";
-import { Console, Effect } from "effect";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
 
 const HttpClientLive = HttpClient.layer("https://example-123.convex.cloud");
 

--- a/apps/docs/clients/js/websocket.mdx
+++ b/apps/docs/clients/js/websocket.mdx
@@ -28,7 +28,7 @@ Use the `WebSocketClient` service inside `Effect.gen` to call your functions wit
 
 ```ts
 import { WebSocketClient } from "@confect/js";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import refs from "./confect/_generated/refs";
 
@@ -53,7 +53,9 @@ Each method returns an `Effect` that can fail with `WebSocketClientError` (wrapp
 
 ```ts
 import { WebSocketClient } from "@confect/js";
-import { Console, Effect, Stream } from "effect";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 
 import refs from "./confect/_generated/refs";
 
@@ -74,7 +76,7 @@ When a ref's spec declares an `error` schema, the decoded error is added to the 
 
 ```ts
 import { WebSocketClient } from "@confect/js";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import refs from "./confect/_generated/refs";
 
@@ -90,7 +92,8 @@ For `reactiveQuery`, a typed failure terminates the `Stream` with the decoded va
 
 ```ts
 import { WebSocketClient } from "@confect/js";
-import { Effect, Stream } from "effect";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 
 import refs from "./confect/_generated/refs";
 
@@ -133,7 +136,9 @@ Provide the `WebSocketClient` layer when running your program.
 
 ```ts
 import { WebSocketClient } from "@confect/js";
-import { Console, Effect, Stream } from "effect";
+import * as Console from "effect/Console";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
 
 const WebSocketClientLive = WebSocketClient.layer(
   "https://example-123.convex.cloud",

--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -38,7 +38,7 @@ Given this spec:
 
 ```ts confect/notes.spec.ts
 import { FunctionSpec, GroupSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import notes from "./_generated/tables/notes";
 
@@ -171,7 +171,7 @@ FunctionSpec.publicMutation({
 
 ```tsx
 import { useMutation } from "@confect/react";
-import { Either } from "effect";
+import * as Either from "effect/Either";
 import refs from "../confect/_generated/refs";
 
 const DeleteNote = ({ noteId }: { noteId: string }) => {

--- a/apps/docs/concepts/file-naming-conventions.mdx
+++ b/apps/docs/concepts/file-naming-conventions.mdx
@@ -14,7 +14,7 @@ A complete pair looks like this. The impl default-imports its sibling spec, pass
 
 ```ts confect/notes.spec.ts
 import { GroupSpec, FunctionSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import notes from "./_generated/tables/notes";
 
@@ -29,7 +29,8 @@ export default GroupSpec.make().addFunction(list);
 
 ```ts confect/notes.impl.ts
 import { FunctionImpl, GroupImpl } from "@confect/server";
-import { Effect, Layer } from "effect";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
 import databaseSchema from "./_generated/schema";
 import { DatabaseReader } from "./_generated/services";

--- a/apps/docs/concepts/spec-impl-model.mdx
+++ b/apps/docs/concepts/spec-impl-model.mdx
@@ -16,7 +16,7 @@ Each group spec is the default export of a `*.spec.ts` file. The group's name co
 
 ```ts confect/notes_and_random/notes.spec.ts
 import { GroupSpec, FunctionSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import notes from "../_generated/tables/notes";
 
@@ -35,7 +35,8 @@ An impl provides the logic for each function declared in your spec. Each impl is
 
 ```ts confect/notes_and_random/notes.impl.ts
 import { FunctionImpl, GroupImpl } from "@confect/server";
-import { Effect, Layer } from "effect";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
 import databaseSchema from "../_generated/schema";
 import { DatabaseReader } from "../_generated/services";

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -44,7 +44,7 @@ bun add convex @confect/core @confect/server @confect/cli @confect/react
 
     ```ts confect/tables/notes.ts
     import { Table } from "@confect/server";
-    import { Schema } from "effect";
+    import * as Schema from "effect/Schema";
 
     export default Table.make(() =>
       Schema.Struct({
@@ -62,7 +62,7 @@ bun add convex @confect/core @confect/server @confect/cli @confect/react
 
     ```ts confect/notes.spec.ts
     import { FunctionSpec, GroupSpec } from "@confect/core";
-    import { Schema } from "effect";
+    import * as Schema from "effect/Schema";
 
     import { Id } from "./_generated/id";
     import notes from "./_generated/tables/notes";
@@ -100,7 +100,8 @@ bun add convex @confect/core @confect/server @confect/cli @confect/react
 
     ```ts confect/notes.impl.ts
     import { FunctionImpl, GroupImpl } from "@confect/server";
-    import { Effect, Layer } from "effect";
+    import * as Effect from "effect/Effect";
+    import * as Layer from "effect/Layer";
 
     import databaseSchema from "./_generated/schema";
     import { DatabaseReader, DatabaseWriter } from "./_generated/services";
@@ -179,7 +180,7 @@ bun add convex @confect/core @confect/server @confect/cli @confect/react
 
     ```tsx src/App.tsx
     import { QueryResult, useMutation, useQuery } from "@confect/react";
-    import { Array } from "effect";
+    import * as Array from "effect/Array";
     import { useState } from "react";
 
     import refs from "../confect/_generated/refs";

--- a/apps/docs/guides/testing.mdx
+++ b/apps/docs/guides/testing.mdx
@@ -58,7 +58,7 @@ Use `@effect/vitest`'s `it.effect` to write effectful tests. Yield `TestConfect`
 ```ts test/notes.test.ts
 import { describe, it } from "@effect/vitest";
 import { assertEquals } from "@effect/vitest/utils";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import refs from "./confect/_generated/refs";
 import * as TestConfect from "./TestConfect";
@@ -107,7 +107,7 @@ When a ref's spec declares an `error` schema, the decoded error is added to the 
 import { describe, it } from "@effect/vitest";
 import { assertLeft } from "@effect/vitest/utils";
 import type { GenericId } from "convex/values";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import { NoteNotFound } from "./confect/notes.spec";
 import refs from "./confect/_generated/refs";

--- a/apps/docs/server/authentication.mdx
+++ b/apps/docs/server/authentication.mdx
@@ -9,7 +9,7 @@ The `Auth` service provides access to the current user's identity. Unlike vanill
 ## Getting the user identity
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { Auth } from "./confect/_generated/services";
 
 Effect.gen(function* () {

--- a/apps/docs/server/cron-jobs.mdx
+++ b/apps/docs/server/cron-jobs.mdx
@@ -20,7 +20,8 @@ Schedules are either an Effect [`Cron`](https://effect.website/docs/scheduling/c
 </Note>
 
 ```ts confect/crons.ts
-import { Cron, Duration } from "effect";
+import * as Cron from "effect/Cron";
+import * as Duration from "effect/Duration";
 import { CronJob, CronJobs } from "@confect/server";
 import refs from "./_generated/refs";
 

--- a/apps/docs/server/database/determinism.mdx
+++ b/apps/docs/server/database/determinism.mdx
@@ -30,7 +30,8 @@ The following do **not** observe real time from within a query handler and so do
 Use Effect's `Clock` service when you need the real timestamp:
 
 ```ts
-import { Clock, Effect } from "effect";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
 import { DatabaseReader } from "./confect/_generated/services";
 
 Effect.gen(function* () {

--- a/apps/docs/server/database/reading.mdx
+++ b/apps/docs/server/database/reading.mdx
@@ -7,7 +7,7 @@ description: "Retrieve documents from the database."
 The `DatabaseReader` service is used to read documents from the database.
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { DatabaseReader } from "./confect/_generated/services";
 
 Effect.gen(function* () {

--- a/apps/docs/server/database/schema.mdx
+++ b/apps/docs/server/database/schema.mdx
@@ -10,7 +10,7 @@ Each table is defined with `Table.make`, which takes a callback returning the ta
 
 ```ts confect/tables/notes.ts
 import { Table } from "@confect/server";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 import { Id } from "../_generated/id";
 
 export default Table.make(() =>
@@ -42,7 +42,7 @@ export default Table.make(() =>
 
 ```ts confect/tables/users.ts
 import { Table } from "@confect/server";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 export default Table.make(() =>
   Schema.Struct({

--- a/apps/docs/server/database/writing.mdx
+++ b/apps/docs/server/database/writing.mdx
@@ -7,7 +7,7 @@ description: "Insert, modify, and delete documents in the database."
 The `DatabaseWriter` service is used to insert, modify, and delete documents in the database.
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { DatabaseWriter } from "./confect/_generated/services";
 
 Effect.gen(function* () {

--- a/apps/docs/server/environment-variables.mdx
+++ b/apps/docs/server/environment-variables.mdx
@@ -12,7 +12,8 @@ Use `Config` from Effect to read [Convex environment variables](https://docs.con
 
 ```ts confect/settings.impl.ts
 import { FunctionImpl } from "@confect/server";
-import { Config, Effect } from "effect";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
 
 import databaseSchema from "./_generated/schema";
 import settings from "./settings.spec";

--- a/apps/docs/server/error-handling.mdx
+++ b/apps/docs/server/error-handling.mdx
@@ -16,7 +16,7 @@ Add an `error` field to any `FunctionSpec` constructor. The schema is an ordinar
 
 ```ts confect/notes.spec.ts
 import { FunctionSpec, GroupSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import { Id } from "./_generated/id";
 import notes from "./_generated/tables/notes";
@@ -39,7 +39,7 @@ export default GroupSpec.make().addFunction(
 To declare more than one failure mode, combine them with `Schema.Union`.
 
 ```ts
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import { Id } from "./_generated/id";
 
@@ -67,7 +67,7 @@ When a spec declares an `error` schema, the corresponding `FunctionImpl` handler
 
 ```ts confect/notes.impl.ts
 import { FunctionImpl } from "@confect/server";
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 
 import databaseSchema from "./_generated/schema";
 import { DatabaseReader } from "./_generated/services";

--- a/apps/docs/server/functions.mdx
+++ b/apps/docs/server/functions.mdx
@@ -25,7 +25,7 @@ Each function spec defines the function's name, arguments schema, and returns sc
 
 ```ts confect/notes.spec.ts
 import { GroupSpec, FunctionSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import notes from "./_generated/tables/notes";
 
@@ -46,7 +46,7 @@ A spec can also declare an optional `error` schema. When it does, the correspond
 
 ```ts
 import { FunctionSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 import { Id } from "./_generated/id";
 import notes from "./_generated/tables/notes";
@@ -71,7 +71,8 @@ The handler receives the decoded arguments as its first parameter and returns an
 
 ```ts confect/notes.impl.ts
 import { FunctionImpl, GroupImpl } from "@confect/server";
-import { Effect, Layer } from "effect";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 
 import databaseSchema from "./_generated/schema";
 import { DatabaseReader } from "./_generated/services";

--- a/apps/docs/server/http-api.mdx
+++ b/apps/docs/server/http-api.mdx
@@ -18,7 +18,9 @@ import {
   HttpApiGroup,
   OpenApi,
 } from "@effect/platform";
-import { Effect, Layer, Schema } from "effect";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 
 import refs from "../_generated/refs";
 import { QueryRunner } from "../_generated/services";
@@ -66,7 +68,7 @@ Create the Convex HTTP router in `confect/http.ts` using `HttpApi.make` from `@c
 ```ts confect/http.ts
 import { HttpApi } from "@confect/server";
 import { HttpMiddleware } from "@effect/platform";
-import { flow } from "effect";
+import { flow } from "effect/Function";
 
 import { ApiLive } from "./http/notes";
 

--- a/apps/docs/server/node-actions.mdx
+++ b/apps/docs/server/node-actions.mdx
@@ -12,7 +12,7 @@ A node spec uses `GroupSpec.makeNode()` and one of `FunctionSpec.publicNodeActio
 
 ```ts confect/email.spec.ts
 import { FunctionSpec, GroupSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 
 export default GroupSpec.makeNode().addFunction(
   FunctionSpec.publicNodeAction({
@@ -35,7 +35,10 @@ A node impl default-imports its sibling spec and passes the database schema from
 ```ts confect/email.impl.ts
 import { FunctionImpl, GroupImpl } from "@confect/server";
 import { Command } from "@effect/platform";
-import { Console, Duration, Effect, Layer } from "effect";
+import * as Console from "effect/Console";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import databaseSchema from "./_generated/schema";
 import email from "./email.spec";
 

--- a/apps/docs/server/plain-convex-functions.mdx
+++ b/apps/docs/server/plain-convex-functions.mdx
@@ -158,7 +158,7 @@ For plain Convex functions, the impl is the Convex function value itself. Pass e
 
 ```ts confect/workpool.impl.ts
 import { FunctionImpl, GroupImpl } from "@confect/server";
-import { Layer } from "effect";
+import * as Layer from "effect/Layer";
 import databaseSchema from "./_generated/schema";
 import { backgroundWork, enqueue, onComplete, status } from "./workpool";
 import workpool from "./workpool.spec";
@@ -217,7 +217,7 @@ A single group can contain both Confect functions (with Effect schemas) and plai
 
 ```ts confect/notes.spec.ts
 import { FunctionSpec, GroupSpec } from "@confect/core";
-import { Schema } from "effect";
+import * as Schema from "effect/Schema";
 import type { search } from "./search";
 import notes from "./_generated/tables/notes";
 

--- a/apps/docs/server/scheduling.mdx
+++ b/apps/docs/server/scheduling.mdx
@@ -11,7 +11,8 @@ Both `runAfter` and `runAt` accept a ref to a mutation or action and an optional
 ## Run after a delay
 
 ```ts
-import { Duration, Effect } from "effect";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
 import refs from "./confect/_generated/refs";
 import { Scheduler } from "./confect/_generated/services";
 

--- a/apps/docs/server/search.mdx
+++ b/apps/docs/server/search.mdx
@@ -9,7 +9,7 @@ description: "Query vector indexes for semantic similarity search."
 The `VectorSearch` service queries vector indexes defined in your [schema](/server/database/schema). It is only available in actions.
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { VectorSearch } from "./confect/_generated/services";
 
 Effect.gen(function* () {

--- a/apps/docs/server/storage.mdx
+++ b/apps/docs/server/storage.mdx
@@ -9,7 +9,7 @@ description: "Store and retrieve blobs using Convex file storage."
 The `StorageReader` service is used to retrieve the URLs of blobs in storage.
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { StorageReader } from "./confect/_generated/services";
 
 Effect.gen(function* () {
@@ -24,7 +24,7 @@ Effect.gen(function* () {
 The `StorageWriter` service is used to write blobs to storage in mutations.
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { StorageWriter } from "./confect/_generated/services";
 
 Effect.gen(function* () {
@@ -53,7 +53,7 @@ storage.delete(storageId);
 The `StorageActionWriter` service is used to read and write blobs to storage in actions.
 
 ```ts
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { StorageActionWriter } from "./confect/_generated/services";
 
 Effect.gen(function* () {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 445ea9b: Loosen and align dependency ranges across all packages:
-
   - The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
   - `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
   - `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
@@ -26,7 +25,6 @@
   ### Filesystem-driven groups
 
   Your API is now authored as colocated `*.spec.ts`/`*.impl.ts` pairs, one pair per group, and **the file's path within `confect/` is the group's name** (its stem for top-level groups, the dot-joined directory path for nested groups). `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument.
-
   - Each `*.spec.ts` `export default`s its `GroupSpec` (named co-exports like error classes are still allowed).
   - Each `*.impl.ts` default-imports its sibling spec, passes it to `FunctionImpl.make` / `GroupImpl.make`, and ends the layer pipeline with `GroupImpl.finalize`—a compile-time completeness check that only typechecks once every function the spec declares has a `FunctionImpl` provided.
   - The root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, and `confect/nodeImpl.ts` files are gone, along with `Impl.make` and `Impl.finalize`. `confect codegen` deletes any of these (and the stale aggregate `_generated/registeredFunctions.ts` / `_generated/nodeRegisteredFunctions.ts`) on upgrade.
@@ -46,12 +44,11 @@
     Schema.Struct({
       userId: Schema.optional(Id("users")),
       text: Schema.String,
-    })
+    }),
   );
   ```
 
   Codegen emits, alongside it:
-
   - `_generated/schema.ts`—the runtime `DatabaseSchema`. Never imports `convex/server`, so a runtime cold start no longer evaluates `defineSchema(...)`.
   - `_generated/convexSchema.ts`—the Convex deploy `SchemaDefinition`, re-exported from `convex/schema.ts`.
   - `_generated/id.ts`—a type-safe `Id` constructor whose argument is constrained to your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`; cross-table `_id` typos are now caught at compile time.
@@ -71,7 +68,7 @@
       name: "list",
       args: Schema.Struct({}),
       returns: Schema.Array(Notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -90,7 +87,7 @@
       name: "list",
       args: () => Schema.Struct({}),
       returns: () => Schema.Array(notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -101,14 +98,13 @@
   const list = FunctionImpl.make(databaseSchema, notes, "list", handler);
   export default GroupImpl.make(databaseSchema, notes).pipe(
     Layer.provide(list),
-    GroupImpl.finalize
+    GroupImpl.finalize,
   );
   ```
 
   ### Node functions are first-class
 
   A group's runtime is now declared solely by its spec—`GroupSpec.makeNode()` for a Node action group, `GroupSpec.make()` otherwise—mirroring vanilla Convex's per-file `"use node"` directive. The separate `node` namespace is gone: Node specs/impls are ordinary colocated pairs that can live anywhere in `confect/`, and codegen emits the `"use node"` directive based on the spec.
-
   - A Node group at `confect/email.spec.ts` is now reached at `refs.public.email.send` instead of `refs.public.node.email.send`.
   - `@confect/core` removes `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec` / `Spec.isNodeSpec`; `Spec.make()` is a single mixed-runtime container and `Refs.make(spec)` takes one argument. `GroupSpec.makeNode()`, `FunctionSpec.publicNodeAction()` / `internalNodeAction()` are unchanged.
 
@@ -125,7 +121,6 @@
   The codegen bundler now uses [`bundle-require`](https://github.com/egoist/bundle-require), so impls may import third-party packages and use `tsconfig.json` `paths` aliases (`~/*`, `@/*`, …) for their own source. A parent `confect/{path}.spec.ts` may now declare functions alongside a sibling `confect/{path}/` subdirectory of further specs, and codegen reports a clear error on a name collision between the two.
 
   ### Migration
-
   1. **Tables.** Delete `confect/schema.ts`. Rename each table file to a valid JS identifier (e.g. `confect/tables/notes.ts`); the basename becomes the table name. Drop the name argument from `Table.make`, wrap the field struct in `() =>`, and replace `GenericId.GenericId("x")` with `Id("x")` from `_generated/id`. If you read `table.name` off a bound table, rename it to `table.tableName`.
   2. **Specs.** Split each group into a colocated `*.spec.ts` that `export default`s `GroupSpec.make()` (no name). Wrap every `args`/`returns`/`error` in `() =>`. Import a table's `Doc`/`Fields` from its wrapper, `import notes from "./_generated/tables/notes"`.
   3. **Impls.** In each `*.impl.ts`, default-import the sibling spec, import `databaseSchema` from `_generated/schema`, pass it to `FunctionImpl.make` / `GroupImpl.make` in place of `api`, end the pipeline with `GroupImpl.finalize`, and `export default` it. Delete the root `confect/spec.ts`, `impl.ts`, `nodeSpec.ts`, and `nodeImpl.ts` (codegen will also remove them).
@@ -170,13 +165,11 @@
   The `node` namespace existed only because the pre-v9 architecture aggregated every function's impl into one module that all generated `convex/` modules imported; Node functions had to be quarantined into a separate spec/impl/registry tree so Convex-runtime functions wouldn't transitively import Node-only code. v9's per-group isolation removed that constraint, so the namespace was no longer load-bearing — only ergonomic overhead that diverged from vanilla Convex (which identifies Node modules per-file, with no directory requirement).
 
   ### Breaking changes
-
   - **API namespace removed.** A Node group at `confect/email.spec.ts` is now referenced as `refs.public.email.send` instead of `refs.public.node.email.send`. Node groups are ordinary groups in the refs tree, nesting preserved like any other group.
   - **Generated layout changed.** Node modules are emitted at `convex/<path>.ts` (carrying `"use node"`) instead of `convex/node/<path>.ts`, and their registries at `confect/_generated/registeredFunctions/<path>.ts`. The single assembled `confect/_generated/spec.ts` now contains every group regardless of runtime; `confect/_generated/nodeSpec.ts` is no longer generated (codegen deletes any stale copy on upgrade).
   - **`@confect/core` API.** Removed `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec`/`Spec.isNodeSpec`. `Spec` is now a single mixed-runtime container (`Spec.make()` accepts groups of any runtime). `Refs.make(spec)` takes a single argument (the unified spec) instead of `(convexSpec, nodeSpec)`. `GroupSpec.makeNode()`/`makeNodeAt()` and `FunctionSpec.publicNodeAction()`/`internalNodeAction()` are unchanged; `GroupSpec` subgroups may now be of any runtime (a group is just a namespace for its children).
 
   ### Migration
-
   1. Move any `confect/node/<path>.spec.ts`/`.impl.ts` files to wherever you want them under `confect/` (e.g. `confect/<path>.spec.ts`); the `node/` directory has no special meaning anymore. Their specs already use `GroupSpec.makeNode()`, so no spec-body change is needed — only fix the impl's relative import of `_generated/schema` if its depth changed.
   2. Update call sites to drop the `node` segment: `refs.public.node.<group>.<fn>` → `refs.public.<group>.<fn>`.
   3. Replace `Refs.make(spec, nodeSpec)` with `Refs.make(spec)` (codegen does this for `_generated/refs.ts` automatically).
@@ -289,7 +282,6 @@
   Previously, `confect/schema.ts` was user-authored and `DatabaseSchema` carried a `convexSchemaDefinition` field that was eagerly rebuilt on every `.addTable(...)`. That field was an `O(n²)` allocation for `n` tables, and it forced both the deploy CLI (which only needs `defineSchema(...)`) and the runtime (which only needs the table codec lookup) through the same module — so any runtime function bundle dragged in `convex/server`'s `defineSchema`. Issue 1.
 
   Codegen now scans `confect/tables/*.ts` (every file must default-export a `Table`) and emits two siblings:
-
   - `confect/_generated/schema.ts` — the runtime `DatabaseSchema`, consumed by `_generated/api.ts`. Imports `@confect/server` but never `convex/server`.
   - `confect/_generated/convexSchema.ts` — the Convex deploy `SchemaDefinition`, re-exported one-line from `convex/schema.ts`. Imports `convex/server` but never `@confect/server`.
 
@@ -302,7 +294,6 @@
   This eliminates a class of subtle infelicities: the file basename and the table name can never drift out of sync, cross-table `_id` references are type-constrained against the actual set of declared tables (catching typos at compile time), and ESM cycle hazards for mutual cross-table `Id` references are gone because authoring files no longer transitively import each other.
 
   Codegen now emits two new sets of files alongside `_generated/schema.ts` and `_generated/convexSchema.ts`:
-
   - `confect/_generated/id.ts` — a single `Id` constructor whose argument is type-constrained to the union of your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`.
   - `confect/_generated/tables/<name>.ts` — one thin wrapper per table that binds the unnamed value from `confect/tables/<name>.ts` to its filename. This is what other modules (specs, impls, HTTP handlers) default-import to reach a table's `Doc`, `Fields`, and `tableName`.
 
@@ -319,7 +310,6 @@
   The bound `Table` now exposes `Fields` / `Doc` / `tableDefinition` as lazy getters that compute their value on first access, then replace themselves with a plain non-writable data property so second-and-subsequent accesses are observably indistinguishable from a plain property (and skip all function-call overhead). The result: a function bundle only pays the schema-construction cost for tables it actually touches via `db.table(name)` (which reaches `Fields` through `Document.decode`). The `UnnamedTable` callable no longer exposes `Fields` or `tableDefinition` — read these off the bound `Table` (the generated `_generated/tables/<name>.ts` wrapper already binds the name).
 
   ### Migration
-
   1. Delete your `confect/schema.ts`. Codegen will refuse to run while a stray copy is present.
   2. Rename each `confect/tables/<Name>.ts` to a valid JS identifier in your chosen casing convention (e.g. `confect/tables/notes.ts`). The basename becomes the table name; you no longer pass it as an argument.
   3. Convert each table file to a **default-export-only** unnamed module: drop the name argument from `Table.make`, wrap the field-schema struct in a `() => ...` callback, and switch any `GenericId.GenericId("users")` references to `Id("users")` imported from `../_generated/id`:
@@ -398,13 +388,11 @@
   `9.0.0-next.4`'s `absoluteExternalsPlugin` externalized every bare-specifier import and rewrote it to a `file://` URL because the bundle was loaded via a parent-less `data:` URL. esbuild's resolver honors `tsconfig.json#compilerOptions.paths`, so a `~/src/foo`-style alias resolved to a local `.ts` file and got externalized as `file:///…/foo.ts` — which Node ESM cannot import (`ERR_UNKNOWN_FILE_EXTENSION`). The codegen bundler hand-rolled a third reimplementation of "load a TypeScript config file at runtime"; each iteration introduced a new bug.
 
   ### What changed
-
   - `@confect/cli/Bundler` now delegates to `bundle-require`, the library `tsup`, `unbuild`, `vite`, `vitest`, and `vuepress` use for this exact problem. `bundle-require` writes a temp `.mjs` next to the source, `import()`s it, and deletes it — so bare-specifier externals (third-party packages, workspace deps) resolve through Node's normal `node_modules` walk and tsconfig `paths` aliases stay inside the bundle.
   - `@confect/cli/confect/dev`'s watcher swaps `absoluteExternalsPlugin` for `bundle-require`'s `externalPlugin`, fed the project's `tsconfig.json#paths` via `loadTsConfig` so dev-mode rebuilds also bundle aliased local source instead of erroring on it.
   - The `absoluteExternalsPlugin` export is removed from `@confect/cli/Bundler`.
 
   ### Fixes
-
   - Restores `confect codegen` for any project that uses `tsconfig.json` `paths` aliases (e.g. `~/*`, `@/*`, `@app/*`) for its own source.
   - As a side benefit, `__dirname`, `__filename`, and `import.meta.url` inside bundled impls now resolve to the original source path instead of the temporary bundle URL (`bundle-require`'s built-in injection).
   - @confect/core@9.0.0-next.5
@@ -421,7 +409,6 @@
   Since `9.0.0-next.0`, codegen bundles each `*.impl.ts` with esbuild so it can load the default-exported `Layer` and read the snapshotted function names from a `Finalized` `GroupImpl`. The bundler only marked `@confect/core`, `@confect/server`, `effect`, and `@effect/*` as external — every other dependency, including all of `node_modules` and every `node:*` built-in reached through inlined CJS source, was bundled into the output. With `format: "esm"`, esbuild rewrites any CJS `require(...)` in that inlined source to a runtime shim that throws `Dynamic require of "<id>" is not supported`, so any impl importing a third-party package (`sharp`, `luxon`, `@clerk/backend`, `jsonwebtoken`, `openai`, etc.) failed during `validateImpl`.
 
   ### What changed
-
   - `@confect/cli/Bundler`'s `absoluteExternalsPlugin` now externalizes every bare specifier (anything not starting with `./`, `../`, or `/`), resolving each to an absolute file URL via the user's `node_modules`. `node:*` built-ins pass through unchanged.
   - The `EXTERNAL_PACKAGES` allow-list is removed; relative imports continue to be bundled so the user's own source is still transpiled together.
   - `@confect/cli/confect/dev` drops the redundant `external: EXTERNAL_PACKAGES` esbuild option — the plugin handles externalization for both codegen and dev-mode watchers.
@@ -429,7 +416,6 @@
   ### Fixes
 
   This restores `confect codegen` for impls that import any non-`@confect/*` / `effect` / `@effect/*` library, fixing the regression introduced in `9.0.0-next.0`.
-
   - @confect/core@9.0.0-next.4
   - @confect/server@9.0.0-next.4
 
@@ -444,7 +430,6 @@
   Since `9.0.0-next.1`, codegen has wrapped every parent leaf that has sibling subdirectory specs in `<parent>.addGroupAt("child", <child>)`. Because `GroupSpec.addGroupAt` is immutable, that produced a fresh object in the assembled tree, while the parent's `*.impl.ts` continued to hold a reference to the original imported leaf. The runtime resolver compared by `===`, so every such impl failed `validateImpl` with "Could not resolve group path for the provided GroupSpec." Child impls happened to work only because `GroupSpec.withName` was secretly mutating its argument in place to keep the child's identity stable — an asymmetry that was load-bearing for one half of the API and broken for the other.
 
   ### What changed
-
   - `@confect/core/Spec` carries a new `readonly paths: ReadonlyMap<GroupSpec.AnyWithProps, string>` field and exposes a chainable `Spec#addPath(group, path)` builder. `add` / `addAt` / `merge` propagate `paths` unchanged; `merge` re-prefixes a node spec's entries with `"node."` to match the merged tree.
   - `@confect/core/GroupSpec.withName` is now pure: it returns a fresh copy when the name differs and no longer rewrites the input in place. No new identity-tracking machinery is introduced.
   - `@confect/server/FunctionImpl.make` and `GroupImpl.make` resolve their group path via `api.spec.paths.get(group)` — an O(1) map lookup instead of a tree walk — and throw a clearer error pointing at `Spec.addPath` when the spec hasn't been registered.
@@ -452,7 +437,6 @@
   - `@confect/cli` codegen emits one `.addPath(<binding>, "<dot.path>")` call per leaf in `_generated/spec.ts` (and `_generated/nodeSpec.ts`) so the imported leaves carry their full paths into the assembled spec value.
 
   ### User-facing impact
-
   - Spec authoring (`*.spec.ts`) and impl authoring (`*.impl.ts`) APIs are unchanged. `FunctionImpl.make(api, spec, name, handler)` and `GroupImpl.make(api, spec)` keep their exact signatures.
   - Generated `_generated/spec.ts` (and `_generated/nodeSpec.ts`) pick up one `.addPath(...)` chain entry per leaf on the next `confect codegen` run. The shape is fully immutable — no module-load mutation, no hidden side effects.
   - Hand-rolled tests that construct a `Spec` and pass it to `Api.make` must now also call `.addPath(spec, "dot.path")` for any group they intend to look up.
@@ -474,7 +458,6 @@
   Previously, codegen keyed import bindings by file basename (the filename minus `.spec.ts`). When two leaves shared a basename they collapsed to a single binding, last write wins. Every `addGroupAt(...)` site that should have referenced any of the colliding leaves ended up referencing the same survivor, and every impl whose sibling spec was dropped failed `validateImpl` with `Could not resolve group path for the provided GroupSpec.` because the assembled tree no longer contained that spec object's identity.
 
   Each binding now carries its own `localName` derived from the leaf's full path segments (e.g. `scripts_operational_seed_mutations`), used both as the imported identifier and at the matching `addGroupAt` site. Top-level leaves with single-segment paths are unchanged (`env`, `notes`, etc.).
-
   - @confect/core@9.0.0-next.2
   - @confect/server@9.0.0-next.2
 
@@ -489,7 +472,6 @@
   Both `confect codegen` and `confect dev` now generate the parent's functions and the subdirectory's groups side by side, as `refs.{path}.{fn}` and `refs.{path}.{child}.{fn}`.
 
   Codegen also now reports a clear error when the parent spec declares a function or subgroup whose name matches one of the subdirectory's child segments, rather than letting the conflict turn into a runtime refs collision. `confect codegen` exits non-zero on this error; `confect dev` logs it and keeps watching so the next save can recover.
-
   - @confect/core@9.0.0-next.1
   - @confect/server@9.0.0-next.1
 
@@ -508,7 +490,6 @@
   Splitting impl across colocated `*.impl.ts` files is the vehicle for fixing that. With this change, `confect codegen` emits one `_generated/registeredFunctions/{path}.ts` per group, and each generated `convex/` module imports only its own group's per-group registry — which in turn imports only its own sibling `.impl.ts`. A Convex function's cold-start bundle now scales with its own group's impl rather than with the size of the whole project.
 
   ### Breaking changes
-
   - `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument; the group name is derived from the spec file's path within `confect/`.
   - `FunctionImpl.make(api, groupSpec, fn, handler)` and `GroupImpl.make(api, groupSpec)` now take the imported sibling spec object as their second argument instead of a dot-path string.
   - Every `GroupImpl` pipeline must end with `GroupImpl.finalize`, which only typechecks once every function declared by the spec has a corresponding `FunctionImpl` provided to the group layer. `GroupImpl.finalize` snapshots the names of every registered function onto the produced `Finalized` `GroupImpl` service value, and `confect codegen` reads those names to verify per-function coverage against the spec at runtime.
@@ -517,7 +498,6 @@
   - Every module under `convex/` is re-emitted to import from `_generated/registeredFunctions/{path}` instead of the previous aggregate file. Users who commit `convex/` to source control should expect a full rewrite of that directory on first codegen.
 
   ### Migration
-
   1. For each existing group, create a colocated `confect/{path}.spec.ts` and `confect/{path}.impl.ts` pair (under a subdirectory for nested groups).
      - In each spec, call `GroupSpec.make()` (or `GroupSpec.makeNode()`) without a name and `export default` the result.
      - In each impl, default-import the sibling spec (e.g. `import notes from "./notes.spec"`), pass it to `FunctionImpl.make`/`GroupImpl.make` in place of the previous dot-path string, append `GroupImpl.finalize` to the pipeline, and `export default` the resulting `GroupImpl` layer:
@@ -525,7 +505,7 @@
        export default GroupImpl.make(api, notes).pipe(
          Layer.provide(list),
          Layer.provide(insert),
-         GroupImpl.finalize
+         GroupImpl.finalize,
        );
        ```
   2. Delete root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, `confect/nodeImpl.ts`, and any parent aggregator spec/impl files. (`confect codegen` will also delete any of these it finds, plus the stale `_generated/registeredFunctions.ts` and `_generated/nodeRegisteredFunctions.ts`, so this step can be skipped.)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 445ea9b: Loosen and align dependency ranges across all packages:
-
   - The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
   - `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
   - `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
@@ -22,7 +21,6 @@
   ### Filesystem-driven groups
 
   Your API is now authored as colocated `*.spec.ts`/`*.impl.ts` pairs, one pair per group, and **the file's path within `confect/` is the group's name** (its stem for top-level groups, the dot-joined directory path for nested groups). `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument.
-
   - Each `*.spec.ts` `export default`s its `GroupSpec` (named co-exports like error classes are still allowed).
   - Each `*.impl.ts` default-imports its sibling spec, passes it to `FunctionImpl.make` / `GroupImpl.make`, and ends the layer pipeline with `GroupImpl.finalize`—a compile-time completeness check that only typechecks once every function the spec declares has a `FunctionImpl` provided.
   - The root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, and `confect/nodeImpl.ts` files are gone, along with `Impl.make` and `Impl.finalize`. `confect codegen` deletes any of these (and the stale aggregate `_generated/registeredFunctions.ts` / `_generated/nodeRegisteredFunctions.ts`) on upgrade.
@@ -42,12 +40,11 @@
     Schema.Struct({
       userId: Schema.optional(Id("users")),
       text: Schema.String,
-    })
+    }),
   );
   ```
 
   Codegen emits, alongside it:
-
   - `_generated/schema.ts`—the runtime `DatabaseSchema`. Never imports `convex/server`, so a runtime cold start no longer evaluates `defineSchema(...)`.
   - `_generated/convexSchema.ts`—the Convex deploy `SchemaDefinition`, re-exported from `convex/schema.ts`.
   - `_generated/id.ts`—a type-safe `Id` constructor whose argument is constrained to your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`; cross-table `_id` typos are now caught at compile time.
@@ -67,7 +64,7 @@
       name: "list",
       args: Schema.Struct({}),
       returns: Schema.Array(Notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -86,7 +83,7 @@
       name: "list",
       args: () => Schema.Struct({}),
       returns: () => Schema.Array(notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -97,14 +94,13 @@
   const list = FunctionImpl.make(databaseSchema, notes, "list", handler);
   export default GroupImpl.make(databaseSchema, notes).pipe(
     Layer.provide(list),
-    GroupImpl.finalize
+    GroupImpl.finalize,
   );
   ```
 
   ### Node functions are first-class
 
   A group's runtime is now declared solely by its spec—`GroupSpec.makeNode()` for a Node action group, `GroupSpec.make()` otherwise—mirroring vanilla Convex's per-file `"use node"` directive. The separate `node` namespace is gone: Node specs/impls are ordinary colocated pairs that can live anywhere in `confect/`, and codegen emits the `"use node"` directive based on the spec.
-
   - A Node group at `confect/email.spec.ts` is now reached at `refs.public.email.send` instead of `refs.public.node.email.send`.
   - `@confect/core` removes `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec` / `Spec.isNodeSpec`; `Spec.make()` is a single mixed-runtime container and `Refs.make(spec)` takes one argument. `GroupSpec.makeNode()`, `FunctionSpec.publicNodeAction()` / `internalNodeAction()` are unchanged.
 
@@ -121,7 +117,6 @@
   The codegen bundler now uses [`bundle-require`](https://github.com/egoist/bundle-require), so impls may import third-party packages and use `tsconfig.json` `paths` aliases (`~/*`, `@/*`, …) for their own source. A parent `confect/{path}.spec.ts` may now declare functions alongside a sibling `confect/{path}/` subdirectory of further specs, and codegen reports a clear error on a name collision between the two.
 
   ### Migration
-
   1. **Tables.** Delete `confect/schema.ts`. Rename each table file to a valid JS identifier (e.g. `confect/tables/notes.ts`); the basename becomes the table name. Drop the name argument from `Table.make`, wrap the field struct in `() =>`, and replace `GenericId.GenericId("x")` with `Id("x")` from `_generated/id`. If you read `table.name` off a bound table, rename it to `table.tableName`.
   2. **Specs.** Split each group into a colocated `*.spec.ts` that `export default`s `GroupSpec.make()` (no name). Wrap every `args`/`returns`/`error` in `() =>`. Import a table's `Doc`/`Fields` from its wrapper, `import notes from "./_generated/tables/notes"`.
   3. **Impls.** In each `*.impl.ts`, default-import the sibling spec, import `databaseSchema` from `_generated/schema`, pass it to `FunctionImpl.make` / `GroupImpl.make` in place of `api`, end the pipeline with `GroupImpl.finalize`, and `export default` it. Delete the root `confect/spec.ts`, `impl.ts`, `nodeSpec.ts`, and `nodeImpl.ts` (codegen will also remove them).
@@ -157,13 +152,11 @@
   The `node` namespace existed only because the pre-v9 architecture aggregated every function's impl into one module that all generated `convex/` modules imported; Node functions had to be quarantined into a separate spec/impl/registry tree so Convex-runtime functions wouldn't transitively import Node-only code. v9's per-group isolation removed that constraint, so the namespace was no longer load-bearing — only ergonomic overhead that diverged from vanilla Convex (which identifies Node modules per-file, with no directory requirement).
 
   ### Breaking changes
-
   - **API namespace removed.** A Node group at `confect/email.spec.ts` is now referenced as `refs.public.email.send` instead of `refs.public.node.email.send`. Node groups are ordinary groups in the refs tree, nesting preserved like any other group.
   - **Generated layout changed.** Node modules are emitted at `convex/<path>.ts` (carrying `"use node"`) instead of `convex/node/<path>.ts`, and their registries at `confect/_generated/registeredFunctions/<path>.ts`. The single assembled `confect/_generated/spec.ts` now contains every group regardless of runtime; `confect/_generated/nodeSpec.ts` is no longer generated (codegen deletes any stale copy on upgrade).
   - **`@confect/core` API.** Removed `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec`/`Spec.isNodeSpec`. `Spec` is now a single mixed-runtime container (`Spec.make()` accepts groups of any runtime). `Refs.make(spec)` takes a single argument (the unified spec) instead of `(convexSpec, nodeSpec)`. `GroupSpec.makeNode()`/`makeNodeAt()` and `FunctionSpec.publicNodeAction()`/`internalNodeAction()` are unchanged; `GroupSpec` subgroups may now be of any runtime (a group is just a namespace for its children).
 
   ### Migration
-
   1. Move any `confect/node/<path>.spec.ts`/`.impl.ts` files to wherever you want them under `confect/` (e.g. `confect/<path>.spec.ts`); the `node/` directory has no special meaning anymore. Their specs already use `GroupSpec.makeNode()`, so no spec-body change is needed — only fix the impl's relative import of `_generated/schema` if its depth changed.
   2. Update call sites to drop the `node` segment: `refs.public.node.<group>.<fn>` → `refs.public.<group>.<fn>`.
   3. Replace `Refs.make(spec, nodeSpec)` with `Refs.make(spec)` (codegen does this for `_generated/refs.ts` automatically).
@@ -270,7 +263,6 @@
   Previously, `confect/schema.ts` was user-authored and `DatabaseSchema` carried a `convexSchemaDefinition` field that was eagerly rebuilt on every `.addTable(...)`. That field was an `O(n²)` allocation for `n` tables, and it forced both the deploy CLI (which only needs `defineSchema(...)`) and the runtime (which only needs the table codec lookup) through the same module — so any runtime function bundle dragged in `convex/server`'s `defineSchema`. Issue 1.
 
   Codegen now scans `confect/tables/*.ts` (every file must default-export a `Table`) and emits two siblings:
-
   - `confect/_generated/schema.ts` — the runtime `DatabaseSchema`, consumed by `_generated/api.ts`. Imports `@confect/server` but never `convex/server`.
   - `confect/_generated/convexSchema.ts` — the Convex deploy `SchemaDefinition`, re-exported one-line from `convex/schema.ts`. Imports `convex/server` but never `@confect/server`.
 
@@ -283,7 +275,6 @@
   This eliminates a class of subtle infelicities: the file basename and the table name can never drift out of sync, cross-table `_id` references are type-constrained against the actual set of declared tables (catching typos at compile time), and ESM cycle hazards for mutual cross-table `Id` references are gone because authoring files no longer transitively import each other.
 
   Codegen now emits two new sets of files alongside `_generated/schema.ts` and `_generated/convexSchema.ts`:
-
   - `confect/_generated/id.ts` — a single `Id` constructor whose argument is type-constrained to the union of your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`.
   - `confect/_generated/tables/<name>.ts` — one thin wrapper per table that binds the unnamed value from `confect/tables/<name>.ts` to its filename. This is what other modules (specs, impls, HTTP handlers) default-import to reach a table's `Doc`, `Fields`, and `tableName`.
 
@@ -300,7 +291,6 @@
   The bound `Table` now exposes `Fields` / `Doc` / `tableDefinition` as lazy getters that compute their value on first access, then replace themselves with a plain non-writable data property so second-and-subsequent accesses are observably indistinguishable from a plain property (and skip all function-call overhead). The result: a function bundle only pays the schema-construction cost for tables it actually touches via `db.table(name)` (which reaches `Fields` through `Document.decode`). The `UnnamedTable` callable no longer exposes `Fields` or `tableDefinition` — read these off the bound `Table` (the generated `_generated/tables/<name>.ts` wrapper already binds the name).
 
   ### Migration
-
   1. Delete your `confect/schema.ts`. Codegen will refuse to run while a stray copy is present.
   2. Rename each `confect/tables/<Name>.ts` to a valid JS identifier in your chosen casing convention (e.g. `confect/tables/notes.ts`). The basename becomes the table name; you no longer pass it as an argument.
   3. Convert each table file to a **default-export-only** unnamed module: drop the name argument from `Table.make`, wrap the field-schema struct in a `() => ...` callback, and switch any `GenericId.GenericId("users")` references to `Id("users")` imported from `../_generated/id`:
@@ -376,7 +366,6 @@
   Since `9.0.0-next.1`, codegen has wrapped every parent leaf that has sibling subdirectory specs in `<parent>.addGroupAt("child", <child>)`. Because `GroupSpec.addGroupAt` is immutable, that produced a fresh object in the assembled tree, while the parent's `*.impl.ts` continued to hold a reference to the original imported leaf. The runtime resolver compared by `===`, so every such impl failed `validateImpl` with "Could not resolve group path for the provided GroupSpec." Child impls happened to work only because `GroupSpec.withName` was secretly mutating its argument in place to keep the child's identity stable — an asymmetry that was load-bearing for one half of the API and broken for the other.
 
   ### What changed
-
   - `@confect/core/Spec` carries a new `readonly paths: ReadonlyMap<GroupSpec.AnyWithProps, string>` field and exposes a chainable `Spec#addPath(group, path)` builder. `add` / `addAt` / `merge` propagate `paths` unchanged; `merge` re-prefixes a node spec's entries with `"node."` to match the merged tree.
   - `@confect/core/GroupSpec.withName` is now pure: it returns a fresh copy when the name differs and no longer rewrites the input in place. No new identity-tracking machinery is introduced.
   - `@confect/server/FunctionImpl.make` and `GroupImpl.make` resolve their group path via `api.spec.paths.get(group)` — an O(1) map lookup instead of a tree walk — and throw a clearer error pointing at `Spec.addPath` when the spec hasn't been registered.
@@ -384,7 +373,6 @@
   - `@confect/cli` codegen emits one `.addPath(<binding>, "<dot.path>")` call per leaf in `_generated/spec.ts` (and `_generated/nodeSpec.ts`) so the imported leaves carry their full paths into the assembled spec value.
 
   ### User-facing impact
-
   - Spec authoring (`*.spec.ts`) and impl authoring (`*.impl.ts`) APIs are unchanged. `FunctionImpl.make(api, spec, name, handler)` and `GroupImpl.make(api, spec)` keep their exact signatures.
   - Generated `_generated/spec.ts` (and `_generated/nodeSpec.ts`) pick up one `.addPath(...)` chain entry per leaf on the next `confect codegen` run. The shape is fully immutable — no module-load mutation, no hidden side effects.
   - Hand-rolled tests that construct a `Spec` and pass it to `Api.make` must now also call `.addPath(spec, "dot.path")` for any group they intend to look up.
@@ -412,7 +400,6 @@
   Splitting impl across colocated `*.impl.ts` files is the vehicle for fixing that. With this change, `confect codegen` emits one `_generated/registeredFunctions/{path}.ts` per group, and each generated `convex/` module imports only its own group's per-group registry — which in turn imports only its own sibling `.impl.ts`. A Convex function's cold-start bundle now scales with its own group's impl rather than with the size of the whole project.
 
   ### Breaking changes
-
   - `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument; the group name is derived from the spec file's path within `confect/`.
   - `FunctionImpl.make(api, groupSpec, fn, handler)` and `GroupImpl.make(api, groupSpec)` now take the imported sibling spec object as their second argument instead of a dot-path string.
   - Every `GroupImpl` pipeline must end with `GroupImpl.finalize`, which only typechecks once every function declared by the spec has a corresponding `FunctionImpl` provided to the group layer. `GroupImpl.finalize` snapshots the names of every registered function onto the produced `Finalized` `GroupImpl` service value, and `confect codegen` reads those names to verify per-function coverage against the spec at runtime.
@@ -421,7 +408,6 @@
   - Every module under `convex/` is re-emitted to import from `_generated/registeredFunctions/{path}` instead of the previous aggregate file. Users who commit `convex/` to source control should expect a full rewrite of that directory on first codegen.
 
   ### Migration
-
   1. For each existing group, create a colocated `confect/{path}.spec.ts` and `confect/{path}.impl.ts` pair (under a subdirectory for nested groups).
      - In each spec, call `GroupSpec.make()` (or `GroupSpec.makeNode()`) without a name and `export default` the result.
      - In each impl, default-import the sibling spec (e.g. `import notes from "./notes.spec"`), pass it to `FunctionImpl.make`/`GroupImpl.make` in place of the previous dot-path string, append `GroupImpl.finalize` to the pipeline, and `export default` the resulting `GroupImpl` layer:
@@ -429,7 +415,7 @@
        export default GroupImpl.make(api, notes).pipe(
          Layer.provide(list),
          Layer.provide(insert),
-         GroupImpl.finalize
+         GroupImpl.finalize,
        );
        ```
   2. Delete root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, `confect/nodeImpl.ts`, and any parent aggregator spec/impl files. (`confect codegen` will also delete any of these it finds, plus the stale `_generated/registeredFunctions.ts` and `_generated/nodeRegisteredFunctions.ts`, so this step can be skipped.)
@@ -467,7 +453,7 @@
 
   export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
     "NoteNotFound",
-    { noteId: GenericId.GenericId("notes") }
+    { noteId: GenericId.GenericId("notes") },
   ) {}
 
   export const notes = GroupSpec.make("notes").addFunction(
@@ -476,7 +462,7 @@
       args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
       returns: Notes.Doc,
       error: NoteNotFound,
-    })
+    }),
   );
   ```
 
@@ -496,7 +482,7 @@
         .table("notes")
         .get(noteId)
         .pipe(Effect.mapError(() => new NoteNotFound({ noteId })));
-    })
+    }),
   );
   ```
 
@@ -568,7 +554,6 @@
   Unspecified failures continue to reject the promise.
 
   ### Migration
-
   - For each `useQuery` call site, replace `result === undefined` checks and direct property access with `QueryResult.match` (or the lower-level `QueryResult.isLoading`/`isSuccess`/`isFailure` predicates).
   - For each `useMutation`/`useAction` call site whose ref now declares an `error` schema, unwrap the resolved `Either` (e.g. with `Either.match`); call sites against refs without an `error` schema need no change.
 

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 445ea9b: Loosen and align dependency ranges across all packages:
-
   - The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
   - `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
   - `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
@@ -25,7 +24,6 @@
   ### Filesystem-driven groups
 
   Your API is now authored as colocated `*.spec.ts`/`*.impl.ts` pairs, one pair per group, and **the file's path within `confect/` is the group's name** (its stem for top-level groups, the dot-joined directory path for nested groups). `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument.
-
   - Each `*.spec.ts` `export default`s its `GroupSpec` (named co-exports like error classes are still allowed).
   - Each `*.impl.ts` default-imports its sibling spec, passes it to `FunctionImpl.make` / `GroupImpl.make`, and ends the layer pipeline with `GroupImpl.finalize`—a compile-time completeness check that only typechecks once every function the spec declares has a `FunctionImpl` provided.
   - The root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, and `confect/nodeImpl.ts` files are gone, along with `Impl.make` and `Impl.finalize`. `confect codegen` deletes any of these (and the stale aggregate `_generated/registeredFunctions.ts` / `_generated/nodeRegisteredFunctions.ts`) on upgrade.
@@ -45,12 +43,11 @@
     Schema.Struct({
       userId: Schema.optional(Id("users")),
       text: Schema.String,
-    })
+    }),
   );
   ```
 
   Codegen emits, alongside it:
-
   - `_generated/schema.ts`—the runtime `DatabaseSchema`. Never imports `convex/server`, so a runtime cold start no longer evaluates `defineSchema(...)`.
   - `_generated/convexSchema.ts`—the Convex deploy `SchemaDefinition`, re-exported from `convex/schema.ts`.
   - `_generated/id.ts`—a type-safe `Id` constructor whose argument is constrained to your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`; cross-table `_id` typos are now caught at compile time.
@@ -70,7 +67,7 @@
       name: "list",
       args: Schema.Struct({}),
       returns: Schema.Array(Notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -89,7 +86,7 @@
       name: "list",
       args: () => Schema.Struct({}),
       returns: () => Schema.Array(notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -100,14 +97,13 @@
   const list = FunctionImpl.make(databaseSchema, notes, "list", handler);
   export default GroupImpl.make(databaseSchema, notes).pipe(
     Layer.provide(list),
-    GroupImpl.finalize
+    GroupImpl.finalize,
   );
   ```
 
   ### Node functions are first-class
 
   A group's runtime is now declared solely by its spec—`GroupSpec.makeNode()` for a Node action group, `GroupSpec.make()` otherwise—mirroring vanilla Convex's per-file `"use node"` directive. The separate `node` namespace is gone: Node specs/impls are ordinary colocated pairs that can live anywhere in `confect/`, and codegen emits the `"use node"` directive based on the spec.
-
   - A Node group at `confect/email.spec.ts` is now reached at `refs.public.email.send` instead of `refs.public.node.email.send`.
   - `@confect/core` removes `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec` / `Spec.isNodeSpec`; `Spec.make()` is a single mixed-runtime container and `Refs.make(spec)` takes one argument. `GroupSpec.makeNode()`, `FunctionSpec.publicNodeAction()` / `internalNodeAction()` are unchanged.
 
@@ -124,7 +120,6 @@
   The codegen bundler now uses [`bundle-require`](https://github.com/egoist/bundle-require), so impls may import third-party packages and use `tsconfig.json` `paths` aliases (`~/*`, `@/*`, …) for their own source. A parent `confect/{path}.spec.ts` may now declare functions alongside a sibling `confect/{path}/` subdirectory of further specs, and codegen reports a clear error on a name collision between the two.
 
   ### Migration
-
   1. **Tables.** Delete `confect/schema.ts`. Rename each table file to a valid JS identifier (e.g. `confect/tables/notes.ts`); the basename becomes the table name. Drop the name argument from `Table.make`, wrap the field struct in `() =>`, and replace `GenericId.GenericId("x")` with `Id("x")` from `_generated/id`. If you read `table.name` off a bound table, rename it to `table.tableName`.
   2. **Specs.** Split each group into a colocated `*.spec.ts` that `export default`s `GroupSpec.make()` (no name). Wrap every `args`/`returns`/`error` in `() =>`. Import a table's `Doc`/`Fields` from its wrapper, `import notes from "./_generated/tables/notes"`.
   3. **Impls.** In each `*.impl.ts`, default-import the sibling spec, import `databaseSchema` from `_generated/schema`, pass it to `FunctionImpl.make` / `GroupImpl.make` in place of `api`, end the pipeline with `GroupImpl.finalize`, and `export default` it. Delete the root `confect/spec.ts`, `impl.ts`, `nodeSpec.ts`, and `nodeImpl.ts` (codegen will also remove them).
@@ -280,7 +275,7 @@
 
   export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
     "NoteNotFound",
-    { noteId: GenericId.GenericId("notes") }
+    { noteId: GenericId.GenericId("notes") },
   ) {}
 
   export const notes = GroupSpec.make("notes").addFunction(
@@ -289,7 +284,7 @@
       args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
       returns: Notes.Doc,
       error: NoteNotFound,
-    })
+    }),
   );
   ```
 
@@ -309,7 +304,7 @@
         .table("notes")
         .get(noteId)
         .pipe(Effect.mapError(() => new NoteNotFound({ noteId })));
-    })
+    }),
   );
   ```
 
@@ -381,7 +376,6 @@
   Unspecified failures continue to reject the promise.
 
   ### Migration
-
   - For each `useQuery` call site, replace `result === undefined` checks and direct property access with `QueryResult.match` (or the lower-level `QueryResult.isLoading`/`isSuccess`/`isFailure` predicates).
   - For each `useMutation`/`useAction` call site whose ref now declares an `error` schema, unwrap the resolved `Either` (e.g. with `Either.match`); call sites against refs without an `error` schema need no change.
 
@@ -410,7 +404,6 @@
 - 2c4b0c9: Fix `HttpClient` to only accept public `Ref`s
 
   `HttpClient` query, mutation, and action methods now correctly reject internal `Ref`s at the type level, matching the runtime behavior of Convex browser clients which can only call public functions.
-
   - @confect/core@5.0.0
 
 ## 4.0.0

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 445ea9b: Loosen and align dependency ranges across all packages:
-
   - The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
   - `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
   - `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
@@ -25,7 +24,6 @@
   ### Filesystem-driven groups
 
   Your API is now authored as colocated `*.spec.ts`/`*.impl.ts` pairs, one pair per group, and **the file's path within `confect/` is the group's name** (its stem for top-level groups, the dot-joined directory path for nested groups). `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument.
-
   - Each `*.spec.ts` `export default`s its `GroupSpec` (named co-exports like error classes are still allowed).
   - Each `*.impl.ts` default-imports its sibling spec, passes it to `FunctionImpl.make` / `GroupImpl.make`, and ends the layer pipeline with `GroupImpl.finalize`—a compile-time completeness check that only typechecks once every function the spec declares has a `FunctionImpl` provided.
   - The root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, and `confect/nodeImpl.ts` files are gone, along with `Impl.make` and `Impl.finalize`. `confect codegen` deletes any of these (and the stale aggregate `_generated/registeredFunctions.ts` / `_generated/nodeRegisteredFunctions.ts`) on upgrade.
@@ -45,12 +43,11 @@
     Schema.Struct({
       userId: Schema.optional(Id("users")),
       text: Schema.String,
-    })
+    }),
   );
   ```
 
   Codegen emits, alongside it:
-
   - `_generated/schema.ts`—the runtime `DatabaseSchema`. Never imports `convex/server`, so a runtime cold start no longer evaluates `defineSchema(...)`.
   - `_generated/convexSchema.ts`—the Convex deploy `SchemaDefinition`, re-exported from `convex/schema.ts`.
   - `_generated/id.ts`—a type-safe `Id` constructor whose argument is constrained to your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`; cross-table `_id` typos are now caught at compile time.
@@ -70,7 +67,7 @@
       name: "list",
       args: Schema.Struct({}),
       returns: Schema.Array(Notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -89,7 +86,7 @@
       name: "list",
       args: () => Schema.Struct({}),
       returns: () => Schema.Array(notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -100,14 +97,13 @@
   const list = FunctionImpl.make(databaseSchema, notes, "list", handler);
   export default GroupImpl.make(databaseSchema, notes).pipe(
     Layer.provide(list),
-    GroupImpl.finalize
+    GroupImpl.finalize,
   );
   ```
 
   ### Node functions are first-class
 
   A group's runtime is now declared solely by its spec—`GroupSpec.makeNode()` for a Node action group, `GroupSpec.make()` otherwise—mirroring vanilla Convex's per-file `"use node"` directive. The separate `node` namespace is gone: Node specs/impls are ordinary colocated pairs that can live anywhere in `confect/`, and codegen emits the `"use node"` directive based on the spec.
-
   - A Node group at `confect/email.spec.ts` is now reached at `refs.public.email.send` instead of `refs.public.node.email.send`.
   - `@confect/core` removes `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec` / `Spec.isNodeSpec`; `Spec.make()` is a single mixed-runtime container and `Refs.make(spec)` takes one argument. `GroupSpec.makeNode()`, `FunctionSpec.publicNodeAction()` / `internalNodeAction()` are unchanged.
 
@@ -124,7 +120,6 @@
   The codegen bundler now uses [`bundle-require`](https://github.com/egoist/bundle-require), so impls may import third-party packages and use `tsconfig.json` `paths` aliases (`~/*`, `@/*`, …) for their own source. A parent `confect/{path}.spec.ts` may now declare functions alongside a sibling `confect/{path}/` subdirectory of further specs, and codegen reports a clear error on a name collision between the two.
 
   ### Migration
-
   1. **Tables.** Delete `confect/schema.ts`. Rename each table file to a valid JS identifier (e.g. `confect/tables/notes.ts`); the basename becomes the table name. Drop the name argument from `Table.make`, wrap the field struct in `() =>`, and replace `GenericId.GenericId("x")` with `Id("x")` from `_generated/id`. If you read `table.name` off a bound table, rename it to `table.tableName`.
   2. **Specs.** Split each group into a colocated `*.spec.ts` that `export default`s `GroupSpec.make()` (no name). Wrap every `args`/`returns`/`error` in `() =>`. Import a table's `Doc`/`Fields` from its wrapper, `import notes from "./_generated/tables/notes"`.
   3. **Impls.** In each `*.impl.ts`, default-import the sibling spec, import `databaseSchema` from `_generated/schema`, pass it to `FunctionImpl.make` / `GroupImpl.make` in place of `api`, end the pipeline with `GroupImpl.finalize`, and `export default` it. Delete the root `confect/spec.ts`, `impl.ts`, `nodeSpec.ts`, and `nodeImpl.ts` (codegen will also remove them).
@@ -288,7 +283,7 @@
 
   export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
     "NoteNotFound",
-    { noteId: GenericId.GenericId("notes") }
+    { noteId: GenericId.GenericId("notes") },
   ) {}
 
   export const notes = GroupSpec.make("notes").addFunction(
@@ -297,7 +292,7 @@
       args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
       returns: Notes.Doc,
       error: NoteNotFound,
-    })
+    }),
   );
   ```
 
@@ -317,7 +312,7 @@
         .table("notes")
         .get(noteId)
         .pipe(Effect.mapError(() => new NoteNotFound({ noteId })));
-    })
+    }),
   );
   ```
 
@@ -389,7 +384,6 @@
   Unspecified failures continue to reject the promise.
 
   ### Migration
-
   - For each `useQuery` call site, replace `result === undefined` checks and direct property access with `QueryResult.match` (or the lower-level `QueryResult.isLoading`/`isSuccess`/`isFailure` predicates).
   - For each `useMutation`/`useAction` call site whose ref now declares an `error` schema, unwrap the resolved `Either` (e.g. with `Either.match`); call sites against refs without an `error` schema need no change.
 

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 445ea9b: Loosen and align dependency ranges across all packages:
-
   - The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
   - `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
   - `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
@@ -25,7 +24,6 @@
   ### Filesystem-driven groups
 
   Your API is now authored as colocated `*.spec.ts`/`*.impl.ts` pairs, one pair per group, and **the file's path within `confect/` is the group's name** (its stem for top-level groups, the dot-joined directory path for nested groups). `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument.
-
   - Each `*.spec.ts` `export default`s its `GroupSpec` (named co-exports like error classes are still allowed).
   - Each `*.impl.ts` default-imports its sibling spec, passes it to `FunctionImpl.make` / `GroupImpl.make`, and ends the layer pipeline with `GroupImpl.finalize`—a compile-time completeness check that only typechecks once every function the spec declares has a `FunctionImpl` provided.
   - The root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, and `confect/nodeImpl.ts` files are gone, along with `Impl.make` and `Impl.finalize`. `confect codegen` deletes any of these (and the stale aggregate `_generated/registeredFunctions.ts` / `_generated/nodeRegisteredFunctions.ts`) on upgrade.
@@ -45,12 +43,11 @@
     Schema.Struct({
       userId: Schema.optional(Id("users")),
       text: Schema.String,
-    })
+    }),
   );
   ```
 
   Codegen emits, alongside it:
-
   - `_generated/schema.ts`—the runtime `DatabaseSchema`. Never imports `convex/server`, so a runtime cold start no longer evaluates `defineSchema(...)`.
   - `_generated/convexSchema.ts`—the Convex deploy `SchemaDefinition`, re-exported from `convex/schema.ts`.
   - `_generated/id.ts`—a type-safe `Id` constructor whose argument is constrained to your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`; cross-table `_id` typos are now caught at compile time.
@@ -70,7 +67,7 @@
       name: "list",
       args: Schema.Struct({}),
       returns: Schema.Array(Notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -89,7 +86,7 @@
       name: "list",
       args: () => Schema.Struct({}),
       returns: () => Schema.Array(notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -100,14 +97,13 @@
   const list = FunctionImpl.make(databaseSchema, notes, "list", handler);
   export default GroupImpl.make(databaseSchema, notes).pipe(
     Layer.provide(list),
-    GroupImpl.finalize
+    GroupImpl.finalize,
   );
   ```
 
   ### Node functions are first-class
 
   A group's runtime is now declared solely by its spec—`GroupSpec.makeNode()` for a Node action group, `GroupSpec.make()` otherwise—mirroring vanilla Convex's per-file `"use node"` directive. The separate `node` namespace is gone: Node specs/impls are ordinary colocated pairs that can live anywhere in `confect/`, and codegen emits the `"use node"` directive based on the spec.
-
   - A Node group at `confect/email.spec.ts` is now reached at `refs.public.email.send` instead of `refs.public.node.email.send`.
   - `@confect/core` removes `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec` / `Spec.isNodeSpec`; `Spec.make()` is a single mixed-runtime container and `Refs.make(spec)` takes one argument. `GroupSpec.makeNode()`, `FunctionSpec.publicNodeAction()` / `internalNodeAction()` are unchanged.
 
@@ -124,7 +120,6 @@
   The codegen bundler now uses [`bundle-require`](https://github.com/egoist/bundle-require), so impls may import third-party packages and use `tsconfig.json` `paths` aliases (`~/*`, `@/*`, …) for their own source. A parent `confect/{path}.spec.ts` may now declare functions alongside a sibling `confect/{path}/` subdirectory of further specs, and codegen reports a clear error on a name collision between the two.
 
   ### Migration
-
   1. **Tables.** Delete `confect/schema.ts`. Rename each table file to a valid JS identifier (e.g. `confect/tables/notes.ts`); the basename becomes the table name. Drop the name argument from `Table.make`, wrap the field struct in `() =>`, and replace `GenericId.GenericId("x")` with `Id("x")` from `_generated/id`. If you read `table.name` off a bound table, rename it to `table.tableName`.
   2. **Specs.** Split each group into a colocated `*.spec.ts` that `export default`s `GroupSpec.make()` (no name). Wrap every `args`/`returns`/`error` in `() =>`. Import a table's `Doc`/`Fields` from its wrapper, `import notes from "./_generated/tables/notes"`.
   3. **Impls.** In each `*.impl.ts`, default-import the sibling spec, import `databaseSchema` from `_generated/schema`, pass it to `FunctionImpl.make` / `GroupImpl.make` in place of `api`, end the pipeline with `GroupImpl.finalize`, and `export default` it. Delete the root `confect/spec.ts`, `impl.ts`, `nodeSpec.ts`, and `nodeImpl.ts` (codegen will also remove them).
@@ -167,13 +162,11 @@
   The `node` namespace existed only because the pre-v9 architecture aggregated every function's impl into one module that all generated `convex/` modules imported; Node functions had to be quarantined into a separate spec/impl/registry tree so Convex-runtime functions wouldn't transitively import Node-only code. v9's per-group isolation removed that constraint, so the namespace was no longer load-bearing — only ergonomic overhead that diverged from vanilla Convex (which identifies Node modules per-file, with no directory requirement).
 
   ### Breaking changes
-
   - **API namespace removed.** A Node group at `confect/email.spec.ts` is now referenced as `refs.public.email.send` instead of `refs.public.node.email.send`. Node groups are ordinary groups in the refs tree, nesting preserved like any other group.
   - **Generated layout changed.** Node modules are emitted at `convex/<path>.ts` (carrying `"use node"`) instead of `convex/node/<path>.ts`, and their registries at `confect/_generated/registeredFunctions/<path>.ts`. The single assembled `confect/_generated/spec.ts` now contains every group regardless of runtime; `confect/_generated/nodeSpec.ts` is no longer generated (codegen deletes any stale copy on upgrade).
   - **`@confect/core` API.** Removed `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec`/`Spec.isNodeSpec`. `Spec` is now a single mixed-runtime container (`Spec.make()` accepts groups of any runtime). `Refs.make(spec)` takes a single argument (the unified spec) instead of `(convexSpec, nodeSpec)`. `GroupSpec.makeNode()`/`makeNodeAt()` and `FunctionSpec.publicNodeAction()`/`internalNodeAction()` are unchanged; `GroupSpec` subgroups may now be of any runtime (a group is just a namespace for its children).
 
   ### Migration
-
   1. Move any `confect/node/<path>.spec.ts`/`.impl.ts` files to wherever you want them under `confect/` (e.g. `confect/<path>.spec.ts`); the `node/` directory has no special meaning anymore. Their specs already use `GroupSpec.makeNode()`, so no spec-body change is needed — only fix the impl's relative import of `_generated/schema` if its depth changed.
   2. Update call sites to drop the `node` segment: `refs.public.node.<group>.<fn>` → `refs.public.<group>.<fn>`.
   3. Replace `Refs.make(spec, nodeSpec)` with `Refs.make(spec)` (codegen does this for `_generated/refs.ts` automatically).
@@ -283,7 +276,6 @@
   Previously, `confect/schema.ts` was user-authored and `DatabaseSchema` carried a `convexSchemaDefinition` field that was eagerly rebuilt on every `.addTable(...)`. That field was an `O(n²)` allocation for `n` tables, and it forced both the deploy CLI (which only needs `defineSchema(...)`) and the runtime (which only needs the table codec lookup) through the same module — so any runtime function bundle dragged in `convex/server`'s `defineSchema`. Issue 1.
 
   Codegen now scans `confect/tables/*.ts` (every file must default-export a `Table`) and emits two siblings:
-
   - `confect/_generated/schema.ts` — the runtime `DatabaseSchema`, consumed by `_generated/api.ts`. Imports `@confect/server` but never `convex/server`.
   - `confect/_generated/convexSchema.ts` — the Convex deploy `SchemaDefinition`, re-exported one-line from `convex/schema.ts`. Imports `convex/server` but never `@confect/server`.
 
@@ -296,7 +288,6 @@
   This eliminates a class of subtle infelicities: the file basename and the table name can never drift out of sync, cross-table `_id` references are type-constrained against the actual set of declared tables (catching typos at compile time), and ESM cycle hazards for mutual cross-table `Id` references are gone because authoring files no longer transitively import each other.
 
   Codegen now emits two new sets of files alongside `_generated/schema.ts` and `_generated/convexSchema.ts`:
-
   - `confect/_generated/id.ts` — a single `Id` constructor whose argument is type-constrained to the union of your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`.
   - `confect/_generated/tables/<name>.ts` — one thin wrapper per table that binds the unnamed value from `confect/tables/<name>.ts` to its filename. This is what other modules (specs, impls, HTTP handlers) default-import to reach a table's `Doc`, `Fields`, and `tableName`.
 
@@ -313,7 +304,6 @@
   The bound `Table` now exposes `Fields` / `Doc` / `tableDefinition` as lazy getters that compute their value on first access, then replace themselves with a plain non-writable data property so second-and-subsequent accesses are observably indistinguishable from a plain property (and skip all function-call overhead). The result: a function bundle only pays the schema-construction cost for tables it actually touches via `db.table(name)` (which reaches `Fields` through `Document.decode`). The `UnnamedTable` callable no longer exposes `Fields` or `tableDefinition` — read these off the bound `Table` (the generated `_generated/tables/<name>.ts` wrapper already binds the name).
 
   ### Migration
-
   1. Delete your `confect/schema.ts`. Codegen will refuse to run while a stray copy is present.
   2. Rename each `confect/tables/<Name>.ts` to a valid JS identifier in your chosen casing convention (e.g. `confect/tables/notes.ts`). The basename becomes the table name; you no longer pass it as an argument.
   3. Convert each table file to a **default-export-only** unnamed module: drop the name argument from `Table.make`, wrap the field-schema struct in a `() => ...` callback, and switch any `GenericId.GenericId("users")` references to `Id("users")` imported from `../_generated/id`:
@@ -403,7 +393,6 @@
   Since `9.0.0-next.1`, codegen has wrapped every parent leaf that has sibling subdirectory specs in `<parent>.addGroupAt("child", <child>)`. Because `GroupSpec.addGroupAt` is immutable, that produced a fresh object in the assembled tree, while the parent's `*.impl.ts` continued to hold a reference to the original imported leaf. The runtime resolver compared by `===`, so every such impl failed `validateImpl` with "Could not resolve group path for the provided GroupSpec." Child impls happened to work only because `GroupSpec.withName` was secretly mutating its argument in place to keep the child's identity stable — an asymmetry that was load-bearing for one half of the API and broken for the other.
 
   ### What changed
-
   - `@confect/core/Spec` carries a new `readonly paths: ReadonlyMap<GroupSpec.AnyWithProps, string>` field and exposes a chainable `Spec#addPath(group, path)` builder. `add` / `addAt` / `merge` propagate `paths` unchanged; `merge` re-prefixes a node spec's entries with `"node."` to match the merged tree.
   - `@confect/core/GroupSpec.withName` is now pure: it returns a fresh copy when the name differs and no longer rewrites the input in place. No new identity-tracking machinery is introduced.
   - `@confect/server/FunctionImpl.make` and `GroupImpl.make` resolve their group path via `api.spec.paths.get(group)` — an O(1) map lookup instead of a tree walk — and throw a clearer error pointing at `Spec.addPath` when the spec hasn't been registered.
@@ -411,7 +400,6 @@
   - `@confect/cli` codegen emits one `.addPath(<binding>, "<dot.path>")` call per leaf in `_generated/spec.ts` (and `_generated/nodeSpec.ts`) so the imported leaves carry their full paths into the assembled spec value.
 
   ### User-facing impact
-
   - Spec authoring (`*.spec.ts`) and impl authoring (`*.impl.ts`) APIs are unchanged. `FunctionImpl.make(api, spec, name, handler)` and `GroupImpl.make(api, spec)` keep their exact signatures.
   - Generated `_generated/spec.ts` (and `_generated/nodeSpec.ts`) pick up one `.addPath(...)` chain entry per leaf on the next `confect codegen` run. The shape is fully immutable — no module-load mutation, no hidden side effects.
   - Hand-rolled tests that construct a `Spec` and pass it to `Api.make` must now also call `.addPath(spec, "dot.path")` for any group they intend to look up.
@@ -450,7 +438,6 @@
   Splitting impl across colocated `*.impl.ts` files is the vehicle for fixing that. With this change, `confect codegen` emits one `_generated/registeredFunctions/{path}.ts` per group, and each generated `convex/` module imports only its own group's per-group registry — which in turn imports only its own sibling `.impl.ts`. A Convex function's cold-start bundle now scales with its own group's impl rather than with the size of the whole project.
 
   ### Breaking changes
-
   - `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument; the group name is derived from the spec file's path within `confect/`.
   - `FunctionImpl.make(api, groupSpec, fn, handler)` and `GroupImpl.make(api, groupSpec)` now take the imported sibling spec object as their second argument instead of a dot-path string.
   - Every `GroupImpl` pipeline must end with `GroupImpl.finalize`, which only typechecks once every function declared by the spec has a corresponding `FunctionImpl` provided to the group layer. `GroupImpl.finalize` snapshots the names of every registered function onto the produced `Finalized` `GroupImpl` service value, and `confect codegen` reads those names to verify per-function coverage against the spec at runtime.
@@ -459,7 +446,6 @@
   - Every module under `convex/` is re-emitted to import from `_generated/registeredFunctions/{path}` instead of the previous aggregate file. Users who commit `convex/` to source control should expect a full rewrite of that directory on first codegen.
 
   ### Migration
-
   1. For each existing group, create a colocated `confect/{path}.spec.ts` and `confect/{path}.impl.ts` pair (under a subdirectory for nested groups).
      - In each spec, call `GroupSpec.make()` (or `GroupSpec.makeNode()`) without a name and `export default` the result.
      - In each impl, default-import the sibling spec (e.g. `import notes from "./notes.spec"`), pass it to `FunctionImpl.make`/`GroupImpl.make` in place of the previous dot-path string, append `GroupImpl.finalize` to the pipeline, and `export default` the resulting `GroupImpl` layer:
@@ -467,7 +453,7 @@
        export default GroupImpl.make(api, notes).pipe(
          Layer.provide(list),
          Layer.provide(insert),
-         GroupImpl.finalize
+         GroupImpl.finalize,
        );
        ```
   2. Delete root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, `confect/nodeImpl.ts`, and any parent aggregator spec/impl files. (`confect codegen` will also delete any of these it finds, plus the stale `_generated/registeredFunctions.ts` and `_generated/nodeRegisteredFunctions.ts`, so this step can be skipped.)
@@ -525,7 +511,7 @@
 
   export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
     "NoteNotFound",
-    { noteId: GenericId.GenericId("notes") }
+    { noteId: GenericId.GenericId("notes") },
   ) {}
 
   export const notes = GroupSpec.make("notes").addFunction(
@@ -534,7 +520,7 @@
       args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
       returns: Notes.Doc,
       error: NoteNotFound,
-    })
+    }),
   );
   ```
 
@@ -554,7 +540,7 @@
         .table("notes")
         .get(noteId)
         .pipe(Effect.mapError(() => new NoteNotFound({ noteId })));
-    })
+    }),
   );
   ```
 
@@ -626,7 +612,6 @@
   Unspecified failures continue to reject the promise.
 
   ### Migration
-
   - For each `useQuery` call site, replace `result === undefined` checks and direct property access with `QueryResult.match` (or the lower-level `QueryResult.isLoading`/`isSuccess`/`isFailure` predicates).
   - For each `useMutation`/`useAction` call site whose ref now declares an `error` schema, unwrap the resolved `Either` (e.g. with `Either.match`); call sites against refs without an `error` schema need no change.
 

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - 445ea9b: Loosen and align dependency ranges across all packages:
-
   - The `convex` peer dependency is now `^1.32.0` in every package (previously pinned exactly to `1.39.1`, or `^1.30.0` in `@confect/react`). The range is validated against convex 1.32.0 through 1.40.0.
   - `@confect/server`'s `@effect/platform-node` peer dependency is now optional — it is only needed when using the `@confect/server/node` entrypoint.
   - `@confect/cli` now uses caret ranges for its `@effect/platform` and `@effect/platform-node` dependencies so they can deduplicate with the versions resolved for `@confect/server`, and no longer declares an unused direct dependency on `@effect/platform-node-shared`.
@@ -26,7 +25,6 @@
   ### Filesystem-driven groups
 
   Your API is now authored as colocated `*.spec.ts`/`*.impl.ts` pairs, one pair per group, and **the file's path within `confect/` is the group's name** (its stem for top-level groups, the dot-joined directory path for nested groups). `GroupSpec.make()` and `GroupSpec.makeNode()` no longer take a name argument.
-
   - Each `*.spec.ts` `export default`s its `GroupSpec` (named co-exports like error classes are still allowed).
   - Each `*.impl.ts` default-imports its sibling spec, passes it to `FunctionImpl.make` / `GroupImpl.make`, and ends the layer pipeline with `GroupImpl.finalize`—a compile-time completeness check that only typechecks once every function the spec declares has a `FunctionImpl` provided.
   - The root `confect/spec.ts`, `confect/impl.ts`, `confect/nodeSpec.ts`, and `confect/nodeImpl.ts` files are gone, along with `Impl.make` and `Impl.finalize`. `confect codegen` deletes any of these (and the stale aggregate `_generated/registeredFunctions.ts` / `_generated/nodeRegisteredFunctions.ts`) on upgrade.
@@ -46,12 +44,11 @@
     Schema.Struct({
       userId: Schema.optional(Id("users")),
       text: Schema.String,
-    })
+    }),
   );
   ```
 
   Codegen emits, alongside it:
-
   - `_generated/schema.ts`—the runtime `DatabaseSchema`. Never imports `convex/server`, so a runtime cold start no longer evaluates `defineSchema(...)`.
   - `_generated/convexSchema.ts`—the Convex deploy `SchemaDefinition`, re-exported from `convex/schema.ts`.
   - `_generated/id.ts`—a type-safe `Id` constructor whose argument is constrained to your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`; cross-table `_id` typos are now caught at compile time.
@@ -71,7 +68,7 @@
       name: "list",
       args: Schema.Struct({}),
       returns: Schema.Array(Notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -90,7 +87,7 @@
       name: "list",
       args: () => Schema.Struct({}),
       returns: () => Schema.Array(notes.Doc),
-    })
+    }),
   );
   ```
 
@@ -101,14 +98,13 @@
   const list = FunctionImpl.make(databaseSchema, notes, "list", handler);
   export default GroupImpl.make(databaseSchema, notes).pipe(
     Layer.provide(list),
-    GroupImpl.finalize
+    GroupImpl.finalize,
   );
   ```
 
   ### Node functions are first-class
 
   A group's runtime is now declared solely by its spec—`GroupSpec.makeNode()` for a Node action group, `GroupSpec.make()` otherwise—mirroring vanilla Convex's per-file `"use node"` directive. The separate `node` namespace is gone: Node specs/impls are ordinary colocated pairs that can live anywhere in `confect/`, and codegen emits the `"use node"` directive based on the spec.
-
   - A Node group at `confect/email.spec.ts` is now reached at `refs.public.email.send` instead of `refs.public.node.email.send`.
   - `@confect/core` removes `Spec.makeNode`, `Spec.merge`, and `Spec.isConvexSpec` / `Spec.isNodeSpec`; `Spec.make()` is a single mixed-runtime container and `Refs.make(spec)` takes one argument. `GroupSpec.makeNode()`, `FunctionSpec.publicNodeAction()` / `internalNodeAction()` are unchanged.
 
@@ -125,7 +121,6 @@
   The codegen bundler now uses [`bundle-require`](https://github.com/egoist/bundle-require), so impls may import third-party packages and use `tsconfig.json` `paths` aliases (`~/*`, `@/*`, …) for their own source. A parent `confect/{path}.spec.ts` may now declare functions alongside a sibling `confect/{path}/` subdirectory of further specs, and codegen reports a clear error on a name collision between the two.
 
   ### Migration
-
   1. **Tables.** Delete `confect/schema.ts`. Rename each table file to a valid JS identifier (e.g. `confect/tables/notes.ts`); the basename becomes the table name. Drop the name argument from `Table.make`, wrap the field struct in `() =>`, and replace `GenericId.GenericId("x")` with `Id("x")` from `_generated/id`. If you read `table.name` off a bound table, rename it to `table.tableName`.
   2. **Specs.** Split each group into a colocated `*.spec.ts` that `export default`s `GroupSpec.make()` (no name). Wrap every `args`/`returns`/`error` in `() =>`. Import a table's `Doc`/`Fields` from its wrapper, `import notes from "./_generated/tables/notes"`.
   3. **Impls.** In each `*.impl.ts`, default-import the sibling spec, import `databaseSchema` from `_generated/schema`, pass it to `FunctionImpl.make` / `GroupImpl.make` in place of `api`, end the pipeline with `GroupImpl.finalize`, and `export default` it. Delete the root `confect/spec.ts`, `impl.ts`, `nodeSpec.ts`, and `nodeImpl.ts` (codegen will also remove them).
@@ -213,7 +208,6 @@
   Previously, `confect/schema.ts` was user-authored and `DatabaseSchema` carried a `convexSchemaDefinition` field that was eagerly rebuilt on every `.addTable(...)`. That field was an `O(n²)` allocation for `n` tables, and it forced both the deploy CLI (which only needs `defineSchema(...)`) and the runtime (which only needs the table codec lookup) through the same module — so any runtime function bundle dragged in `convex/server`'s `defineSchema`. Issue 1.
 
   Codegen now scans `confect/tables/*.ts` (every file must default-export a `Table`) and emits two siblings:
-
   - `confect/_generated/schema.ts` — the runtime `DatabaseSchema`, consumed by `_generated/api.ts`. Imports `@confect/server` but never `convex/server`.
   - `confect/_generated/convexSchema.ts` — the Convex deploy `SchemaDefinition`, re-exported one-line from `convex/schema.ts`. Imports `convex/server` but never `@confect/server`.
 
@@ -226,7 +220,6 @@
   This eliminates a class of subtle infelicities: the file basename and the table name can never drift out of sync, cross-table `_id` references are type-constrained against the actual set of declared tables (catching typos at compile time), and ESM cycle hazards for mutual cross-table `Id` references are gone because authoring files no longer transitively import each other.
 
   Codegen now emits two new sets of files alongside `_generated/schema.ts` and `_generated/convexSchema.ts`:
-
   - `confect/_generated/id.ts` — a single `Id` constructor whose argument is type-constrained to the union of your table names. Use `Id("notes")` everywhere you previously wrote `GenericId.GenericId("notes")`.
   - `confect/_generated/tables/<name>.ts` — one thin wrapper per table that binds the unnamed value from `confect/tables/<name>.ts` to its filename. This is what other modules (specs, impls, HTTP handlers) default-import to reach a table's `Doc`, `Fields`, and `tableName`.
 
@@ -243,7 +236,6 @@
   The bound `Table` now exposes `Fields` / `Doc` / `tableDefinition` as lazy getters that compute their value on first access, then replace themselves with a plain non-writable data property so second-and-subsequent accesses are observably indistinguishable from a plain property (and skip all function-call overhead). The result: a function bundle only pays the schema-construction cost for tables it actually touches via `db.table(name)` (which reaches `Fields` through `Document.decode`). The `UnnamedTable` callable no longer exposes `Fields` or `tableDefinition` — read these off the bound `Table` (the generated `_generated/tables/<name>.ts` wrapper already binds the name).
 
   ### Migration
-
   1. Delete your `confect/schema.ts`. Codegen will refuse to run while a stray copy is present.
   2. Rename each `confect/tables/<Name>.ts` to a valid JS identifier in your chosen casing convention (e.g. `confect/tables/notes.ts`). The basename becomes the table name; you no longer pass it as an argument.
   3. Convert each table file to a **default-export-only** unnamed module: drop the name argument from `Table.make`, wrap the field-schema struct in a `() => ...` callback, and switch any `GenericId.GenericId("users")` references to `Id("users")` imported from `../_generated/id`:
@@ -395,7 +387,7 @@
 
   export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
     "NoteNotFound",
-    { noteId: GenericId.GenericId("notes") }
+    { noteId: GenericId.GenericId("notes") },
   ) {}
 
   export const notes = GroupSpec.make("notes").addFunction(
@@ -404,7 +396,7 @@
       args: Schema.Struct({ noteId: GenericId.GenericId("notes") }),
       returns: Notes.Doc,
       error: NoteNotFound,
-    })
+    }),
   );
   ```
 
@@ -424,7 +416,7 @@
         .table("notes")
         .get(noteId)
         .pipe(Effect.mapError(() => new NoteNotFound({ noteId })));
-    })
+    }),
   );
   ```
 
@@ -496,7 +488,6 @@
   Unspecified failures continue to reject the promise.
 
   ### Migration
-
   - For each `useQuery` call site, replace `result === undefined` checks and direct property access with `QueryResult.match` (or the lower-level `QueryResult.isLoading`/`isSuccess`/`isFailure` predicates).
   - For each `useMutation`/`useAction` call site whose ref now declares an `error` schema, unwrap the resolved `Either` (e.g. with `Either.match`); call sites against refs without an `error` schema need no change.
 


### PR DESCRIPTION
## Summary

Updates all documentation code examples to use explicit subpath imports from the Effect library (e.g., `import * as Effect from "effect/Effect"`) instead of importing from the main `"effect"` entry point. This aligns with Effect's recommended import style and provides better tree-shaking and clarity about which modules are being used.

## Changes

- **WebSocket client docs**: Updated imports for `Effect`, `Console`, and `Stream` to use subpath imports
- **HTTP client docs**: Updated imports for `Effect` and `Console` to use subpath imports
- **Getting started quickstart**: Updated imports for `Schema`, `Effect`, `Layer`, and `Array` to use subpath imports
- **Server functions docs**: Updated imports for `Schema`, `Effect`, and `Layer` to use subpath imports
- **Node actions docs**: Updated imports for `Schema`, `Console`, `Duration`, `Effect`, and `Layer` to use subpath imports
- **Error handling docs**: Updated imports for `Schema` and `Effect` to use subpath imports
- **HTTP API docs**: Updated imports for `Effect`, `Layer`, `Schema`, and `Function` to use subpath imports
- **Storage docs**: Updated imports for `Effect` to use subpath imports
- **File naming conventions docs**: Updated imports for `Schema`, `Effect`, and `Layer` to use subpath imports
- **Spec-impl model docs**: Updated imports for `Schema`, `Effect`, and `Layer` to use subpath imports
- **React client docs**: Updated imports for `Schema` and `Either` to use subpath imports
- **Testing guide docs**: Updated imports for `Effect` to use subpath imports
- **Database schema docs**: Updated imports for `Schema` to use subpath imports
- **Plain Convex functions docs**: Updated imports for `Layer` and `Schema` to use subpath imports
- **Cron jobs docs**: Updated imports for `Cron` and `Duration` to use subpath imports
- **Determinism docs**: Updated imports for `Clock` and `Effect` to use subpath imports
- **Environment variables docs**: Updated imports for `Config` and `Effect` to use subpath imports
- **Scheduling docs**: Updated imports for `Duration` and `Effect` to use subpath imports
- **Authentication docs**: Updated imports for `Effect` to use subpath imports
- **Database reading docs**: Updated imports for `Effect` to use subpath imports
- **Database writing docs**: Updated imports for `Effect` to use subpath imports
- **Search docs**: Updated imports for `Effect` to use subpath imports

## Implementation Details

All changes follow the pattern of converting:
```ts
import { Module } from "effect";
```

to:
```ts
import * as Module from "effect/Module";
```

This applies consistently across all documentation files to provide a uniform and best-practice example for users.

https://claude.ai/code/session_019QxuXrtAA17Hp9MQKmtTU9