### PR TITLE
Generate typed Convex components registry

### DIFF
--- a/.changeset/generate-typed-components-registry.md
+++ b/.changeset/generate-typed-components-registry.md
@@ -1,0 +1,17 @@
+---
+"@confect/cli": minor
+---
+
+Generate a typed Convex components registry at `confect/_generated/components.ts`
+
+`confect codegen` and `confect dev` now evaluate `convex/convex.config.ts` and generate a typed `components` registry with one entry per installed component (`app.use(...)`). Import it from anywhere in your `confect/` directory to pass typed component references to component clients:
+
+```ts
+import { components } from "./_generated/components";
+
+const pool = new Workpool(components.workpool, { maxParallelism: 3 });
+```
+
+Previously the only typed registry was the `components` export of `convex/_generated/api`, which cannot be imported from a Confect impl's import graph: `confect codegen` bundles and evaluates each impl, and `convex/_generated/api` doesn't exist yet at that point (Convex generates it from the `convex/` modules Confect codegen itself produces). The workaround — `componentsGeneric().workpool as unknown as ComponentApi` — required an unsafe cast at every call site.
+
+Each entry is typed with the `ComponentApi` type that component packages export from `_generated/component.js` (the convention Convex's own codegen uses), so no cast is needed. Components installed from npm are typed via their package specifier; locally-defined components are typed via a relative path. Edits to `convex.config.ts` re-run codegen in `confect dev`.

--- a/apps/docs/concepts/project-structure.mdx
+++ b/apps/docs/concepts/project-structure.mdx
@@ -7,6 +7,7 @@ description: "Understand the structure of a Confect project."
 <Tree>
   <Tree.Folder name="confect" defaultOpen>
     <Tree.Folder name="_generated" defaultOpen>
+      <Tree.File name="components.ts" />
       <Tree.File name="convexSchema.ts" />
       <Tree.File name="docs.ts" />
       <Tree.File name="id.ts" />
@@ -51,6 +52,10 @@ description: "Understand the structure of a Confect project."
 ## `confect/`
 
 ### `_generated/`
+
+#### `components.ts`
+
+Contains a typed `components` registry with one entry per Convex [component](https://docs.convex.dev/components) installed via `app.use(...)` in `convex/convex.config.ts`. Use it wherever a component client expects a component reference (e.g. `new Workpool(components.workpool, ...)`). Unlike the `components` export of `convex/_generated/api`, this file is safe to import from your impl files' import graphs. See [Components](/server/components).
 
 #### `convexSchema.ts`
 

--- a/apps/docs/server/components.mdx
+++ b/apps/docs/server/components.mdx
@@ -4,15 +4,42 @@ title: "Components"
 description: "Use Convex components in your Confect app."
 ---
 
-Convex [components](https://docs.convex.dev/components) are configured in `convex/convex.config.ts`, which is one of the files in the `convex/` directory that Confect does not manage. Configure and use components using the vanilla Convex API.
+Convex [components](https://docs.convex.dev/components) are configured in `convex/convex.config.ts`, which is one of the files in the `convex/` directory that Confect does not manage. Configure components using the vanilla Convex API.
 
 ```ts convex/convex.config.ts
 import { defineApp } from "convex/server";
+import workpool from "@convex-dev/workpool/convex.config";
 
 const app = defineApp();
+app.use(workpool, { name: "workpool" });
 
 export default app;
 ```
+
+## Referencing components
+
+Component clients (like `Workpool`) take a component reference. Convex generates a typed `components` registry in `convex/_generated/api`, but importing that file from a module that a Confect impl imports breaks `confect codegen`: Confect bundles and evaluates each impl's import graph, and `convex/_generated/api` doesn't exist yet at that point (Convex generates it from the `convex/` modules that Confect codegen itself produces).
+
+Instead, import the registry that Confect generates at `confect/_generated/components.ts`. It has the same shape and types as Convex's, but it is derived directly from `convex/convex.config.ts`, so it exists before Convex codegen runs and is safe to import anywhere in your `confect/` directory.
+
+```ts confect/workpool.ts
+import { Workpool } from "@convex-dev/workpool";
+import { components } from "./_generated/components";
+
+const pool = new Workpool(components.workpool, {
+  maxParallelism: 3,
+});
+```
+
+<Note>
+  The generated registry types each component with the `ComponentApi` type that
+  component packages export from `_generated/component.js`. Recently published
+  versions of the official `@convex-dev/*` components all follow this
+  convention; a component that predates it will still work at runtime but won't
+  get precise types.
+</Note>
+
+## Defining functions for components
 
 Some components (such as [Workflow](https://www.convex.dev/components/workflow), [Migrations](https://www.convex.dev/components/migrations), and [Workpool](https://www.convex.dev/components/workpool)) expect you to define Convex functions in your project that they can reference. You can integrate these into your Confect spec and impl using [plain Convex functions](/server/plain-convex-functions).
 

--- a/apps/docs/server/components.mdx
+++ b/apps/docs/server/components.mdx
@@ -18,9 +18,7 @@ export default app;
 
 ## Referencing components
 
-Component clients (like `Workpool`) take a component reference. Convex generates a typed `components` registry in `convex/_generated/api`, but importing that file from a module that a Confect impl imports breaks `confect codegen`: Confect bundles and evaluates each impl's import graph, and `convex/_generated/api` doesn't exist yet at that point (Convex generates it from the `convex/` modules that Confect codegen itself produces).
-
-Instead, import the registry that Confect generates at `confect/_generated/components.ts`. It has the same shape and types as Convex's, but it is derived directly from `convex/convex.config.ts`, so it exists before Convex codegen runs and is safe to import anywhere in your `confect/` directory.
+Component clients (like `Workpool`) take a component reference. Import the typed `components` registry that Confect generates at `confect/_generated/components.ts`:
 
 ```ts confect/workpool.ts
 import { Workpool } from "@convex-dev/workpool";
@@ -32,11 +30,19 @@ const pool = new Workpool(components.workpool, {
 ```
 
 <Note>
-  The generated registry types each component with the `ComponentApi` type that
-  component packages export from `_generated/component.js`. Recently published
-  versions of the official `@convex-dev/*` components all follow this
-  convention; a component that predates it will still work at runtime but won't
-  get precise types.
+  Use this registry rather than the `components` export of
+  `convex/_generated/api`, which doesn't exist yet when `confect codegen`
+  evaluates your code and so breaks codegen on a clean checkout. Confect's
+  registry is equivalent, but is derived directly from
+  `convex/convex.config.ts`, so it is safe to import anywhere in your `confect/`
+  directory.
+</Note>
+
+<Note>
+  Each component is typed with the `ComponentApi` type that component packages
+  export from `_generated/component.js`. Recently published versions of the
+  official `@convex-dev/*` components all follow this convention; a component
+  that predates it will still work at runtime but won't get precise types.
 </Note>
 
 ## Defining functions for components

--- a/apps/docs/server/plain-convex-functions.mdx
+++ b/apps/docs/server/plain-convex-functions.mdx
@@ -45,7 +45,7 @@ export default app;
 
 ### Write the Convex functions
 
-Write standard Convex functions using the Convex API and place them in your `confect/` directory. By [convention](/concepts/file-naming-conventions), they go adjacent to their corresponding spec and impl files—for example, `workpool.ts` alongside `workpool.spec.ts` and `workpool.impl.ts`.
+Write standard Convex functions using the Convex API and place them in your `confect/` directory. By [convention](/concepts/file-naming-conventions), they go adjacent to their corresponding spec and impl files—for example, `workpool.ts` alongside `workpool.spec.ts` and `workpool.impl.ts`. The component reference comes from Confect's generated [components registry](/server/components#referencing-components).
 
 ```ts confect/workpool.ts
 import {
@@ -55,13 +55,14 @@ import {
   vOnCompleteArgs,
 } from "@convex-dev/workpool";
 import { v } from "convex/values";
-import { components, internal } from "../convex/_generated/api";
+import { internal } from "../convex/_generated/api";
 import {
   internalAction,
   internalMutation,
   mutation,
   query,
 } from "../convex/_generated/server";
+import { components } from "./_generated/components";
 
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,

--- a/apps/example/confect/_generated/components.ts
+++ b/apps/example/confect/_generated/components.ts
@@ -1,0 +1,7 @@
+import { componentsGeneric } from "convex/server";
+
+export type Components = {
+  "workpool": import("@convex-dev/workpool/_generated/component.js").ComponentApi<"workpool">;
+};
+
+export const components: Components = componentsGeneric() as unknown as Components;

--- a/apps/example/confect/_generated/components.ts
+++ b/apps/example/confect/_generated/components.ts
@@ -4,4 +4,4 @@ export type Components = {
   "workpool": import("@convex-dev/workpool/_generated/component.js").ComponentApi<"workpool">;
 };
 
-export const components: Components = componentsGeneric() as unknown as Components;
+export const components: Components = componentsGeneric() as any;

--- a/apps/example/confect/workpool.ts
+++ b/apps/example/confect/workpool.ts
@@ -5,13 +5,14 @@ import {
   vWorkId,
 } from "@convex-dev/workpool";
 import { v } from "convex/values";
-import { components, internal } from "../convex/_generated/api";
+import { internal } from "../convex/_generated/api";
 import {
   internalAction,
   internalMutation,
   mutation,
   query,
 } from "../convex/_generated/server";
+import { components } from "./_generated/components";
 
 const pool = new Workpool(components.workpool, {
   maxParallelism: 3,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,10 +21,12 @@
     "exsolve": "^1.1.0"
   },
   "devDependencies": {
+    "@convex-dev/workpool": "0.4.6",
     "@effect/language-service": "0.86.1",
     "@effect/vitest": "0.29.0",
     "@types/node": "25.3.3",
     "@vitest/coverage-v8": "3.2.4",
+    "convex": "1.40.0",
     "effect": "3.21.2",
     "tsdown": "0.20.3",
     "typescript": "5.9.3",

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -64,7 +64,7 @@ const resolveCjs = Option.liftThrowable((specifier: string, importer: string) =>
   createRequire(importer).resolve(specifier),
 );
 
-const resolveModule = (
+export const resolveModule = (
   specifier: string,
   importer: string,
 ): Option.Option<string> =>
@@ -163,9 +163,15 @@ const captureBuildResultPlugin = (
  * so callers can inspect the import graph (see {@link directlyImports}); the
  * metafile is captured via a small `onEnd` plugin because `bundle-require`
  * itself only exposes a flat `dependencies: string[]`.
+ *
+ * `options.plugins` are registered ahead of every other plugin — including
+ * `bundle-require`'s own `externalPlugin` — so a caller-supplied plugin can
+ * claim resolutions (e.g. `convex.config` imports) before the workspace and
+ * externalization heuristics see them.
  */
 export const bundle = (
   entryPoint: string,
+  options?: { readonly plugins?: ReadonlyArray<esbuild.Plugin> },
 ): Effect.Effect<Bundled, BundlerError, Path.Path> =>
   Effect.gen(function* () {
     const path = yield* Path.Path;
@@ -187,6 +193,7 @@ export const bundle = (
           format: "esm",
           esbuildOptions: {
             plugins: [
+              ...(options?.plugins ?? []),
               bundleWorkspacePlugin(path, skipPatterns),
               captureBuildResultPlugin(buildResultRef),
             ],

--- a/packages/cli/src/CodegenError.ts
+++ b/packages/cli/src/CodegenError.ts
@@ -125,6 +125,14 @@ export class ConflictingDocNameError extends Schema.TaggedError<ConflictingDocNa
   },
 ) {}
 
+export class InvalidConvexConfigError extends Schema.TaggedError<InvalidConvexConfigError>()(
+  "InvalidConvexConfigError",
+  {
+    configPath: Schema.String,
+    reason: Schema.String,
+  },
+) {}
+
 export const CodegenError = Schema.Union(
   BuildError,
   MissingImplFileError,
@@ -140,6 +148,7 @@ export const CodegenError = Schema.Union(
   DuplicateTableNameError,
   LegacySchemaFileError,
   ConflictingDocNameError,
+  InvalidConvexConfigError,
 );
 export type CodegenError = typeof CodegenError.Type;
 
@@ -306,6 +315,15 @@ const renderConflictingDocNameError = (
   );
 };
 
+const renderInvalidConvexConfigError = (
+  error: InvalidConvexConfigError,
+): AnsiDoc.AnsiDoc =>
+  singleLine(
+    AnsiDoc.text("Convex config "),
+    formatPathDoc(error.configPath),
+    AnsiDoc.text(` could not be evaluated: ${error.reason}`),
+  );
+
 const renderLegacySchemaFileError = (
   error: LegacySchemaFileError,
 ): AnsiDoc.AnsiDoc =>
@@ -404,6 +422,12 @@ export const renderCodegenError = (error: CodegenError): string => {
     Match.tag("ConflictingDocNameError", (e) =>
       pipe(
         renderConflictingDocNameError(e),
+        AnsiDoc.render({ style: "pretty" }),
+      ),
+    ),
+    Match.tag("InvalidConvexConfigError", (e) =>
+      pipe(
+        renderInvalidConvexConfigError(e),
         AnsiDoc.render({ style: "pretty" }),
       ),
     ),

--- a/packages/cli/src/ConvexConfig.ts
+++ b/packages/cli/src/ConvexConfig.ts
@@ -1,0 +1,259 @@
+import * as Path from "@effect/platform/Path";
+import * as Array from "effect/Array";
+import * as Effect from "effect/Effect";
+import { pipe } from "effect/Function";
+import * as Option from "effect/Option";
+import * as Order from "effect/Order";
+import * as Record from "effect/Record";
+import * as Schema from "effect/Schema";
+import type * as esbuild from "esbuild";
+import { fromBundlerError, type BuildError } from "./BuildError";
+import * as Bundler from "./Bundler";
+import { InvalidConvexConfigError } from "./CodegenError";
+
+export const CONVEX_CONFIG_FILENAME = "convex.config.ts";
+
+/**
+ * A component installed on the app via `app.use(...)` in
+ * `convex/convex.config.ts`.
+ */
+export interface InstalledComponent {
+  /**
+   * The mount name (`app.use`'s `name` option, falling back to the name the
+   * component was defined with).
+   */
+  readonly name: string;
+  /**
+   * Where the component's definition was imported from: the original import
+   * specifier when it was bare (e.g. `@convex-dev/workpool/convex.config`),
+   * or the resolved absolute path when it was relative (a locally-defined
+   * component).
+   */
+  readonly componentDefinitionPath: string;
+}
+
+const COMPONENT_CONFIG_NAMESPACE = "confect-component-config";
+
+/**
+ * Matches the trailing `convex.config` segment of a component-definition
+ * import (with or without an extension), e.g.
+ * `@convex-dev/workpool/convex.config` or `./waitlist/convex.config.ts`.
+ */
+const CONVEX_CONFIG_SUFFIX = /[/\\]convex\.config(\.[cm]?[jt]s)?$/;
+
+/**
+ * `convex/server`'s `app.use(definition)` rejects any definition object that
+ * lacks a string `componentDefinitionPath` ("This code only works in Convex
+ * runtime"): that property is normally stamped on by the Convex backend's
+ * module system when it evaluates a definition bundle. To evaluate
+ * `convex.config.ts` in plain Node, this plugin intercepts every non-entry
+ * import of a `convex.config` module (mirroring the Convex CLI's own
+ * `componentPlugin`) and swaps in a virtual wrapper that re-exports the real
+ * definition with `componentDefinitionPath` and `defaultName` filled in — the
+ * exact shape of Convex's `ImportedComponentDefinition`.
+ */
+export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
+  name: "confect:component-config",
+  setup(build) {
+    build.onResolve({ filter: /convex\.config/ }, (args) => {
+      // The app's own `convex.config.ts` is the entry point; only imports of
+      // *component* definitions get wrapped. Skipping non-file namespaces
+      // also stops the wrapper's own import of the real module (whose
+      // importer lives in this plugin's namespace) from recursing.
+      if (args.kind === "entry-point") return undefined;
+      if (args.namespace !== "file" && args.namespace !== "") return undefined;
+
+      const importer =
+        args.importer !== "" ? args.importer : path.join(args.resolveDir, "_");
+
+      // Component definitions are conventionally imported extensionless
+      // (`.../convex.config`), which npm `exports` maps resolve but plain
+      // file resolution may not — probe the same candidates Convex does.
+      const extension = path.extname(args.path);
+      const candidates = [
+        args.path,
+        ...(extension === ".js"
+          ? [args.path.slice(0, -".js".length) + ".ts"]
+          : []),
+        ...(extension !== ".js" && extension !== ".ts"
+          ? [args.path + ".js", args.path + ".ts"]
+          : []),
+      ];
+
+      return pipe(
+        candidates,
+        Array.filterMap((candidate) =>
+          Bundler.resolveModule(candidate, importer),
+        ),
+        Array.head,
+        Option.match({
+          onNone: () => undefined,
+          onSome: (resolved) => ({
+            path: resolved,
+            namespace: COMPONENT_CONFIG_NAMESPACE,
+            pluginData: { specifier: args.path },
+          }),
+        }),
+      );
+    });
+
+    build.onLoad(
+      { filter: /.*/, namespace: COMPONENT_CONFIG_NAMESPACE },
+      (args) => {
+        const specifier = (args.pluginData as { specifier: string }).specifier;
+        // Convex's codegen doesn't trust relative specifiers as identifiers
+        // (the importer's location is lost after bundling), so record the
+        // resolved absolute path for those; bare specifiers are kept verbatim
+        // so the generated type import stays a package specifier.
+        const isBareSpecifier =
+          !specifier.startsWith(".") && !path.isAbsolute(specifier);
+        const componentDefinitionPath = isBareSpecifier ? specifier : args.path;
+
+        // The real module is imported (not inlined) so that an npm component
+        // definition is externalized by `bundle-require` and evaluated from
+        // its own on-disk location, while a locally-defined `.ts` component
+        // gets bundled. `defaultName` comes from `defineComponent(name)`'s
+        // `_name`, keeping `app.use`'s name resolution identical to the
+        // Convex runtime's.
+        return {
+          loader: "js",
+          resolveDir: path.dirname(args.path),
+          contents: [
+            `import real from ${JSON.stringify(args.path)};`,
+            `export default { ...real, componentDefinitionPath: ${JSON.stringify(componentDefinitionPath)}, defaultName: real._name };`,
+          ].join("\n"),
+        };
+      },
+    );
+  },
+});
+
+/**
+ * The subset of `app.export()` (Convex's `AppDefinitionAnalysis`) that the
+ * registry needs: each installed component's mount name and the
+ * `componentDefinitionPath` injected by {@link componentConfigPlugin}.
+ */
+const AppDefinitionAnalysis = Schema.Struct({
+  childComponents: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      path: Schema.String,
+    }),
+  ),
+});
+
+const byName = Order.mapInput(
+  Order.string,
+  (component: InstalledComponent) => component.name,
+);
+
+/**
+ * Bundle and evaluate `convex/convex.config.ts` and list the components
+ * installed on the app, in mount-name order. `displayPath` is used in error
+ * messages (mirroring how impl/spec bundling reports relative paths).
+ */
+export const discoverInstalledComponents = (
+  convexConfigPath: string,
+  displayPath: string,
+): Effect.Effect<
+  ReadonlyArray<InstalledComponent>,
+  BuildError | InvalidConvexConfigError,
+  Path.Path
+> =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+
+    const { module } = yield* Bundler.bundle(convexConfigPath, {
+      plugins: [componentConfigPlugin(path)],
+    }).pipe(Effect.mapError((error) => fromBundlerError(displayPath, error)));
+
+    const app = module.default as
+      | { _isRoot?: unknown; export?: unknown }
+      | null
+      | undefined;
+
+    if (
+      app === null ||
+      typeof app !== "object" ||
+      app._isRoot !== true ||
+      typeof app.export !== "function"
+    ) {
+      return yield* new InvalidConvexConfigError({
+        configPath: displayPath,
+        reason:
+          "it must default-export the app definition created by `defineApp()`.",
+      });
+    }
+
+    const analysis = yield* Effect.try({
+      try: () => (app.export as () => unknown)(),
+      catch: (cause) =>
+        new InvalidConvexConfigError({
+          configPath: displayPath,
+          reason: `exporting the app definition threw: ${String(cause)}.`,
+        }),
+    });
+
+    const decoded = yield* Schema.decodeUnknown(AppDefinitionAnalysis)(
+      analysis,
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new InvalidConvexConfigError({
+            configPath: displayPath,
+            reason: `the app definition's installed components could not be read: ${cause.message}.`,
+          }),
+      ),
+    );
+
+    const components = pipe(
+      decoded.childComponents,
+      Array.map(
+        ({ name, path: componentDefinitionPath }): InstalledComponent => ({
+          name,
+          componentDefinitionPath,
+        }),
+      ),
+      Array.sort(byName),
+    );
+
+    const duplicateNames = pipe(
+      components,
+      Array.groupBy(({ name }) => name),
+      Record.toEntries,
+      Array.filter(([, group]) => group.length > 1),
+      Array.map(([name]) => name),
+    );
+    if (Array.isNonEmptyReadonlyArray(duplicateNames)) {
+      return yield* new InvalidConvexConfigError({
+        configPath: displayPath,
+        reason: `multiple components are installed under the same name (${Array.join(duplicateNames, ", ")}); pass a unique \`name\` to \`app.use\` for each.`,
+      });
+    }
+
+    return components;
+  });
+
+/**
+ * The module specifier the generated registry's `ComponentApi` type import
+ * should use for a component, following Convex's own codegen convention:
+ * `<definition path minus the trailing convex.config segment>/_generated/component.js`.
+ * Bare (npm) definition paths are used verbatim; locally-defined components
+ * (recorded as absolute paths) become a relative path from
+ * `confect/_generated`.
+ */
+export const typeImportPath = (
+  path: Path.Path,
+  componentDefinitionPath: string,
+  confectGeneratedDirectory: string,
+): string => {
+  const stripped = componentDefinitionPath.replace(CONVEX_CONFIG_SUFFIX, "");
+  if (!path.isAbsolute(stripped)) {
+    return stripped;
+  }
+  const relative = path
+    .relative(confectGeneratedDirectory, stripped)
+    .split(path.sep)
+    .join("/");
+  return relative.startsWith(".") ? relative : `./${relative}`;
+};

