### PR TITLE
Refactor declaration emit test to use shared compiled program

### DIFF
--- a/packages/server/test/mock-backend/declarationEmit.test.ts
+++ b/packages/server/test/mock-backend/declarationEmit.test.ts
@@ -2,52 +2,92 @@ import * as Path from "@effect/platform/Path";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { expect, layer } from "@effect/vitest";
 import * as Array from "effect/Array";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import { pipe } from "effect/Function";
+import * as Layer from "effect/Layer";
 import * as String from "effect/String";
 import * as ts from "typescript";
+
+const entries = ["services.ts", "docs.ts", "refs.ts", "schema.ts", "spec.ts"];
+
+class CompiledProgram extends Context.Tag(
+  "@confect/server/test/mock-backend/declarationEmit.test/CompiledProgram",
+)<
+  CompiledProgram,
+  {
+    readonly host: ts.CompilerHost;
+    readonly emitted: ReadonlyMap<string, string>;
+    readonly program: ts.Program;
+    readonly emitResult: ts.EmitResult;
+  }
+>() {}
+
+const buildProgram = Effect.gen(function* () {
+  const path = yield* Path.Path;
+
+  const entryPath = (entry: string) =>
+    path.resolve(import.meta.dirname, "fixtures/confect/_generated", entry);
+
+  const configPath = path.resolve(import.meta.dirname, "../../tsconfig.json");
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(configPath),
+  );
+
+  const options: ts.CompilerOptions = {
+    ...parsed.options,
+    noEmit: false,
+    declaration: true,
+    emitDeclarationOnly: true,
+    declarationMap: false,
+  };
+
+  const emitted = new Map<string, string>();
+  const host = ts.createCompilerHost(options);
+  host.writeFile = (fileName, text) => {
+    emitted.set(path.normalize(fileName), text);
+  };
+
+  const program = ts.createProgram(
+    Array.map(entries, entryPath),
+    options,
+    host,
+  );
+  const emitResult = program.emit();
+
+  return { host, emitted, program, emitResult };
+});
+
+const TestLayer = Layer.provideMerge(
+  Layer.effect(CompiledProgram, buildProgram),
+  NodePath.layer,
+);
 
 const compile = (entry: string) =>
   Effect.gen(function* () {
     const path = yield* Path.Path;
-
-    const configPath = path.resolve(import.meta.dirname, "../../tsconfig.json");
-    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
-    const parsed = ts.parseJsonConfigFileContent(
-      configFile.config,
-      ts.sys,
-      path.dirname(configPath),
-    );
-
-    const options: ts.CompilerOptions = {
-      ...parsed.options,
-      noEmit: false,
-      declaration: true,
-      emitDeclarationOnly: true,
-      declarationMap: false,
-    };
-
-    const emitted = new Map<string, string>();
-    const host = ts.createCompilerHost(options);
-    host.writeFile = (fileName, text) => {
-      emitted.set(path.normalize(fileName), text);
-    };
+    const { host, emitted, program, emitResult } = yield* CompiledProgram;
 
     const entryPath = path.resolve(
       import.meta.dirname,
       "fixtures/confect/_generated",
       entry,
     );
-    const program = ts.createProgram([entryPath], options, host);
-    const result = program.emit();
+    const sourceFile = program.getSourceFile(entryPath);
 
     const declarationPath = path.normalize(
       pipe(entryPath, String.replace(/\.ts$/, ".d.ts")),
     );
 
     const diagnostics = Array.appendAll(
-      ts.getPreEmitDiagnostics(program),
-      result.diagnostics,
+      ts.getPreEmitDiagnostics(program, sourceFile),
+      Array.filter(
+        emitResult.diagnostics,
+        (diagnostic) => diagnostic.file === sourceFile,
+      ),
     );
 
     return { host, emitted, declarationPath, diagnostics };
@@ -69,7 +109,7 @@ const emitDeclaration = (entry: string) =>
     return declaration;
   });
 
-layer(NodePath.layer)("declaration emit", (it) => {
+layer(TestLayer, { timeout: "60 seconds" })("declaration emit", (it) => {
   it.effect(
     "services.d.ts prints public types by name",
     () =>


### PR DESCRIPTION
## Summary

Refactored the `declarationEmit.test.ts` test suite to build the TypeScript program once and share it across all test cases, rather than recompiling for each entry point. This improves test performance and reduces redundant compilation work.

## Key Changes

- Extracted program compilation logic into a `buildProgram` effect that compiles all entry files (`services.ts`, `docs.ts`, `refs.ts`, `schema.ts`, `spec.ts`) once
- Created a `CompiledProgram` context tag to store the shared compiled program, compiler host, emitted files map, and emit result
- Introduced `TestLayer` that provides the `CompiledProgram` context alongside `NodePath.layer`
- Updated `compile()` to retrieve the pre-built program from context and filter diagnostics per entry file instead of recompiling
- Updated test layer invocation to use `TestLayer` with a 60-second timeout to accommodate the initial compilation

## Implementation Details

- The shared program is built once with all entry files, avoiding redundant TypeScript compilation across test cases
- Diagnostics are now filtered per source file to maintain per-entry validation while using the shared program
- The `entryPath` helper was extracted to support both the build phase and individual test lookups

https://claude.ai/code/session_019uEUFxJ2AaRoqH6L5yZvSL