### PR TITLE
Reformat changeset for declaration-emittable types

### DIFF
--- a/.changeset/declaration-emittable-types.md
+++ b/.changeset/declaration-emittable-types.md
@@ -3,20 +3,8 @@
 "@confect/cli": minor
 ---
 
-Make Confect's public types declaration-emittable, fixing `TS7056` under
-`tsc --build` with `composite`/`declaration` (e.g. consuming a Confect backend
-as a referenced TypeScript project).
+Make Confect's public types declaration-emittable, fixing `TS7056` under `tsc --build` with `composite`/`declaration` (e.g. consuming a Confect backend as a referenced TypeScript project).
 
-The schema-generic service tags (`DatabaseReader`, `DatabaseWriter`,
-`VectorSearch`, `QueryCtx`/`MutationCtx`/`ActionCtx`) now back their
-`Context.GenericTag` with named generic interfaces, and codegen annotates the
-`_generated/services.ts` exports with the corresponding tag aliases — so
-declaration emit prints the names by reference instead of re-expanding the
-whole data model (the example backend's `services.d.ts` drops from ~307 KB to
-~5.6 KB).
+The schema-generic service tags (`DatabaseReader`, `DatabaseWriter`, `VectorSearch`, `QueryCtx`/`MutationCtx`/`ActionCtx`) now back their `Context.GenericTag` with named generic interfaces, and codegen annotates the `_generated/services.ts` exports with the corresponding tag aliases — so declaration emit prints the names by reference instead of re-expanding the whole data model (the example backend's `services.d.ts` drops from ~307 KB to ~5.6 KB).
 
-Codegen also emits `_generated/docs.ts` — a nominal `interface` per table plus
-a `Docs` registry — threaded into the reader/writer tags via the
-`Document.Document<Schema, Table>` helper, so query/mutation helpers print named
-document types (e.g. `NotesDoc`) with no added annotations. Runtime behaviour is
-unchanged.
+Codegen also emits `_generated/docs.ts` — a nominal `interface` per table plus a `Docs` registry — threaded into the reader/writer tags via the `Document.Document<Schema, Table>` helper, so query/mutation helpers print named document types (e.g. `NotesDoc`) with no added annotations. Runtime behaviour is unchanged.


### PR DESCRIPTION
This PR reformats the changeset entry for the declaration-emittable types feature to improve readability by converting multi-line paragraphs into single-line format.

**Changes:**
- Reformatted the changeset markdown to use single-line paragraphs instead of line-wrapped text
- No functional changes to the documented feature or its description

**Context:**
The changeset describes improvements to Confect's type declarations to fix `TS7056` errors under `tsc --build` with `composite`/`declaration` settings. The feature includes:
- Named generic interfaces backing schema-generic service tags
- Codegen annotations for tag aliases to reduce declaration file sizes
- Generated `_generated/docs.ts` with nominal document type interfaces

This is purely a formatting change to the changeset file with no impact on the actual implementation.

https://claude.ai/code/session_01QZe2xowT599E6TZqJ1iPYe