### PR TITLE
Emit document types as `type` aliases instead of `interface`

### DIFF
--- a/.changeset/docs-type-alias-non-object.md
+++ b/.changeset/docs-type-alias-non-object.md
@@ -1,0 +1,20 @@
+---
+"@confect/cli": patch
+"@confect/server": patch
+---
+
+Fix codegen emitting an invalid `interface … extends Document.Document<…>` in
+`_generated/docs.ts` for tables whose document type is not a single object.
+
+`Document.Document<Schema, Table>` is a type alias that resolves to whatever the
+table's schema is, so for a `Schema.Union` table (or any non-object document:
+branded primitives, `Schema.transform` results, …) it resolves to a union. An
+`interface` cannot extend a union, so the generated `XDoc` tripped `TS2312` and
+collapsed to an unusable type, which then broke every reader/writer helper that
+printed it.
+
+Codegen now emits a `type` alias per table — `export type NotesDoc =
+Document.Document<typeof schemaDefinition, "notes">;` — which keeps the named
+document type (so declaration emit still prints `NotesDoc` rather than the
+expanded row) while supporting every document shape. Runtime behaviour is
+unchanged.

--- a/apps/docs/server/database/schema.mdx
+++ b/apps/docs/server/database/schema.mdx
@@ -67,20 +67,14 @@ A `Table`'s `Doc` property contains an Effect `Schema` for the table's document,
 
 `Fields` and `Doc` are runtime `Schema`s — _values_. Reach for them whenever you need a value: a spec's `returns`, an HTTP endpoint's `addSuccess`, or decoding. Their TypeScript types are available as `typeof notes.Doc.Type` and `typeof notes.Fields.Type`.
 
-When you only need to annotate something with a table's document _type_, codegen also emits named document interfaces in `confect/_generated/docs.ts` — one per table (`NotesDoc`, `UsersDoc`, …) plus a `Docs` registry:
+When you only need to annotate something with a table's document _type_, codegen also emits named document types in `confect/_generated/docs.ts` — one per table (`NotesDoc`, `UsersDoc`, …) plus a `Docs` registry:
 
 ```ts confect/_generated/docs.ts
 import type { Document } from "@confect/server";
 import type schemaDefinition from "./schema";
 
-export interface NotesDoc extends Document.Document<
-  typeof schemaDefinition,
-  "notes"
-> {}
-export interface UsersDoc extends Document.Document<
-  typeof schemaDefinition,
-  "users"
-> {}
+export type NotesDoc = Document.Document<typeof schemaDefinition, "notes">;
+export type UsersDoc = Document.Document<typeof schemaDefinition, "users">;
 
 export interface Docs {
   notes: NotesDoc;
@@ -96,12 +90,12 @@ import type { NotesDoc } from "./confect/_generated/docs";
 const renderNote = (note: NotesDoc) => note.text;
 ```
 
-You can also write the type inline with the same helper the generated interfaces extend, `Document.Document<typeof schemaDefinition, "notes">`, and drop the system fields with `Document.WithoutSystemFields<NotesDoc>`.
+You can also write the type inline with the same helper the generated types alias, `Document.Document<typeof schemaDefinition, "notes">`, and drop the system fields with `Document.WithoutSystemFields<NotesDoc>`.
 
 As a rule of thumb: reach for `notes.Doc` when you need a **value** (a `Schema`), and `NotesDoc` when you need a **type**.
 
 <Note>
-  Each interface's name is the table name folded to PascalCase, so
-  `user_profiles` and `userProfiles` would both produce `UserProfilesDoc`.
-  Codegen reports an error if two tables would collide on the same name.
+  Each type's name is the table name folded to PascalCase, so `user_profiles`
+  and `userProfiles` would both produce `UserProfilesDoc`. Codegen reports an
+  error if two tables would collide on the same name.
 </Note>

--- a/apps/example/confect/_generated/docs.ts
+++ b/apps/example/confect/_generated/docs.ts
@@ -1,9 +1,9 @@
 import type { Document } from "@confect/server";
 import type schemaDefinition from "./schema";
 
