### PR TITLE
Add type annotations to generated aggregate modules for declaration emit

### DIFF
--- a/.changeset/declaration-emittable-aggregate-modules.md
+++ b/.changeset/declaration-emittable-aggregate-modules.md
@@ -3,14 +3,8 @@
 "@confect/cli": minor
 ---
 
-Make the generated `_generated/refs.ts`, `schema.ts`, and `spec.ts` modules declaration-emittable, fixing `TS7056` ("inferred type … exceeds the maximum length the compiler will serialize") under `tsc --build` with `composite`/`declaration` at scale.
+You can now compile a Confect backend with TypeScript declaration emit and consume it as a project reference.
 
-These aggregate modules previously exported the _un-annotated_ result of a Confect builder call, so declaration emit had to infer and serialize the fully-expanded result type — every ref for `refs.ts`, the whole schema for `schema.ts`, and every function's arg/return schema for `spec.ts` — which trips `TS7056` once a backend has dozens of tables and functions. This blocked consuming a Confect backend as a referenced TypeScript project (so every consumer recompiled the backend's source).
+Previously, enabling `composite`/`declaration` on a project that included your generated `confect/_generated` modules failed with `TS7056` ("inferred type … exceeds the maximum length the compiler will serialize") once the backend had more than a handful of tables and functions. As a result, a Confect backend couldn't be a referenced/composite TypeScript project — every consumer had to pull in and recompile its source, hurting editor responsiveness and incremental typecheck times in larger workspaces.
 
-Codegen now annotates each aggregate export with a compact, alias-headed type reference (mirroring `services.ts`/`docs.ts`), so declaration emit prints the reference by name instead of re-expanding it:
-
-- `refs.ts` is typed with the new `Refs.FromSpec<typeof spec>`.
-- `schema.ts` is typed with `DatabaseSchema.DatabaseSchema<…>` over the `typeof <table>` union.
-- `spec.ts` is typed with a reconstructed `Spec.Spec<…>` whose groups are referenced by `typeof`; the new `GroupSpec.AddGroups` helper covers a leaf spec module that also has nested subgroups.
-
-`@confect/core` gains two additive public types: `Refs.FromSpec` and `GroupSpec.AddGroups`.
+Regenerating your backend (`confect codegen`) now produces `_generated` modules that emit declarations cleanly, so you can turn on `composite`/`declaration` for the backend and have downstream packages depend on it via project references (`.d.ts`) instead of source.

--- a/.changeset/declaration-emittable-aggregate-modules.md
+++ b/.changeset/declaration-emittable-aggregate-modules.md
@@ -1,10 +1,10 @@
 ---
-"@confect/core": minor
-"@confect/cli": minor
+"@confect/core": patch
+"@confect/cli": patch
 ---
 
-You can now compile a Confect backend with TypeScript declaration emit and consume it as a project reference.
+Fix `TS7056` ("inferred type … exceeds the maximum length the compiler will serialize") when compiling a Confect backend with declaration emit.
 
-Previously, enabling `composite`/`declaration` on a project that included your generated `confect/_generated` modules failed with `TS7056` ("inferred type … exceeds the maximum length the compiler will serialize") once the backend had more than a handful of tables and functions. As a result, a Confect backend couldn't be a referenced/composite TypeScript project — every consumer had to pull in and recompile its source, hurting editor responsiveness and incremental typecheck times in larger workspaces.
+Enabling `composite`/`declaration` on a project that included your generated `confect/_generated` modules failed with `TS7056` once the backend had more than a handful of tables and functions. This prevented a Confect backend from being a referenced/composite TypeScript project — every consumer had to pull in and recompile its source, hurting editor responsiveness and incremental typecheck times in larger workspaces.
 
 Regenerating your backend (`confect codegen`) now produces `_generated` modules that emit declarations cleanly, so you can turn on `composite`/`declaration` for the backend and have downstream packages depend on it via project references (`.d.ts`) instead of source.

--- a/.changeset/declaration-emittable-aggregate-modules.md
+++ b/.changeset/declaration-emittable-aggregate-modules.md
@@ -1,0 +1,16 @@
+---
+"@confect/core": minor
+"@confect/cli": minor
+---
+
+Make the generated `_generated/refs.ts`, `schema.ts`, and `spec.ts` modules declaration-emittable, fixing `TS7056` ("inferred type … exceeds the maximum length the compiler will serialize") under `tsc --build` with `composite`/`declaration` at scale.
+
+These aggregate modules previously exported the _un-annotated_ result of a Confect builder call, so declaration emit had to infer and serialize the fully-expanded result type — every ref for `refs.ts`, the whole schema for `schema.ts`, and every function's arg/return schema for `spec.ts` — which trips `TS7056` once a backend has dozens of tables and functions. This blocked consuming a Confect backend as a referenced TypeScript project (so every consumer recompiled the backend's source).
+
+Codegen now annotates each aggregate export with a compact, alias-headed type reference (mirroring `services.ts`/`docs.ts`), so declaration emit prints the reference by name instead of re-expanding it:
+
+- `refs.ts` is typed with the new `Refs.FromSpec<typeof spec>`.
+- `schema.ts` is typed with `DatabaseSchema.DatabaseSchema<…>` over the `typeof <table>` union.
+- `spec.ts` is typed with a reconstructed `Spec.Spec<…>` whose groups are referenced by `typeof`; the new `GroupSpec.AddGroups` helper covers a leaf spec module that also has nested subgroups.
+
+`@confect/core` gains two additive public types: `Refs.FromSpec` and `GroupSpec.AddGroups`.

--- a/apps/example/confect/_generated/refs.ts
+++ b/apps/example/confect/_generated/refs.ts
@@ -1,4 +1,6 @@
 import { Refs } from "@confect/core";
 import spec from "./spec";
 
-export default Refs.make(spec);
+const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);
+
+export default refs;