--- a/packages/cli/src/ConvexConfig.ts
+++ b/packages/cli/src/ConvexConfig.ts
@@ -24,10 +24,12 @@ export interface InstalledComponent {
    */
   readonly name: string;
   /**
-   * Where the component's definition was imported from: the original import
-   * specifier when it was bare (e.g. `@convex-dev/workpool/convex.config`),
-   * or the resolved absolute path when it was relative (a locally-defined
-   * component).
+   * The directory the component's definition lives in, mirroring the Convex
+   * runtime's convention (a `componentDefinitionPath` identifies the
+   * definition's directory): the import specifier minus its trailing
+   * `convex.config` segment when it was bare (e.g. `@convex-dev/workpool`),
+   * or the resolved absolute directory when it was relative (a
+   * locally-defined component).
    */
   readonly componentDefinitionPath: string;
 }
@@ -101,13 +103,21 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
       { filter: /.*/, namespace: COMPONENT_CONFIG_NAMESPACE },
       (args) => {
         const specifier = (args.pluginData as { specifier: string }).specifier;
-        // Convex's codegen doesn't trust relative specifiers as identifiers
-        // (the importer's location is lost after bundling), so record the
-        // resolved absolute path for those; bare specifiers are kept verbatim
-        // so the generated type import stays a package specifier.
+        // The injected path is the definition's *directory*, matching the
+        // Convex runtime's convention — so even if a future convex version
+        // stops reading `defaultName`, `app.use`'s last-resort fallback
+        // (`componentDefinitionPath.split("/").pop()`) still yields the
+        // conventional component name rather than `convex.config`. Convex's
+        // codegen doesn't trust relative specifiers as identifiers (the
+        // importer's location is lost after bundling), so those are recorded
+        // as the resolved absolute directory; bare specifiers keep their
+        // package prefix so the generated type import stays a package
+        // specifier.
         const isBareSpecifier =
           !specifier.startsWith(".") && !path.isAbsolute(specifier);
-        const componentDefinitionPath = isBareSpecifier ? specifier : args.path;
+        const componentDefinitionPath = isBareSpecifier
+          ? specifier.replace(CONVEX_CONFIG_SUFFIX, "")
+          : path.dirname(args.path);
 
         // The real module is imported (not inlined) so that an npm component
         // definition is externalized by `bundle-require` and evaluated from
@@ -146,6 +156,16 @@ const byName = Order.mapInput(
   Order.string,
   (component: InstalledComponent) => component.name,
 );
+
+/**
+ * Convex component names must be alphanumeric plus underscores (see
+ * `defineComponent`'s docs). Beyond rejecting genuinely invalid names, this
+ * is a drift tripwire: if a future convex version stopped resolving names
+ * the way we rely on (e.g. `defaultName` disappearing), the fallback name
+ * would be a path segment like `convex.config` — caught here as a clear
+ * error instead of silently emitting a broken registry.
+ */
+const VALID_COMPONENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
  * Bundle and evaluate `convex/convex.config.ts` and list the components
@@ -217,6 +237,22 @@ export const discoverInstalledComponents = (
       Array.sort(byName),
     );
 
+    const invalidNames = pipe(
+      components,
+      Array.map(({ name }) => name),
+      Array.filter((name) => !VALID_COMPONENT_NAME.test(name)),
+    );
+    if (Array.isNonEmptyReadonlyArray(invalidNames)) {
+      return yield* new InvalidConvexConfigError({
+        configPath: displayPath,
+        reason: `component names must be alphanumeric plus underscores, but got: ${pipe(
+          invalidNames,
+          Array.map((name) => `"${name}"`),
+          Array.join(", "),
+        )}. Pass a valid \`name\` to \`app.use\`.`,
+      });
+    }
+
     const duplicateNames = pipe(
       components,
       Array.groupBy(({ name }) => name),
@@ -237,22 +273,20 @@ export const discoverInstalledComponents = (
 /**
  * The module specifier the generated registry's `ComponentApi` type import
  * should use for a component, following Convex's own codegen convention:
- * `<definition path minus the trailing convex.config segment>/_generated/component.js`.
- * Bare (npm) definition paths are used verbatim; locally-defined components
- * (recorded as absolute paths) become a relative path from
- * `confect/_generated`.
+ * `<definition directory>/_generated/component.js`. Bare (npm) definition
+ * directories are used verbatim; locally-defined components (recorded as
+ * absolute directories) become a relative path from `confect/_generated`.
  */
 export const typeImportPath = (
   path: Path.Path,
   componentDefinitionPath: string,
   confectGeneratedDirectory: string,
 ): string => {
-  const stripped = componentDefinitionPath.replace(CONVEX_CONFIG_SUFFIX, "");
-  if (!path.isAbsolute(stripped)) {
-    return stripped;
+  if (!path.isAbsolute(componentDefinitionPath)) {
+    return componentDefinitionPath;
   }
   const relative = path
-    .relative(confectGeneratedDirectory, stripped)
+    .relative(confectGeneratedDirectory, componentDefinitionPath)
     .split(path.sep)
     .join("/");
   return relative.startsWith(".") ? relative : `./${relative}`;

--- a/packages/cli/src/ConvexConfig.ts
+++ b/packages/cli/src/ConvexConfig.ts
@@ -6,6 +6,7 @@ import * as Option from "effect/Option";
 import * as Order from "effect/Order";
 import * as Record from "effect/Record";
 import * as Schema from "effect/Schema";
+import * as String from "effect/String";
 import type * as esbuild from "esbuild";
 import { fromBundlerError, type BuildError } from "./BuildError";
 import * as Bundler from "./Bundler";
@@ -75,7 +76,7 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
       const candidates = [
         args.path,
         ...(extension === ".js"
-          ? [args.path.slice(0, -".js".length) + ".ts"]
+          ? [String.slice(0, -".js".length)(args.path) + ".ts"]
           : []),
         ...(extension !== ".js" && extension !== ".ts"
           ? [args.path + ".js", args.path + ".ts"]
@@ -114,9 +115,9 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
         // package prefix so the generated type import stays a package
         // specifier.
         const isBareSpecifier =
-          !specifier.startsWith(".") && !path.isAbsolute(specifier);
+          !String.startsWith(".")(specifier) && !path.isAbsolute(specifier);
         const componentDefinitionPath = isBareSpecifier
-          ? specifier.replace(CONVEX_CONFIG_SUFFIX, "")
+          ? String.replace(CONVEX_CONFIG_SUFFIX, "")(specifier)
           : path.dirname(args.path);
 
         // The real module is imported (not inlined) so that an npm component
@@ -128,10 +129,13 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
         return {
           loader: "js",
           resolveDir: path.dirname(args.path),
-          contents: [
-            `import real from ${JSON.stringify(args.path)};`,
-            `export default { ...real, componentDefinitionPath: ${JSON.stringify(componentDefinitionPath)}, defaultName: real._name };`,
-          ].join("\n"),
+          contents: Array.join(
+            [
+              `import real from ${JSON.stringify(args.path)};`,
+              `export default { ...real, componentDefinitionPath: ${JSON.stringify(componentDefinitionPath)}, defaultName: real._name };`,
+            ],
+            "\n",
+          ),
         };
       },
     );
@@ -210,7 +214,7 @@ export const discoverInstalledComponents = (
       catch: (cause) =>
         new InvalidConvexConfigError({
           configPath: displayPath,
-          reason: `exporting the app definition threw: ${String(cause)}.`,
+          reason: `exporting the app definition threw: ${globalThis.String(cause)}.`,
         }),
     });
 
@@ -240,7 +244,9 @@ export const discoverInstalledComponents = (
     const invalidNames = pipe(
       components,
       Array.map(({ name }) => name),
-      Array.filter((name) => !VALID_COMPONENT_NAME.test(name)),
+      Array.filter((name) =>
+        Option.isNone(String.match(VALID_COMPONENT_NAME)(name)),
+      ),
     );
     if (Array.isNonEmptyReadonlyArray(invalidNames)) {
       return yield* new InvalidConvexConfigError({
@@ -285,9 +291,10 @@ export const typeImportPath = (
   if (!path.isAbsolute(componentDefinitionPath)) {
     return componentDefinitionPath;
   }
-  const relative = path
-    .relative(confectGeneratedDirectory, componentDefinitionPath)
-    .split(path.sep)
-    .join("/");
-  return relative.startsWith(".") ? relative : `./${relative}`;
+  const relative = pipe(
+    path.relative(confectGeneratedDirectory, componentDefinitionPath),
+    String.split(path.sep),
+    Array.join("/"),
+  );
+  return String.startsWith(".")(relative) ? relative : `./${relative}`;
 };

--- a/packages/cli/src/confect/codegen.ts
+++ b/packages/cli/src/confect/codegen.ts
@@ -20,6 +20,7 @@ import {
   ParentChildNameCollisionError,
 } from "../CodegenError";
 import { ConfectDirectory } from "../ConfectDirectory";
+import * as ConvexConfig from "../ConvexConfig";
 import { ConvexDirectory } from "../ConvexDirectory";
 import * as DocName from "../DocName";
 import * as FunctionPaths from "../FunctionPaths";
@@ -42,6 +43,7 @@ import {
   logSuccess,
   logWarn,
 } from "../log";
+import { ProjectRoot } from "../ProjectRoot";
 import {
   assemblyNodesFromLeaves,
   type SpecAssemblyNode,
@@ -73,6 +75,9 @@ const GENERATED_CONVEX_SCHEMA_PATH = Effect.andThen(Path.Path, (path) =>
 );
 const GENERATED_ID_PATH = Effect.andThen(Path.Path, (path) =>
   path.join(GENERATED_DIRNAME, "id.ts"),
+);
+const GENERATED_COMPONENTS_PATH = Effect.andThen(Path.Path, (path) =>
+  path.join(GENERATED_DIRNAME, "components.ts"),
 );
 const GENERATED_TABLES_DIRNAME = Effect.andThen(Path.Path, (path) =>
   path.join(GENERATED_DIRNAME, "tables"),
@@ -160,6 +165,9 @@ const runCodegen = Effect.gen(function* () {
       generateDocs(tableModules),
       generateServices,
       generateConvexSchema(tableModules),
+      // Must land before impl validation: impls may import the generated
+      // components registry, so it has to exist when their bundles are built.
+      generateComponents,
     ],
     { concurrency: "unbounded" },
   );
@@ -891,6 +899,57 @@ const generateRefs = Effect.gen(function* () {
   const refsContents = yield* templates.refs({ specImportPath });
 
   yield* writeFileStringAndLog(refsPath, refsContents);
+});
+
+/**
+ * Generate `confect/_generated/components.ts` — the typed registry of Convex
+ * components installed in `convex/convex.config.ts` (see
+ * {@link templates.components}). The file is emitted even when there is no
+ * `convex.config.ts` (as an empty registry) so the import surface stays
+ * stable. It must exist before impl validation because impl modules may
+ * import it.
+ */
+export const generateComponents = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const convexDirectory = yield* ConvexDirectory.get;
+  const projectRoot = yield* ProjectRoot.get;
+
+  const confectGeneratedDirectory = path.join(
+    confectDirectory,
+    GENERATED_DIRNAME,
+  );
+  const generatedComponentsPath = yield* GENERATED_COMPONENTS_PATH;
+  const componentsPath = path.join(confectDirectory, generatedComponentsPath);
+
+  const convexConfigPath = path.join(
+    convexDirectory,
+    ConvexConfig.CONVEX_CONFIG_FILENAME,
+  );
+
+  const installedComponents = (yield* fs.exists(convexConfigPath))
+    ? yield* ConvexConfig.discoverInstalledComponents(
+        convexConfigPath,
+        path.relative(projectRoot, convexConfigPath),
+      )
+    : [];
+
+  const contents = yield* templates.components({
+    components: Array.map(
+      installedComponents,
+      ({ name, componentDefinitionPath }) => ({
+        name,
+        typeImportPath: ConvexConfig.typeImportPath(
+          path,
+          componentDefinitionPath,
+          confectGeneratedDirectory,
+        ),
+      }),
+    ),
+  });
+
+  yield* writeFileStringAndLog(componentsPath, contents);
 });
 
 const logGenerated = (effect: typeof generateHttp) =>

--- a/packages/cli/src/confect/dev.ts
+++ b/packages/cli/src/confect/dev.ts
@@ -31,6 +31,7 @@ import * as esbuild from "esbuild";
 import * as Bundler from "../Bundler";
 import * as CodegenError from "../CodegenError";
 import { ConfectDirectory } from "../ConfectDirectory";
+import { CONVEX_CONFIG_FILENAME } from "../ConvexConfig";
 import { ConvexDirectory } from "../ConvexDirectory";
 import * as FunctionPaths from "../FunctionPaths";
 import type * as GroupPaths from "../GroupPaths";
@@ -225,6 +226,7 @@ export const dev = Command.make("dev", {}, () =>
           ),
         ),
         confectStructureWatcher(signal, pendingRef, restartQueue),
+        convexConfigStructureWatcher(signal, pendingRef, restartQueue),
         syncLoop(
           signal,
           pendingRef,
@@ -464,7 +466,28 @@ const discoverEntryPoints = Effect.gen(function* () {
     (relativePath) => tryEntry(relativePath, "specDirty"),
   );
 
-  return Array.getSomes([...fixedEntryOptions, ...implEntryOptions]);
+  // `convex/convex.config.ts` feeds the generated components registry, so
+  // edits to it (or to a locally-defined component definition it imports —
+  // npm component definitions are externalized and not watched) must re-run
+  // codegen.
+  const convexDirectory = yield* ConvexDirectory.get;
+  const convexConfigEntryOption = yield* Effect.gen(function* () {
+    const absolutePath = path.join(convexDirectory, CONVEX_CONFIG_FILENAME);
+    if (!(yield* fs.exists(absolutePath))) {
+      return Option.none<EntryPoint>();
+    }
+    return Option.some<EntryPoint>({
+      absolutePath,
+      displayPath: path.relative(projectRoot, absolutePath),
+      pendingKey: "specDirty",
+    });
+  });
+
+  return Array.getSomes([
+    ...fixedEntryOptions,
+    convexConfigEntryOption,
+    ...implEntryOptions,
+  ]);
 });
 
 const esbuildOptions = (
@@ -698,6 +721,41 @@ const confectStructureWatcher = (
           pendingRef,
           restartQueue,
         }),
+      ),
+    );
+  });
+
+/**
+ * Non-recursive `fs.watch` on the convex directory, reacting only to
+ * `convex.config.ts`. Recursion is deliberately avoided: codegen (Confect's
+ * and Convex's) writes into `convex/` and `convex/_generated/` constantly,
+ * and reacting to those writes would loop. Create/Remove offers to
+ * `restartQueue` so the entry-point watcher set picks up (or drops) the
+ * config's esbuild watcher.
+ */
+const convexConfigStructureWatcher = (
+  signal: Queue.Queue<void>,
+  pendingRef: Ref.Ref<Pending>,
+  restartQueue: Queue.Queue<void>,
+) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const convexDirectory = yield* ConvexDirectory.get;
+
+    yield* pipe(
+      fs.watch(convexDirectory),
+      Stream.debounce(Duration.millis(200)),
+      Stream.runForEach((event) =>
+        path.relative(convexDirectory, event.path) === CONVEX_CONFIG_FILENAME
+          ? flipDirtyAndSignal(
+              pendingRef,
+              signal,
+              "specDirty",
+              restartQueue,
+              event._tag !== "Update",
+            )
+          : Effect.void,
       ),
     );
   });

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -295,9 +295,10 @@ export const authConfig = ({ authImportPath }: { authImportPath: string }) =>
  * evaluates each impl's import graph, and `convex/_generated/api` doesn't
  * exist yet at that point.
  *
- * The `as unknown as` cast is confined here: `componentsGeneric()` is typed
+ * The `as any` cast is confined here: `componentsGeneric()` is typed
  * `AnyChildComponents`, which deliberately doesn't overlap the precise
- * registry type.
+ * registry type; the `Components` annotation on the const supplies the
+ * real type.
  */
 export const components = ({
   components: installedComponents,
@@ -329,7 +330,7 @@ export const components = ({
     yield* cbw.blankLine();
 
     yield* cbw.writeLine(
-      `export const components: Components = componentsGeneric() as unknown as Components;`,
+      `export const components: Components = componentsGeneric() as any;`,
     );
 
     return yield* cbw.toString();

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -283,6 +283,58 @@ export const authConfig = ({ authImportPath }: { authImportPath: string }) =>
     return yield* cbw.toString();
   });
 
+/**
+ * Emit `confect/_generated/components.ts` — a typed registry of the Convex
+ * components installed via `app.use(...)` in `convex/convex.config.ts`.
+ * Mirrors the `components` export of Convex's generated
+ * `convex/_generated/api`: the runtime value is `componentsGeneric()` (a
+ * name-preserving proxy), and each entry is typed with the `ComponentApi`
+ * that component packages export from `_generated/component.js`. Unlike
+ * `convex/_generated/api`, this file exists before `convex codegen` ever
+ * runs, so impl modules can import it safely — `confect codegen` bundles and
+ * evaluates each impl's import graph, and `convex/_generated/api` doesn't
+ * exist yet at that point.
+ *
+ * The `as unknown as` cast is confined here: `componentsGeneric()` is typed
+ * `AnyChildComponents`, which deliberately doesn't overlap the precise
+ * registry type.
+ */
+export const components = ({
+  components: installedComponents,
+}: {
+  components: ReadonlyArray<{ name: string; typeImportPath: string }>;
+}) =>
+  Effect.gen(function* () {
+    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+
+    yield* cbw.writeLine(`import { componentsGeneric } from "convex/server";`);
+    yield* cbw.blankLine();
+
+    if (installedComponents.length === 0) {
+      yield* cbw.writeLine(`export type Components = {};`);
+    } else {
+      yield* cbw.writeLine(`export type Components = {`);
+      yield* cbw.indent(
+        Effect.forEach(
+          installedComponents,
+          ({ name, typeImportPath }) =>
+            cbw.writeLine(
+              `"${name}": import("${typeImportPath}/_generated/component.js").ComponentApi<"${name}">;`,
+            ),
+          { discard: true },
+        ),
+      );
+      yield* cbw.writeLine(`};`);
+    }
+    yield* cbw.blankLine();
+
+    yield* cbw.writeLine(
+      `export const components: Components = componentsGeneric() as unknown as Components;`,
+    );
+
+    return yield* cbw.toString();
+  });
+
 export const refs = ({ specImportPath }: { specImportPath: string }) =>
   Effect.gen(function* () {
     const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });

--- a/packages/cli/test/ConvexConfig.test.ts
+++ b/packages/cli/test/ConvexConfig.test.ts
@@ -174,7 +174,7 @@ export type Components = {
   "workpool": import("@convex-dev/workpool/_generated/component.js").ComponentApi<"workpool">;
 };
 
-export const components: Components = componentsGeneric() as unknown as Components;
+export const components: Components = componentsGeneric() as any;
 `,
       );
     }).pipe(Effect.scoped),
@@ -206,7 +206,7 @@ export const components: Components = componentsGeneric() as unknown as Componen
 
 export type Components = {};
 
-export const components: Components = componentsGeneric() as unknown as Components;
+export const components: Components = componentsGeneric() as any;
 `,
       );
     }).pipe(Effect.scoped),