-export interface NotesDoc extends Document.Document<typeof schemaDefinition, "notes"> {}
-export interface TagsDoc extends Document.Document<typeof schemaDefinition, "tags"> {}
-export interface UsersDoc extends Document.Document<typeof schemaDefinition, "users"> {}
+export type NotesDoc = Document.Document<typeof schemaDefinition, "notes">;
+export type TagsDoc = Document.Document<typeof schemaDefinition, "tags">;
+export type UsersDoc = Document.Document<typeof schemaDefinition, "users">;
 
 export interface Docs {
   notes: NotesDoc;

--- a/packages/cli/src/DocName.ts
+++ b/packages/cli/src/DocName.ts
@@ -4,7 +4,7 @@ import { pipe } from "effect/Function";
 import * as String from "effect/String";
 
 /**
- * The name of a table's generated document interface in
+ * The name of a table's generated document type in
  * `confect/_generated/docs.ts` (e.g. `UserProfilesDoc`). Branded so it can't be
  * confused with an arbitrary string — construct it with {@link fromTableName}.
  */
@@ -13,7 +13,7 @@ export type DocName = string & Brand.Brand<"DocName">;
 const DocName = Brand.nominal<DocName>();
 
 /**
- * Convert a Convex table name to the name of its generated document interface
+ * Convert a Convex table name to the name of its generated document type
  * in `confect/_generated/docs.ts`.
  *
  * The table name is split on underscores and the first letter of each segment

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -278,13 +278,16 @@ export const refs = ({ specImportPath }: { specImportPath: string }) =>
   });
 
 /**
- * Emit `_generated/docs.ts`: one nominal `interface <table>` per table plus a
- * `Docs` registry. Each interface `extends Document.Document<typeof
- * schemaDefinition, "<table>">`, so it stays structurally exact while giving
- * the document a *name* — declaration emit then prints e.g. `NotesDoc` instead
- * of expanding the row structure. The registry is threaded into the generated
- * `DatabaseReader`/`DatabaseWriter` tags so query/mutation helpers print named
- * documents with no user annotations.
+ * Emit `_generated/docs.ts`: one named `type <table>` alias per table plus a
+ * `Docs` registry. Each alias is `Document.Document<typeof schemaDefinition,
+ * "<table>">`, so it stays structurally exact while giving the document a
+ * *name* — declaration emit then prints e.g. `NotesDoc` instead of expanding
+ * the row structure. A `type` alias (rather than an extending `interface`) is
+ * used so it works for every document shape: object tables, but also union
+ * schemas (`Schema.Union`) and other non-object documents, which an `interface
+ * … extends` cannot represent (TS2312). The registry is threaded into the
+ * generated `DatabaseReader`/`DatabaseWriter` tags so query/mutation helpers
+ * print named documents with no user annotations.
  */
 export const docs = ({
   schemaImportPath,
@@ -311,7 +314,7 @@ export const docs = ({
 
     for (const { tableName, docName } of tables) {
       yield* cbw.writeLine(
-        `export interface ${docName} extends Document.Document<typeof schemaDefinition, "${tableName}"> {}`,
+        `export type ${docName} = Document.Document<typeof schemaDefinition, "${tableName}">;`,
       );
     }
     yield* cbw.blankLine();

--- a/packages/cli/test/codegen.test.ts
+++ b/packages/cli/test/codegen.test.ts
@@ -33,6 +33,7 @@ layer(CodegenLayer)("TableModule.discover", (it) => {
     Effect.gen(function* () {
       const tables = yield* discoverTables;
       expect(tables.map((t) => t.tableName).sort()).toEqual([
+        "events",
         "notes",
         "tags",
         "users",

--- a/packages/server/test/mock-backend/declarationEmit.test.ts
+++ b/packages/server/test/mock-backend/declarationEmit.test.ts
@@ -80,12 +80,6 @@ layer(NodePath.layer)("declaration emit", (it) => {
     60_000,
   );
 
-  // The `events` fixture's schema is a `Schema.Union`, so its document type is a
-  // union rather than a single object. Codegen must emit `EventsDoc` as a `type`
-  // alias — an `interface EventsDoc extends Document.Document<…>` would trip
-  // TS2312 ("an interface can only extend an object type"). Plain declaration
-  // emit tolerates type errors, so we assert there are *no* diagnostics rather
-  // than merely that a `.d.ts` was produced.
   it.effect(
     "docs.d.ts emits non-object (union) document types without error",
     () =>

--- a/packages/server/test/mock-backend/declarationEmit.test.ts
+++ b/packages/server/test/mock-backend/declarationEmit.test.ts
@@ -7,7 +7,7 @@ import { pipe } from "effect/Function";
 import * as String from "effect/String";
 import * as ts from "typescript";
 
-const emitDeclaration = (entry: string) =>
+const compile = (entry: string) =>
   Effect.gen(function* () {
     const path = yield* Path.Path;
 
@@ -44,13 +44,23 @@ const emitDeclaration = (entry: string) =>
     const declarationPath = path.normalize(
       pipe(entryPath, String.replace(/\.ts$/, ".d.ts")),
     );
+
+    const diagnostics = Array.appendAll(
+      ts.getPreEmitDiagnostics(program),
+      result.diagnostics,
+    );
+
+    return { host, emitted, declarationPath, diagnostics };
+  });
+
+const emitDeclaration = (entry: string) =>
+  Effect.gen(function* () {
+    const { host, emitted, declarationPath, diagnostics } =
+      yield* compile(entry);
+
     const declaration = emitted.get(declarationPath);
 
     if (declaration === undefined) {
-      const diagnostics = Array.appendAll(
-        ts.getPreEmitDiagnostics(program),
-        result.diagnostics,
-      );
       return yield* Effect.dieMessage(
         `${entry} produced no declaration emit:\n${ts.formatDiagnostics(diagnostics, host)}`,
       );
@@ -66,6 +76,26 @@ layer(NodePath.layer)("declaration emit", (it) => {
       Effect.gen(function* () {
         const declaration = yield* emitDeclaration("services.ts");
         expect(declaration).toMatchSnapshot();
+      }),
+    60_000,
+  );
+
+  // The `events` fixture's schema is a `Schema.Union`, so its document type is a
+  // union rather than a single object. Codegen must emit `EventsDoc` as a `type`
+  // alias — an `interface EventsDoc extends Document.Document<…>` would trip
+  // TS2312 ("an interface can only extend an object type"). Plain declaration
+  // emit tolerates type errors, so we assert there are *no* diagnostics rather
+  // than merely that a `.d.ts` was produced.
+  it.effect(
+    "docs.d.ts emits non-object (union) document types without error",
+    () =>
+      Effect.gen(function* () {
+        const { host, diagnostics } = yield* compile("docs.ts");
+
+        expect(
+          ts.formatDiagnostics(diagnostics, host),
+          "docs.ts must typecheck cleanly — non-object doc types require `type` aliases, not `interface … extends`",
+        ).toBe("");
       }),
     60_000,
   );

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/convexSchema.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/convexSchema.ts
@@ -1,10 +1,12 @@
 import { defineSchema as $defineSchema } from "convex/server";
 
+import events from "./tables/events";
 import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
 
 export default $defineSchema({
+  events: events.tableDefinition,
   notes: notes.tableDefinition,
   tags: tags.tableDefinition,
   users: users.tableDefinition,

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/docs.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/docs.ts
@@ -1,11 +1,13 @@
 import type { Document } from "@confect/server";
 import type schemaDefinition from "./schema";
 
-export interface NotesDoc extends Document.Document<typeof schemaDefinition, "notes"> {}
-export interface TagsDoc extends Document.Document<typeof schemaDefinition, "tags"> {}
-export interface UsersDoc extends Document.Document<typeof schemaDefinition, "users"> {}
+export type EventsDoc = Document.Document<typeof schemaDefinition, "events">;
+export type NotesDoc = Document.Document<typeof schemaDefinition, "notes">;
+export type TagsDoc = Document.Document<typeof schemaDefinition, "tags">;
+export type UsersDoc = Document.Document<typeof schemaDefinition, "users">;
 
 export interface Docs {
+  events: EventsDoc;
   notes: NotesDoc;
   tags: TagsDoc;
   users: UsersDoc;

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/id.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/id.ts
@@ -1,6 +1,6 @@
 import { GenericId } from "@confect/core";
 
-export type TableNames = "notes" | "tags" | "users";
+export type TableNames = "events" | "notes" | "tags" | "users";
 
 export const Id = <const TableName extends TableNames>(
   tableName: TableName,

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/schema.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/schema.ts
@@ -1,10 +1,12 @@
 import { DatabaseSchema as $DatabaseSchema } from "@confect/server";
 
+import events from "./tables/events";
 import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
 
 export default $DatabaseSchema.make({
+  events,
   notes,
   tags,
   users,

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/tables/events.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/tables/events.ts
@@ -1,0 +1,3 @@
+import unnamed from "../../tables/events";
+
+export default unnamed("events");

--- a/packages/server/test/mock-backend/fixtures/confect/tables/events.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/tables/events.ts
@@ -1,0 +1,12 @@
+import { Table } from "@confect/server";
+import * as Schema from "effect/Schema";
+
+// A table whose document type is a discriminated union rather than a single
+// object. Its generated `EventsDoc` must be emitted as a `type` alias — an
+// `interface … extends Document.Document<…>` cannot extend a union (TS2312).
+export default Table.make(() =>
+  Schema.Union(
+    Schema.Struct({ kind: Schema.Literal("a"), a: Schema.String }),
+    Schema.Struct({ kind: Schema.Literal("b"), b: Schema.Number }),
+  ),
+);

--- a/packages/server/test/mock-backend/fixtures/confect/tables/events.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/tables/events.ts
@@ -1,9 +1,6 @@
 import { Table } from "@confect/server";
 import * as Schema from "effect/Schema";
 
-// A table whose document type is a discriminated union rather than a single
-// object. Its generated `EventsDoc` must be emitted as a `type` alias — an
-// `interface … extends Document.Document<…>` cannot extend a union (TS2312).
 export default Table.make(() =>
   Schema.Union(
     Schema.Struct({ kind: Schema.Literal("a"), a: Schema.String }),


### PR DESCRIPTION
## Summary

Changes codegen to emit document type definitions in `confect/_generated/docs.ts` as `type` aliases instead of `interface` declarations. This fixes a TypeScript error when a table's document type is not a single object (e.g., a discriminated union).

## Changes

- **Codegen template** (`packages/cli/src/templates.ts`): Changed the `docs` template to emit `export type DocName = Document.Document<…>` instead of `export interface DocName extends Document.Document<…> {}`
  - Updated JSDoc to explain why `type` aliases are necessary for non-object document shapes
  - Updated `DocName.ts` comments to refer to "document type" instead of "document interface"

- **Test fixtures**: Added an `events` table with a `Schema.Union` document type to verify the fix works for non-object schemas
  - New table definition in `packages/server/test/mock-backend/fixtures/confect/tables/events.ts`
  - Updated generated files to include the new table

- **Declaration emit test** (`packages/server/test/mock-backend/declarationEmit.test.ts`): Refactored to extract compilation logic into a reusable `compile` helper function, then added a new test case that verifies `docs.ts` emits without TypeScript diagnostics for union document types

- **Documentation** (`apps/docs/server/database/schema.mdx`): Updated to reflect that generated document definitions are now `type` aliases rather than `interface` declarations

## Implementation Details

The change is necessary because TypeScript's `interface` construct can only extend object types. When a table's schema is a `Schema.Union` or other non-object type, an `interface … extends Document.Document<…>` would violate TS2312 and fail to compile. Using `type` aliases preserves the structural typing and named document types while supporting every document shape.

The generated `Docs` registry interface remains unchanged — it still uses `interface` to define the mapping of table names to their document types.

https://claude.ai/code/session_01EaxUNoT5FqUaxWLQ7NXpWM