--- a/apps/example/confect/_generated/schema.ts
+++ b/apps/example/confect/_generated/schema.ts
@@ -4,8 +4,14 @@ import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
 
-export default $DatabaseSchema.make({
+const schemaDefinition: $DatabaseSchema.DatabaseSchema<
+  typeof notes |
+  typeof tags |
+  typeof users
+> = $DatabaseSchema.make({
   notes,
   tags,
   users,
 });
+
+export default schemaDefinition;

--- a/apps/example/confect/_generated/schema.ts
+++ b/apps/example/confect/_generated/schema.ts
@@ -4,7 +4,7 @@ import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
 
-const schemaDefinition: $DatabaseSchema.DatabaseSchema<
+const databaseSchema: $DatabaseSchema.DatabaseSchema<
   typeof notes |
   typeof tags |
   typeof users
@@ -14,4 +14,4 @@ const schemaDefinition: $DatabaseSchema.DatabaseSchema<
   users,
 });
 
-export default schemaDefinition;
+export default databaseSchema;

--- a/apps/example/confect/_generated/spec.ts
+++ b/apps/example/confect/_generated/spec.ts
@@ -5,4 +5,11 @@ import notes_and_random_notes from "../notes_and_random/notes.spec";
 import notes_and_random_random from "../notes_and_random/random.spec";
 import workpool from "../workpool.spec";
 