--- a/packages/cli/test/ConvexConfig.test.ts
+++ b/packages/cli/test/ConvexConfig.test.ts
@@ -1,0 +1,199 @@
+import * as FileSystem from "@effect/platform/FileSystem";
+import * as Path from "@effect/platform/Path";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { assert, expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Either from "effect/Either";
+import * as Layer from "effect/Layer";
+import { generateComponents } from "@confect/cli/confect/codegen";
+import { ConfectDirectory } from "@confect/cli/ConfectDirectory";
+import {
+  discoverInstalledComponents,
+  typeImportPath,
+} from "@confect/cli/ConvexConfig";
+import { ConvexDirectory } from "@confect/cli/ConvexDirectory";
+import { ProjectRoot } from "@confect/cli/ProjectRoot";
+
+const fixturesRoot = `${import.meta.dirname}/fixtures/components`;
+
+const TestLayer = Layer.mergeAll(NodePath.layer, NodeFileSystem.layer);
+
+const directoriesLayer = ({
+  confectDirectory,
+  convexDirectory,
+  projectRoot,
+}: {
+  confectDirectory: string;
+  convexDirectory: string;
+  projectRoot: string;
+}) =>
+  Layer.mergeAll(
+    Layer.mock(ConfectDirectory, {
+      _tag: "@confect/cli/ConfectDirectory",
+      get: Effect.succeed(confectDirectory),
+    }),
+    Layer.mock(ConvexDirectory, {
+      _tag: "@confect/cli/ConvexDirectory",
+      get: Effect.succeed(convexDirectory),
+    }),
+    Layer.mock(ProjectRoot, {
+      _tag: "@confect/cli/ProjectRoot",
+      get: Effect.succeed(projectRoot),
+    }),
+  );
+
+layer(TestLayer)("discoverInstalledComponents", (it) => {
+  it.effect(
+    "lists npm components by mount name, keeping bare import specifiers",
+    () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const components = yield* discoverInstalledComponents(
+          path.join(fixturesRoot, "bare", "convex", "convex.config.ts"),
+          "convex/convex.config.ts",
+        );
+
+        expect(components).toEqual([
+          {
+            name: "secondPool",
+            componentDefinitionPath: "@convex-dev/workpool/convex.config",
+          },
+          {
+            name: "workpool",
+            componentDefinitionPath: "@convex-dev/workpool/convex.config",
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "records locally-defined components as resolved absolute paths",
+    () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const components = yield* discoverInstalledComponents(
+          path.join(fixturesRoot, "local", "convex", "convex.config.ts"),
+          "convex/convex.config.ts",
+        );
+
+        assert.strictEqual(components.length, 1);
+        const [waitlist] = components;
+        assert(waitlist !== undefined);
+        expect(waitlist.name).toBe("waitlist");
+        expect(path.isAbsolute(waitlist.componentDefinitionPath)).toBe(true);
+        expect(
+          waitlist.componentDefinitionPath.endsWith(
+            path.join("local", "convex", "waitlist", "convex.config.ts"),
+          ),
+        ).toBe(true);
+
+        const importPath = typeImportPath(
+          path,
+          waitlist.componentDefinitionPath,
+          path.join(fixturesRoot, "local", "confect", "_generated"),
+        );
+        expect(importPath).toBe("../../convex/waitlist");
+      }),
+  );
+
+  it.effect("fails with a BuildError when the config throws on import", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const result = yield* Effect.either(
+        discoverInstalledComponents(
+          path.join(fixturesRoot, "throwing", "convex", "convex.config.ts"),
+          "convex/convex.config.ts",
+        ),
+      );
+
+      assert(Either.isLeft(result));
+      expect(result.left._tag).toBe("ImportFailedError");
+    }),
+  );
+
+  it.effect(
+    "fails with InvalidConvexConfigError when the default export is not an app definition",
+    () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const result = yield* Effect.either(
+          discoverInstalledComponents(
+            path.join(fixturesRoot, "invalid", "convex", "convex.config.ts"),
+            "convex/convex.config.ts",
+          ),
+        );
+
+        assert(Either.isLeft(result));
+        expect(result.left._tag).toBe("InvalidConvexConfigError");
+      }),
+  );
+});
+
+layer(TestLayer)("generateComponents", (it) => {
+  it.effect("writes a typed registry derived from `app.use(...)` calls", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const confectDirectory = yield* fs.makeTempDirectoryScoped();
+      yield* fs.makeDirectory(path.join(confectDirectory, "_generated"));
+
+      yield* generateComponents.pipe(
+        Effect.provide(
+          directoriesLayer({
+            confectDirectory,
+            convexDirectory: path.join(fixturesRoot, "bare", "convex"),
+            projectRoot: path.join(fixturesRoot, "bare"),
+          }),
+        ),
+      );
+
+      const contents = yield* fs.readFileString(
+        path.join(confectDirectory, "_generated", "components.ts"),
+      );
+      expect(contents).toBe(
+        `import { componentsGeneric } from "convex/server";
+
+export type Components = {
+  "secondPool": import("@convex-dev/workpool/_generated/component.js").ComponentApi<"secondPool">;
+  "workpool": import("@convex-dev/workpool/_generated/component.js").ComponentApi<"workpool">;
+};
+
+export const components: Components = componentsGeneric() as unknown as Components;
+`,
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("writes an empty registry when there is no convex.config.ts", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const confectDirectory = yield* fs.makeTempDirectoryScoped();
+      yield* fs.makeDirectory(path.join(confectDirectory, "_generated"));
+      const convexDirectory = yield* fs.makeTempDirectoryScoped();
+
+      yield* generateComponents.pipe(
+        Effect.provide(
+          directoriesLayer({
+            confectDirectory,
+            convexDirectory,
+            projectRoot: path.dirname(convexDirectory),
+          }),
+        ),
+      );
+
+      const contents = yield* fs.readFileString(
+        path.join(confectDirectory, "_generated", "components.ts"),
+      );
+      expect(contents).toBe(
+        `import { componentsGeneric } from "convex/server";
+
+export type Components = {};
+
+export const components: Components = componentsGeneric() as unknown as Components;
+`,
+      );
+    }).pipe(Effect.scoped),
+  );
+});

