### PR TITLE
Stop Version Packages PRs from churning formatting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,6 +2,7 @@
   "$schema": "../node_modules/@changesets/config/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
+  "prettier": false,
   "fixed": [["@confect/*"]],
   "linked": [],
   "access": "public",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: pnpm version-packages
           publish: pnpm release
           branch: ${{ github.ref_name }}
         env:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test": "vitest run",
     "test:server:local-backend": "pnpm --filter @confect/server test:local-backend",
     "test:server:mock-backend": "pnpm --filter @confect/server test:mock-backend",
-    "typecheck": "tsc -b tsconfig.packages.json tsconfig.json"
+    "typecheck": "tsc -b tsconfig.packages.json tsconfig.json",
+    "version-packages": "changeset version && pnpm format"
   }
 }


### PR DESCRIPTION
Every Changesets "Version Packages" PR (e.g. #453) failed the Format CI
check and carried a diff several times larger than the actual release
changes. Two things were going wrong:

- `changeset version` runs the changelogs through its bundled Prettier,
  rewriting *existing* entries in a style that conflicts with oxfmt —
  inserting blank lines before lists and even reformatting code inside
  fenced blocks (dropping trailing commas), which oxfmt can't restore.
- Even without Prettier, the freshly prepended entry doesn't quite match
  oxfmt's style (sub-list indentation, missing blank line).

Setting `"prettier": false` in `.changeset/config.json` (supported since
@changesets/cli 2.27) makes versioning leave existing changelog content
untouched. The new `version-packages` script then runs `pnpm format`
after `changeset version`, and the release workflow uses it as the
changesets action's `version` command, so release PRs arrive formatted
to repo style.

Verified locally with the pending changeset: `pnpm version-packages`
followed by `pnpm format:check` passes, and the diff shrinks to just the
new changelog entries and version bumps.

https://claude.ai/code/session_01UzR2XZLx9F3BSuvz9Nvz1U