-export default Spec.make().addAt("email", email).addAt("env", env).addAt("notes_and_random", GroupSpec.makeAt("notes_and_random").addGroupAt("notes", notes_and_random_notes).addGroupAt("random", notes_and_random_random)).addAt("workpool", workpool);
+const spec: Spec.Spec<
+  | GroupSpec.NamedAt<typeof email, "email">
+  | GroupSpec.NamedAt<typeof env, "env">
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "notes_and_random", never, GroupSpec.NamedAt<typeof notes_and_random_notes, "notes"> | GroupSpec.NamedAt<typeof notes_and_random_random, "random">>, "notes_and_random">
+  | GroupSpec.NamedAt<typeof workpool, "workpool">
+> = Spec.make().addAt("email", email).addAt("env", env).addAt("notes_and_random", GroupSpec.makeAt("notes_and_random").addGroupAt("notes", notes_and_random_notes).addGroupAt("random", notes_and_random_random)).addAt("workpool", workpool);
+
+export default spec;

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -105,18 +105,13 @@ export const runtimeSchema = ({
 
     yield* cbw.blankLine();
 
-    // Annotate the default export with the `DatabaseSchema` interface head
-    // (its `Tables_` is the exact `typeof <table>` union the call infers) so
-    // declaration emit prints the reference by name. An un-annotated default
-    // export forces inference-serialization of the whole schema and trips
-    // TS7056 at scale under `composite`/`declaration`.
     if (tableModules.length === 0) {
       yield* cbw.writeLine(
-        `const schemaDefinition: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});`,
+        `const databaseSchema: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});`,
       );
     } else {
       yield* cbw.writeLine(
-        `const schemaDefinition: $DatabaseSchema.DatabaseSchema<`,
+        `const databaseSchema: $DatabaseSchema.DatabaseSchema<`,
       );
       yield* cbw.indent(
         Effect.gen(function* () {
@@ -139,7 +134,7 @@ export const runtimeSchema = ({
     }
 
     yield* cbw.blankLine();
-    yield* cbw.writeLine(`export default schemaDefinition;`);
+    yield* cbw.writeLine(`export default databaseSchema;`);
 
     return yield* cbw.toString();
   });
@@ -294,10 +289,6 @@ export const refs = ({ specImportPath }: { specImportPath: string }) =>
     yield* cbw.writeLine(`import { Refs } from "@confect/core";`);
     yield* cbw.writeLine(`import spec from "${specImportPath}";`);
     yield* cbw.blankLine();
-    // Annotate with the named `Refs.FromSpec` head so declaration emit prints
-    // the reference by name instead of serializing the fully-expanded
-    // (`Types.Simplify`) ref trees — an un-annotated default export trips
-    // TS7056 at scale under `composite`/`declaration`.
     yield* cbw.writeLine(
       `const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);`,
     );
@@ -678,29 +669,15 @@ const writeRootAddAt = (
     yield* cbw.write(")");
   });
 
-/**
- * Type-level mirror of {@link writeGroupAssembly}: the compact type of the
- * group *value* a node assembles. Each leaf is referenced as
- * `typeof <localName>` (and each container as `GroupSpec.GroupSpec<…>` over its
- * children) so the annotation stays a small set of references — declaration
- * emit then prints those names instead of expanding every group's full
- * structure (an un-annotated `export default` does expand, tripping TS7056 at
- * scale).
- */
-const groupTypeRef = (node: SpecAssemblyNode): string => {
+const groupTypeExpr = (node: SpecAssemblyNode): string => {
   const childUnion = Array.map(
     node.children,
-    (child) => `GroupSpec.NamedAt<${groupTypeRef(child)}, "${child.segment}">`,
+    (child) => `GroupSpec.NamedAt<${groupTypeExpr(child)}, "${child.segment}">`,
   ).join(" | ");
 
   return Option.match(node.importBinding, {
-    // A binding-less container is always built with `GroupSpec.makeAt`, which is
-    // Convex-runtime and registers no functions: `GroupSpec<"Convex", seg, never, …>`.
     onNone: () =>
       `GroupSpec.GroupSpec<"Convex", "${node.segment}", never, ${childUnion}>`,
-    // A leaf spec module: its precise type lives in its own module, referenced
-    // by `typeof`. When it also has nested subgroups, `AddGroups` unions them in
-    // (the type-level mirror of the appended `.addGroupAt(...)` calls).
     onSome: (binding) =>
       node.children.length === 0
         ? `typeof ${binding.localName}`
@@ -708,9 +685,8 @@ const groupTypeRef = (node: SpecAssemblyNode): string => {
   });
 };
 
-/** Each root group is added via `.addAt(seg, …)`, i.e. `NamedAt<groupType, seg>`. */
-const rootGroupMemberRef = (node: SpecAssemblyNode): string =>
-  `GroupSpec.NamedAt<${groupTypeRef(node)}, "${node.segment}">`;
+const rootGroupTypeMember = (node: SpecAssemblyNode): string =>
+  `GroupSpec.NamedAt<${groupTypeExpr(node)}, "${node.segment}">`;
 
 export const assembledSpec = ({
   nodes,
@@ -720,8 +696,6 @@ export const assembledSpec = ({
   Effect.gen(function* () {
     const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    // `GroupSpec` is needed whenever there are any groups: every root member of
-    // the annotation is a `GroupSpec.NamedAt<…>` reference.
     yield* cbw.writeLine(
       nodes.length > 0
         ? `import { GroupSpec, Spec } from "@confect/core";`
@@ -736,14 +710,6 @@ export const assembledSpec = ({
 
     yield* cbw.blankLine();
 
-    // Annotate the default export with the spec's type, reconstructed as compact
-    // `typeof`/interface references (see `groupTypeRef`). Without an explicit
-    // annotation, declaration emit infers and serializes the fully-expanded spec
-    // — every function's arg/return schema — and trips TS7056 under
-    // `composite`/`declaration`. The value is runtime-agnostic: a Node group's
-    // `makeNode()` is already baked into its imported leaf spec, so the root is
-    // always `Spec.make()` and binding-less container groups always use
-    // `GroupSpec.makeAt`.
     yield* cbw.write(`const spec: `);
     if (nodes.length === 0) {
       yield* cbw.write(`Spec.Spec`);
@@ -753,12 +719,16 @@ export const assembledSpec = ({
       yield* cbw.indent(
         Effect.gen(function* () {
           for (const node of nodes) {
-            yield* cbw.writeLine(`| ${rootGroupMemberRef(node)}`);
+            yield* cbw.writeLine(`| ${rootGroupTypeMember(node)}`);
           }
         }),
       );
       yield* cbw.write(`>`);
     }
+    // The assembled spec is runtime-agnostic: a Node group's `makeNode()` is
+    // already baked into its imported leaf spec, so the root is always
+    // `Spec.make()` and binding-less container groups always use
+    // `GroupSpec.makeAt` (containers register no functions and carry no runtime).
     yield* cbw.write(` = Spec.make()`);
     yield* Effect.forEach(nodes, (node) =>
       writeRootAddAt(cbw, node, "GroupSpec.makeAt"),

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -105,10 +105,29 @@ export const runtimeSchema = ({
 
     yield* cbw.blankLine();
 
+    // Annotate the default export with the `DatabaseSchema` interface head
+    // (its `Tables_` is the exact `typeof <table>` union the call infers) so
+    // declaration emit prints the reference by name. An un-annotated default
+    // export forces inference-serialization of the whole schema and trips
+    // TS7056 at scale under `composite`/`declaration`.
     if (tableModules.length === 0) {
-      yield* cbw.writeLine(`export default $DatabaseSchema.make({});`);
+      yield* cbw.writeLine(
+        `const schemaDefinition: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});`,
+      );
     } else {
-      yield* cbw.writeLine(`export default $DatabaseSchema.make({`);
+      yield* cbw.writeLine(
+        `const schemaDefinition: $DatabaseSchema.DatabaseSchema<`,
+      );
+      yield* cbw.indent(
+        Effect.gen(function* () {
+          for (let i = 0; i < tableModules.length; i++) {
+            const { tableName } = tableModules[i]!;
+            const isLast = i === tableModules.length - 1;
+            yield* cbw.writeLine(`typeof ${tableName}${isLast ? "" : " |"}`);
+          }
+        }),
+      );
+      yield* cbw.writeLine(`> = $DatabaseSchema.make({`);
       yield* cbw.indent(
         Effect.gen(function* () {
           for (const { tableName } of tableModules) {
@@ -118,6 +137,9 @@ export const runtimeSchema = ({
       );
       yield* cbw.writeLine(`});`);
     }
+
+    yield* cbw.blankLine();
+    yield* cbw.writeLine(`export default schemaDefinition;`);
 
     return yield* cbw.toString();
   });
@@ -272,7 +294,15 @@ export const refs = ({ specImportPath }: { specImportPath: string }) =>
     yield* cbw.writeLine(`import { Refs } from "@confect/core";`);
     yield* cbw.writeLine(`import spec from "${specImportPath}";`);
     yield* cbw.blankLine();
-    yield* cbw.writeLine(`export default Refs.make(spec);`);
+    // Annotate with the named `Refs.FromSpec` head so declaration emit prints
+    // the reference by name instead of serializing the fully-expanded
+    // (`Types.Simplify`) ref trees — an un-annotated default export trips
+    // TS7056 at scale under `composite`/`declaration`.
+    yield* cbw.writeLine(
+      `const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);`,
+    );
+    yield* cbw.blankLine();
+    yield* cbw.writeLine(`export default refs;`);
 
     return yield* cbw.toString();
   });
@@ -648,6 +678,40 @@ const writeRootAddAt = (
     yield* cbw.write(")");
   });
 
+/**
+ * Type-level mirror of {@link writeGroupAssembly}: the compact type of the
+ * group *value* a node assembles. Each leaf is referenced as
+ * `typeof <localName>` (and each container as `GroupSpec.GroupSpec<…>` over its
+ * children) so the annotation stays a small set of references — declaration
+ * emit then prints those names instead of expanding every group's full
+ * structure (an un-annotated `export default` does expand, tripping TS7056 at
+ * scale).
+ */
+const groupTypeRef = (node: SpecAssemblyNode): string => {
+  const childUnion = Array.map(
+    node.children,
+    (child) => `GroupSpec.NamedAt<${groupTypeRef(child)}, "${child.segment}">`,
+  ).join(" | ");
+
+  return Option.match(node.importBinding, {
+    // A binding-less container is always built with `GroupSpec.makeAt`, which is
+    // Convex-runtime and registers no functions: `GroupSpec<"Convex", seg, never, …>`.
+    onNone: () =>
+      `GroupSpec.GroupSpec<"Convex", "${node.segment}", never, ${childUnion}>`,
+    // A leaf spec module: its precise type lives in its own module, referenced
+    // by `typeof`. When it also has nested subgroups, `AddGroups` unions them in
+    // (the type-level mirror of the appended `.addGroupAt(...)` calls).
+    onSome: (binding) =>
+      node.children.length === 0
+        ? `typeof ${binding.localName}`
+        : `GroupSpec.AddGroups<typeof ${binding.localName}, ${childUnion}>`,
+  });
+};
+
+/** Each root group is added via `.addAt(seg, …)`, i.e. `NamedAt<groupType, seg>`. */
+const rootGroupMemberRef = (node: SpecAssemblyNode): string =>
+  `GroupSpec.NamedAt<${groupTypeRef(node)}, "${node.segment}">`;
+
 export const assembledSpec = ({
   nodes,
 }: {
@@ -656,13 +720,10 @@ export const assembledSpec = ({
   Effect.gen(function* () {
     const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    const nodeRequiresGroupFactory = (node: SpecAssemblyNode): boolean =>
-      Option.isNone(node.importBinding) ||
-      Array.some(node.children, nodeRequiresGroupFactory);
-
-    const needsGroupSpec = Array.some(nodes, nodeRequiresGroupFactory);
+    // `GroupSpec` is needed whenever there are any groups: every root member of
+    // the annotation is a `GroupSpec.NamedAt<…>` reference.
     yield* cbw.writeLine(
-      needsGroupSpec
+      nodes.length > 0
         ? `import { GroupSpec, Spec } from "@confect/core";`
         : `import { Spec } from "@confect/core";`,
     );
@@ -675,16 +736,37 @@ export const assembledSpec = ({
 
     yield* cbw.blankLine();
 
-    // The assembled spec is runtime-agnostic: a Node group's `makeNode()` is
-    // already baked into its imported leaf spec, so the root is always
-    // `Spec.make()` and binding-less container groups always use
-    // `GroupSpec.makeAt` (containers register no functions and carry no runtime).
-    yield* cbw.write(`export default Spec.make()`);
+    // Annotate the default export with the spec's type, reconstructed as compact
+    // `typeof`/interface references (see `groupTypeRef`). Without an explicit
+    // annotation, declaration emit infers and serializes the fully-expanded spec
+    // — every function's arg/return schema — and trips TS7056 under
+    // `composite`/`declaration`. The value is runtime-agnostic: a Node group's
+    // `makeNode()` is already baked into its imported leaf spec, so the root is
+    // always `Spec.make()` and binding-less container groups always use
+    // `GroupSpec.makeAt`.
+    yield* cbw.write(`const spec: `);
+    if (nodes.length === 0) {
+      yield* cbw.write(`Spec.Spec`);
+    } else {
+      yield* cbw.write(`Spec.Spec<`);
+      yield* cbw.newLine();
+      yield* cbw.indent(
+        Effect.gen(function* () {
+          for (const node of nodes) {
+            yield* cbw.writeLine(`| ${rootGroupMemberRef(node)}`);
+          }
+        }),
+      );
+      yield* cbw.write(`>`);
+    }
+    yield* cbw.write(` = Spec.make()`);
     yield* Effect.forEach(nodes, (node) =>
       writeRootAddAt(cbw, node, "GroupSpec.makeAt"),
     );
     yield* cbw.write(";");
     yield* cbw.newLine();
+    yield* cbw.blankLine();
+    yield* cbw.writeLine(`export default spec;`);
 
     return yield* cbw.toString();
   });

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -114,13 +114,14 @@ export const runtimeSchema = ({
         `const databaseSchema: $DatabaseSchema.DatabaseSchema<`,
       );
       yield* cbw.indent(
-        Effect.gen(function* () {
-          for (let i = 0; i < tableModules.length; i++) {
-            const { tableName } = tableModules[i]!;
-            const isLast = i === tableModules.length - 1;
-            yield* cbw.writeLine(`typeof ${tableName}${isLast ? "" : " |"}`);
-          }
-        }),
+        Effect.forEach(
+          tableModules,
+          ({ tableName }, i) =>
+            cbw.writeLine(
+              `typeof ${tableName}${i === tableModules.length - 1 ? "" : " |"}`,
+            ),
+          { discard: true },
+        ),
       );
       yield* cbw.writeLine(`> = $DatabaseSchema.make({`);
       yield* cbw.indent(

--- a/packages/cli/test/SpecAssemblyNode.test.ts
+++ b/packages/cli/test/SpecAssemblyNode.test.ts
@@ -69,8 +69,6 @@ describe("SpecAssemblyNode", () => {
     "assembledSpec imports GroupSpec whenever there are groups (for the annotation's NamedAt references)",
     () =>
       Effect.gen(function* () {
-        // Even all-leaf specs need `GroupSpec`: the default export's type
-        // annotation references `GroupSpec.NamedAt<…>` for every root group.
         const nodes = assemblyNodesFromLeaves([
           leaf("notes.spec.ts", ["notes"]),
           leaf("notes/archived.spec.ts", ["notes", "archived"]),
@@ -80,7 +78,6 @@ describe("SpecAssemblyNode", () => {
         expect(contents).toContain(
           'import { GroupSpec, Spec } from "@confect/core";',
         );
-        // The binding-with-children case is annotated via `GroupSpec.AddGroups`.
         expect(contents).toContain(
           'GroupSpec.AddGroups<typeof notes, GroupSpec.NamedAt<typeof notes_archived, "archived">>',
         );

--- a/packages/cli/test/SpecAssemblyNode.test.ts
+++ b/packages/cli/test/SpecAssemblyNode.test.ts
@@ -66,19 +66,39 @@ describe("SpecAssemblyNode", () => {
   );
 
   it.effect(
-    "assembledSpec only imports GroupSpec when at least one node lacks a leaf binding",
+    "assembledSpec imports GroupSpec whenever there are groups (for the annotation's NamedAt references)",
     () =>
       Effect.gen(function* () {
+        // Even all-leaf specs need `GroupSpec`: the default export's type
+        // annotation references `GroupSpec.NamedAt<…>` for every root group.
         const nodes = assemblyNodesFromLeaves([
           leaf("notes.spec.ts", ["notes"]),
           leaf("notes/archived.spec.ts", ["notes", "archived"]),
         ]);
         const contents = yield* templates.assembledSpec({ nodes });
 
+        expect(contents).toContain(
+          'import { GroupSpec, Spec } from "@confect/core";',
+        );
+        // The binding-with-children case is annotated via `GroupSpec.AddGroups`.
+        expect(contents).toContain(
+          'GroupSpec.AddGroups<typeof notes, GroupSpec.NamedAt<typeof notes_archived, "archived">>',
+        );
+      }),
+  );
+
+  it.effect(
+    "assembledSpec imports only Spec (not GroupSpec) for an empty spec",
+    () =>
+      Effect.gen(function* () {
+        const contents = yield* templates.assembledSpec({ nodes: [] });
+
         expect(contents).toContain('import { Spec } from "@confect/core";');
         expect(contents).not.toContain(
           'import { GroupSpec, Spec } from "@confect/core";',
         );
+        expect(contents).toContain("const spec: Spec.Spec = Spec.make();");
+        expect(contents).toContain("export default spec;");
       }),
   );
 

--- a/packages/core/src/GroupSpec.ts
+++ b/packages/core/src/GroupSpec.ts
@@ -93,16 +93,6 @@ export type NamedAt<Group extends Any, Name_ extends string> = Omit<
   readonly name: Name_;
 };
 
-/**
- * Unions `ExtraGroups` into a `GroupSpec`'s subgroups — the type-level mirror of
- * chaining `.addGroupAt(...)` onto an already-built group.
- *
- * Used by generated `_generated/spec.ts` to annotate a leaf spec module that
- * also has nested subgroups (e.g. `notes.spec.ts` alongside
- * `notes/archived.spec.ts`): the annotation stays a compact
- * `AddGroups<typeof <leaf>, …>` reference so declaration emit prints the leaf by
- * name instead of expanding its full structure (which trips TS7056 at scale).
- */
 export type AddGroups<
   Group extends AnyWithProps,
   ExtraGroups extends AnyWithProps,

--- a/packages/core/src/GroupSpec.ts
+++ b/packages/core/src/GroupSpec.ts
@@ -93,6 +93,29 @@ export type NamedAt<Group extends Any, Name_ extends string> = Omit<
   readonly name: Name_;
 };
 
+/**
+ * Unions `ExtraGroups` into a `GroupSpec`'s subgroups — the type-level mirror of
+ * chaining `.addGroupAt(...)` onto an already-built group.
+ *
+ * Used by generated `_generated/spec.ts` to annotate a leaf spec module that
+ * also has nested subgroups (e.g. `notes.spec.ts` alongside
+ * `notes/archived.spec.ts`): the annotation stays a compact
+ * `AddGroups<typeof <leaf>, …>` reference so declaration emit prints the leaf by
+ * name instead of expanding its full structure (which trips TS7056 at scale).
+ */
+export type AddGroups<
+  Group extends AnyWithProps,
+  ExtraGroups extends AnyWithProps,
+> =
+  Group extends GroupSpec<
+    infer Runtime,
+    infer Name_,
+    infer Functions_,
+    infer Groups_
+  >
+    ? GroupSpec<Runtime, Name_, Functions_, Groups_ | ExtraGroups>
+    : never;
+
 const Proto = {
   [TypeId]: TypeId,
 

--- a/packages/core/src/Refs.ts
+++ b/packages/core/src/Refs.ts
@@ -12,6 +12,20 @@ export type Refs<
   Predicate extends Ref.Any = Ref.Any,
 > = Types.Simplify<OmitEmpty<Helper<Spec.Groups<Spec_>, Predicate>>>;
 
+/**
+ * The result of {@link make}: the `public`/`internal` ref trees for a spec.
+ *
+ * Named (rather than an inferred anonymous object) so generated
+ * `_generated/refs.ts` can annotate its default export with
+ * `Refs.FromSpec<typeof spec>` — declaration emit then prints the reference by
+ * name instead of serializing the fully-expanded `Types.Simplify` ref trees
+ * (which trips `TS7056` at scale under `composite`/`declaration`).
+ */
+export interface FromSpec<Spec_ extends Spec.AnyWithProps> {
+  public: Refs<Spec_, Ref.AnyPublic>;
+  internal: Refs<Spec_, Ref.AnyInternal>;
+}
+
 type GroupRefs<
   Group extends GroupSpec.AnyWithProps,
   Predicate extends Ref.Any,
@@ -74,10 +88,7 @@ type Any =
 
 export const make = <Spec_ extends Spec.AnyWithProps>(
   spec: Spec_,
-): {
-  public: Refs<Spec_, Ref.AnyPublic>;
-  internal: Refs<Spec_, Ref.AnyInternal>;
-} => {
+): FromSpec<Spec_> => {
   const refs = makeHelper(spec.groups);
   return {
     public: refs as Refs<Spec_, Ref.AnyPublic>,

--- a/packages/core/src/Refs.ts
+++ b/packages/core/src/Refs.ts
@@ -12,15 +12,6 @@ export type Refs<
   Predicate extends Ref.Any = Ref.Any,
 > = Types.Simplify<OmitEmpty<Helper<Spec.Groups<Spec_>, Predicate>>>;
 
-/**
- * The result of {@link make}: the `public`/`internal` ref trees for a spec.
- *
- * Named (rather than an inferred anonymous object) so generated
- * `_generated/refs.ts` can annotate its default export with
- * `Refs.FromSpec<typeof spec>` — declaration emit then prints the reference by
- * name instead of serializing the fully-expanded `Types.Simplify` ref trees
- * (which trips `TS7056` at scale under `composite`/`declaration`).
- */
 export interface FromSpec<Spec_ extends Spec.AnyWithProps> {
   public: Refs<Spec_, Ref.AnyPublic>;
   internal: Refs<Spec_, Ref.AnyInternal>;

--- a/packages/server/test/local-backend/fixtures/confect/_generated/refs.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/refs.ts
@@ -1,4 +1,6 @@
 import { Refs } from "@confect/core";
 import spec from "./spec";
 
-export default Refs.make(spec);
+const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);
+
+export default refs;

--- a/packages/server/test/local-backend/fixtures/confect/_generated/schema.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/schema.ts
@@ -1,5 +1,5 @@
 import { DatabaseSchema as $DatabaseSchema } from "@confect/server";
 
-const schemaDefinition: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});
+const databaseSchema: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});
 
-export default schemaDefinition;
+export default databaseSchema;

--- a/packages/server/test/local-backend/fixtures/confect/_generated/schema.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/schema.ts
@@ -1,3 +1,5 @@
 import { DatabaseSchema as $DatabaseSchema } from "@confect/server";
 
-export default $DatabaseSchema.make({});
+const schemaDefinition: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});
+
+export default schemaDefinition;

--- a/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
@@ -2,4 +2,8 @@ import { GroupSpec, Spec } from "@confect/core";
 import groups_cacheControl from "../groups/cacheControl.spec";
 import groups_cacheStubbed from "../groups/cacheStubbed.spec";
 
-export default Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed));
+const spec: Spec.Spec<
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_cacheControl, "cacheControl"> | GroupSpec.NamedAt<typeof groups_cacheStubbed, "cacheStubbed">>, "groups">
+> = Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed));
+
+export default spec;

--- a/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
+++ b/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`declaration emit > refs.d.ts emits compact types without TS7056 1`] = `
+"import { Refs } from "@confect/core";
+import spec from "./spec";
+declare const refs: Refs.FromSpec<typeof spec>;
+export default refs;
+"
+`;
+
+exports[`declaration emit > schema.d.ts emits compact types without TS7056 1`] = `
+"import { DatabaseSchema as $DatabaseSchema } from "@confect/server";
+import events from "./tables/events";
+import notes from "./tables/notes";
+import tags from "./tables/tags";
+import users from "./tables/users";
+declare const schemaDefinition: $DatabaseSchema.DatabaseSchema<typeof events | typeof notes | typeof tags | typeof users>;
+export default schemaDefinition;
+"
+`;
+
 exports[`declaration emit > services.d.ts prints public types by name 1`] = `
 "import { ActionCtx as ActionCtx_, Auth as Auth_, type DataModel, DatabaseReader as DatabaseReader_, DatabaseWriter as DatabaseWriter_, MutationCtx as MutationCtx_, QueryCtx as QueryCtx_, StorageActionWriter as StorageActionWriter_, StorageReader as StorageReader_, StorageWriter as StorageWriter_, VectorSearch as VectorSearch_ } from "@confect/server";
 import type schemaDefinition from "./schema";
@@ -38,5 +57,20 @@ export declare const MutationCtx: MutationCtx_.MutationCtxTag<DataModel.ToConvex
 export type MutationCtx = typeof MutationCtx.Identifier;
 export declare const ActionCtx: ActionCtx_.ActionCtxTag<DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>>;
 export type ActionCtx = typeof ActionCtx.Identifier;
+"
+`;
+
+exports[`declaration emit > spec.d.ts emits compact types without TS7056 1`] = `
+"import { GroupSpec, Spec } from "@confect/core";
+import databaseReader from "../databaseReader.spec";
+import groups_aliasImporter from "../groups/aliasImporter.spec";
+import groups_cjsImporter from "../groups/cjsImporter.spec";
+import groups_notes from "../groups/notes.spec";
+import groups_random from "../groups/random.spec";
+import groups_runners from "../groups/runners.spec";
+import groups_typedErrors from "../groups/typedErrors.spec";
+import typedErrorsNode from "../typedErrorsNode.spec";
+declare const spec: Spec.Spec<GroupSpec.NamedAt<typeof databaseReader, "databaseReader"> | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<typeof groups_random, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups"> | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">>;
+export default spec;
 "
 `;

--- a/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
+++ b/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
@@ -67,10 +67,11 @@ import groups_aliasImporter from "../groups/aliasImporter.spec";
 import groups_cjsImporter from "../groups/cjsImporter.spec";
 import groups_notes from "../groups/notes.spec";
 import groups_random from "../groups/random.spec";
+import groups_random_stats from "../groups/random/stats.spec";
 import groups_runners from "../groups/runners.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 import typedErrorsNode from "../typedErrorsNode.spec";
-declare const spec: Spec.Spec<GroupSpec.NamedAt<typeof databaseReader, "databaseReader"> | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<typeof groups_random, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups"> | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">>;
+declare const spec: Spec.Spec<GroupSpec.NamedAt<typeof databaseReader, "databaseReader"> | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<GroupSpec.AddGroups<typeof groups_random, GroupSpec.NamedAt<typeof groups_random_stats, "stats">>, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups"> | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">>;
 export default spec;
 "
 `;

--- a/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
+++ b/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`declaration emit > refs.d.ts emits compact types without TS7056 1`] = `
+exports[`declaration emit > refs.ts emits a declaration without TS7056 1`] = `
 "import { Refs } from "@confect/core";
 import spec from "./spec";
 declare const refs: Refs.FromSpec<typeof spec>;
@@ -8,14 +8,14 @@ export default refs;
 "
 `;
 
-exports[`declaration emit > schema.d.ts emits compact types without TS7056 1`] = `
+exports[`declaration emit > schema.ts emits a declaration without TS7056 1`] = `
 "import { DatabaseSchema as $DatabaseSchema } from "@confect/server";
 import events from "./tables/events";
 import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
-declare const schemaDefinition: $DatabaseSchema.DatabaseSchema<typeof events | typeof notes | typeof tags | typeof users>;
-export default schemaDefinition;
+declare const databaseSchema: $DatabaseSchema.DatabaseSchema<typeof events | typeof notes | typeof tags | typeof users>;
+export default databaseSchema;
 "
 `;
 
@@ -60,7 +60,7 @@ export type ActionCtx = typeof ActionCtx.Identifier;
 "
 `;
 
-exports[`declaration emit > spec.d.ts emits compact types without TS7056 1`] = `
+exports[`declaration emit > spec.ts emits a declaration without TS7056 1`] = `
 "import { GroupSpec, Spec } from "@confect/core";
 import databaseReader from "../databaseReader.spec";
 import groups_aliasImporter from "../groups/aliasImporter.spec";

--- a/packages/server/test/mock-backend/declarationEmit.test.ts
+++ b/packages/server/test/mock-backend/declarationEmit.test.ts
@@ -94,29 +94,16 @@ layer(NodePath.layer)("declaration emit", (it) => {
     60_000,
   );
 
-  // The aggregate modules (`refs.ts`, `schema.ts`, `spec.ts`) export the result
-  // of a Confect builder call. Without an alias-headed annotation, declaration
-  // emit must infer and serialize the fully-expanded result type, which trips
-  // TS7056 ("inferred type ... exceeds the maximum length the compiler will
-  // serialize") at scale. These tests assert clean emit (no diagnostics) and
-  // snapshot the compact, reference-based `.d.ts` so a regression that
-  // re-introduced expansion would change the snapshot.
-  for (const entry of ["refs.ts", "schema.ts", "spec.ts"] as const) {
-    it.effect(
-      `${entry.replace(/\.ts$/, ".d.ts")} emits compact types without TS7056`,
-      () =>
-        Effect.gen(function* () {
-          const { host, diagnostics } = yield* compile(entry);
+  it.effect.each(["refs.ts", "schema.ts", "spec.ts"])(
+    "%s emits a declaration without TS7056",
+    (entry) =>
+      Effect.gen(function* () {
+        const { host, emitted, declarationPath, diagnostics } =
+          yield* compile(entry);
 
-          expect(
-            ts.formatDiagnostics(diagnostics, host),
-            `${entry} must emit declarations cleanly (no TS7056) — the default export needs an alias-headed annotation`,
-          ).toBe("");
-
-          const declaration = yield* emitDeclaration(entry);
-          expect(declaration).toMatchSnapshot();
-        }),
-      60_000,
-    );
-  }
+        expect(ts.formatDiagnostics(diagnostics, host)).toBe("");
+        expect(emitted.get(declarationPath)).toMatchSnapshot();
+      }),
+    60_000,
+  );
 });

--- a/packages/server/test/mock-backend/declarationEmit.test.ts
+++ b/packages/server/test/mock-backend/declarationEmit.test.ts
@@ -93,4 +93,30 @@ layer(NodePath.layer)("declaration emit", (it) => {
       }),
     60_000,
   );
+
+  // The aggregate modules (`refs.ts`, `schema.ts`, `spec.ts`) export the result
+  // of a Confect builder call. Without an alias-headed annotation, declaration
+  // emit must infer and serialize the fully-expanded result type, which trips
+  // TS7056 ("inferred type ... exceeds the maximum length the compiler will
+  // serialize") at scale. These tests assert clean emit (no diagnostics) and
+  // snapshot the compact, reference-based `.d.ts` so a regression that
+  // re-introduced expansion would change the snapshot.
+  for (const entry of ["refs.ts", "schema.ts", "spec.ts"] as const) {
+    it.effect(
+      `${entry.replace(/\.ts$/, ".d.ts")} emits compact types without TS7056`,
+      () =>
+        Effect.gen(function* () {
+          const { host, diagnostics } = yield* compile(entry);
+
+          expect(
+            ts.formatDiagnostics(diagnostics, host),
+            `${entry} must emit declarations cleanly (no TS7056) — the default export needs an alias-headed annotation`,
+          ).toBe("");
+
+          const declaration = yield* emitDeclaration(entry);
+          expect(declaration).toMatchSnapshot();
+        }),
+      60_000,
+    );
+  }
 });

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/refs.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/refs.ts
@@ -1,4 +1,6 @@
 import { Refs } from "@confect/core";
 import spec from "./spec";
 
-export default Refs.make(spec);
+const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);
+
+export default refs;

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/random/stats.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/random/stats.ts
@@ -1,0 +1,5 @@
+import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";
+import databaseSchema from "../../../schema";
+import stats from "../../../../groups/random/stats.impl";
+
+export default RegisteredFunctions.buildForGroup<typeof import("../../../../groups/random/stats.spec")["default"]>(databaseSchema, stats, RegisteredConvexFunction.make);

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/schema.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/schema.ts
@@ -5,7 +5,7 @@ import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
 
-const schemaDefinition: $DatabaseSchema.DatabaseSchema<
+const databaseSchema: $DatabaseSchema.DatabaseSchema<
   typeof events |
   typeof notes |
   typeof tags |
@@ -17,4 +17,4 @@ const schemaDefinition: $DatabaseSchema.DatabaseSchema<
   users,
 });
 
-export default schemaDefinition;
+export default databaseSchema;

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/schema.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/schema.ts
@@ -5,9 +5,16 @@ import notes from "./tables/notes";
 import tags from "./tables/tags";
 import users from "./tables/users";
 
-export default $DatabaseSchema.make({
+const schemaDefinition: $DatabaseSchema.DatabaseSchema<
+  typeof events |
+  typeof notes |
+  typeof tags |
+  typeof users
+> = $DatabaseSchema.make({
   events,
   notes,
   tags,
   users,
 });
+
+export default schemaDefinition;

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
@@ -4,14 +4,15 @@ import groups_aliasImporter from "../groups/aliasImporter.spec";
 import groups_cjsImporter from "../groups/cjsImporter.spec";
 import groups_notes from "../groups/notes.spec";
 import groups_random from "../groups/random.spec";
+import groups_random_stats from "../groups/random/stats.spec";
 import groups_runners from "../groups/runners.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 import typedErrorsNode from "../typedErrorsNode.spec";
 
 const spec: Spec.Spec<
   | GroupSpec.NamedAt<typeof databaseReader, "databaseReader">
-  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<typeof groups_random, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups">
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<GroupSpec.AddGroups<typeof groups_random, GroupSpec.NamedAt<typeof groups_random_stats, "stats">>, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups">
   | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">
-> = Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors)).addAt("typedErrorsNode", typedErrorsNode);
+> = Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random.addGroupAt("stats", groups_random_stats)).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors)).addAt("typedErrorsNode", typedErrorsNode);
 
 export default spec;

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
@@ -8,4 +8,10 @@ import groups_runners from "../groups/runners.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 import typedErrorsNode from "../typedErrorsNode.spec";
 
-export default Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors)).addAt("typedErrorsNode", typedErrorsNode);
+const spec: Spec.Spec<
+  | GroupSpec.NamedAt<typeof databaseReader, "databaseReader">
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<typeof groups_random, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups">
+  | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">
+> = Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors)).addAt("typedErrorsNode", typedErrorsNode);
+
+export default spec;

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.impl.ts
@@ -1,0 +1,14 @@
+import { FunctionImpl, GroupImpl } from "@confect/server";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import databaseSchema from "../../_generated/schema";
+import stats from "./stats.spec";
+
+const count = FunctionImpl.make(databaseSchema, stats, "count", () =>
+  Effect.succeed(0),
+);
+
+export default GroupImpl.make(databaseSchema, stats).pipe(
+  Layer.provide(count),
+  GroupImpl.finalize,
+);

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
@@ -1,0 +1,10 @@
+import { FunctionSpec, GroupSpec } from "@confect/core";
+import * as Schema from "effect/Schema";
+
+export default GroupSpec.make().addFunction(
+  FunctionSpec.publicQuery({
+    name: "count",
+    args: () => Schema.Struct({}),
+    returns: () => Schema.Number,
+  }),
+);

--- a/packages/server/test/mock-backend/fixtures/convex/_generated/api.d.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/_generated/api.d.ts
@@ -145,6 +145,9 @@ export declare const api: {
     };
     random: {
       getNumber: FunctionReference<"action", "public", {}, number>;
+      stats: {
+        count: FunctionReference<"query", "public", {}, number>;
+      };
     };
     runners: {
       countNotesViaRunner: FunctionReference<"action", "public", {}, number>;

--- a/packages/server/test/mock-backend/fixtures/convex/groups/random/stats.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/groups/random/stats.ts
@@ -1,0 +1,3 @@
+import registeredFunctions from "../../../confect/_generated/registeredFunctions/groups/random/stats";
+
+export const count = registeredFunctions.count;


### PR DESCRIPTION
## Summary

Fix `TS7056` ("inferred type … exceeds the maximum length the compiler will serialize") when compiling a Confect backend with declaration emit enabled. This allows backends to be used as TypeScript project references, enabling consumers to depend on `.d.ts` declarations instead of recompiling source.

## Key Changes

- **Generated `schema.ts`**: Changed from `export default $DatabaseSchema.make({})` to a typed constant `const databaseSchema: $DatabaseSchema.DatabaseSchema<...>` with explicit table union type, then `export default databaseSchema`
- **Generated `refs.ts`**: Changed from `export default Refs.make(spec)` to a typed constant `const refs: Refs.FromSpec<typeof spec>` with explicit type annotation, then `export default refs`
- **Generated `spec.ts`**: Changed from `export default Spec.make()...` to a typed constant `const spec: Spec.Spec<...>` with explicit group union type annotation, then `export default spec`
- **New `Refs.FromSpec<T>` interface**: Added to `@confect/core` to provide a reusable type for the refs object structure (`{ public, internal }`)
- **New `GroupSpec.AddGroups<T, U>` type**: Added to `@confect/core` to support type composition for nested groups
- **New `groupTypeExpr()` and `rootGroupTypeMember()` helpers**: Added to codegen to compute precise type expressions for spec groups
- **Updated test fixtures**: All generated files now include explicit type annotations and separate export statements
- **New test cases**: Added declaration emit tests for `refs.ts`, `schema.ts`, and `spec.ts` to verify they compile without `TS7056`

## Implementation Details

The core issue was that TypeScript's declaration emitter has a serialization length limit. By extracting the `Spec.make()` call into a typed constant with an explicit type annotation, the compiler can serialize the type once and reference it by name in the `.d.ts` file, rather than inlining the full inferred type.

The type annotations use union types for table/group references (e.g., `typeof events | typeof notes | typeof tags`) and nested `GroupSpec.NamedAt<...>` and `GroupSpec.AddGroups<...>` constructs to precisely capture the structure without exceeding serialization limits.

All generated modules now follow the pattern:
```typescript
const <name>: <ExplicitType> = <initialization>;
export default <name>;
```

This ensures declaration emit produces clean, referenceable types.

https://claude.ai/code/session_01UVLsqLobi24vSr96FCUnHo