--- a/packages/cli/test/ConvexConfig.test.ts
+++ b/packages/cli/test/ConvexConfig.test.ts
@@ -57,18 +57,18 @@ layer(TestLayer)("discoverInstalledComponents", (it) => {
         expect(components).toEqual([
           {
             name: "secondPool",
-            componentDefinitionPath: "@convex-dev/workpool/convex.config",
+            componentDefinitionPath: "@convex-dev/workpool",
           },
           {
             name: "workpool",
-            componentDefinitionPath: "@convex-dev/workpool/convex.config",
+            componentDefinitionPath: "@convex-dev/workpool",
           },
         ]);
       }),
   );
 
   it.effect(
-    "records locally-defined components as resolved absolute paths",
+    "records locally-defined components as resolved absolute directories",
     () =>
       Effect.gen(function* () {
         const path = yield* Path.Path;
@@ -81,12 +81,9 @@ layer(TestLayer)("discoverInstalledComponents", (it) => {
         const [waitlist] = components;
         assert(waitlist !== undefined);
         expect(waitlist.name).toBe("waitlist");
-        expect(path.isAbsolute(waitlist.componentDefinitionPath)).toBe(true);
-        expect(
-          waitlist.componentDefinitionPath.endsWith(
-            path.join("local", "convex", "waitlist", "convex.config.ts"),
-          ),
-        ).toBe(true);
+        expect(waitlist.componentDefinitionPath).toBe(
+          path.join(fixturesRoot, "local", "convex", "waitlist"),
+        );
 
         const importPath = typeImportPath(
           path,
@@ -110,6 +107,24 @@ layer(TestLayer)("discoverInstalledComponents", (it) => {
       assert(Either.isLeft(result));
       expect(result.left._tag).toBe("ImportFailedError");
     }),
+  );
+
+  it.effect(
+    "fails with InvalidConvexConfigError when a component name is invalid",
+    () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const result = yield* Effect.either(
+          discoverInstalledComponents(
+            path.join(fixturesRoot, "badName", "convex", "convex.config.ts"),
+            "convex/convex.config.ts",
+          ),
+        );
+
+        assert(Either.isLeft(result));
+        assert(result.left._tag === "InvalidConvexConfigError");
+        expect(result.left.reason).toContain('"not a valid name"');
+      }),
   );
 
   it.effect(

--- a/packages/cli/test/fixtures/components/badName/convex/convex.config.ts
+++ b/packages/cli/test/fixtures/components/badName/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import workpool from "@convex-dev/workpool/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(workpool, { name: "not a valid name" });
+
+export default app;

--- a/packages/cli/test/fixtures/components/bare/convex/convex.config.ts
+++ b/packages/cli/test/fixtures/components/bare/convex/convex.config.ts
@@ -1,0 +1,8 @@
+import workpool from "@convex-dev/workpool/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(workpool);
+app.use(workpool, { name: "secondPool" });
+
+export default app;

--- a/packages/cli/test/fixtures/components/invalid/convex/convex.config.ts
+++ b/packages/cli/test/fixtures/components/invalid/convex/convex.config.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/cli/test/fixtures/components/local/convex/convex.config.ts
+++ b/packages/cli/test/fixtures/components/local/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import { defineApp } from "convex/server";
+import waitlist from "./waitlist/convex.config";
+
+const app = defineApp();
+app.use(waitlist);
+
+export default app;

--- a/packages/cli/test/fixtures/components/local/convex/waitlist/convex.config.ts
+++ b/packages/cli/test/fixtures/components/local/convex/waitlist/convex.config.ts
@@ -1,0 +1,3 @@
+import { defineComponent } from "convex/server";
+
+export default defineComponent("waitlist");

--- a/packages/cli/test/fixtures/components/throwing/convex/convex.config.ts
+++ b/packages/cli/test/fixtures/components/throwing/convex/convex.config.ts
@@ -1,0 +1,10 @@
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+
+const alwaysThrows = () => {
+  throw new Error("convex.config.ts evaluation failed");
+};
+alwaysThrows();
+
+export default app;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
     devDependencies:
+      '@convex-dev/workpool':
+        specifier: 0.4.6
+        version: 0.4.6(convex-helpers@0.1.118(@standard-schema/spec@1.1.0)(convex@1.40.0(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(convex@1.40.0(react@19.2.4))
       '@effect/language-service':
         specifier: 0.86.1
         version: 0.86.1
@@ -193,6 +196,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.3)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.6.0))
+      convex:
+        specifier: 1.40.0
+        version: 1.40.0(react@19.2.4)
       effect:
         specifier: 3.21.2
         version: 3.21.2


### PR DESCRIPTION
Generate a typed `components` registry at `confect/_generated/components.ts` by evaluating `convex/convex.config.ts` and extracting installed components from `app.use(...)` calls.

## Summary

This change enables Confect to generate a typed registry of Convex components that can be safely imported from anywhere in the `confect/` directory. Previously, the only typed registry was `convex/_generated/api`'s `components` export, which cannot be imported during `confect codegen` because `convex/_generated/api` doesn't exist yet when Confect evaluates impl modules.

## Key Changes

- **New `ConvexConfig.ts` module**: Implements component discovery by:
  - Bundling and evaluating `convex/convex.config.ts` in Node
  - Injecting a custom esbuild plugin (`componentConfigPlugin`) that wraps component definition imports with `componentDefinitionPath` and `defaultName` metadata (mirroring Convex's runtime behavior)
  - Parsing the app definition's `childComponents` to extract mount names and definition paths
  - Validating component names and detecting duplicates
  - Computing relative import paths for locally-defined components

- **New `generateComponents` effect in `codegen.ts`**: Generates `confect/_generated/components.ts` with:
  - A `Components` type with one entry per installed component, typed with each component's `ComponentApi`
  - A `components` const initialized via `componentsGeneric()` (matching Convex's pattern)
  - Graceful handling of missing `convex.config.ts` (emits empty registry)
  - Execution before impl validation so impls can safely import the registry

- **New `components` template in `templates.ts`**: Renders the typed registry file

- **Dev mode integration**: Added `convexConfigStructureWatcher` to detect changes to `convex.config.ts` and trigger codegen restart (without recursing into `convex/_generated/` writes)

- **Error handling**: New `InvalidConvexConfigError` for config evaluation failures, invalid component names, and duplicates

- **Documentation updates**: Added component usage guide showing how to import and use the typed registry

- **Test fixtures and suite**: Comprehensive tests covering bare npm components, locally-defined components, invalid names, missing configs, and evaluation errors

## Implementation Details

The `componentConfigPlugin` intercepts non-entry imports of `convex.config` modules and wraps them in a virtual module that re-exports the definition with injected metadata. This allows the plugin to evaluate component definitions in plain Node (where they lack the Convex runtime's automatic metadata injection) while preserving the distinction between bare specifiers (npm packages, kept as-is) and relative paths (locally-defined, resolved to absolute directories for consistency with Convex's codegen).

https://claude.ai/code/session_018q2weeQmJUhC2mY9d24181