### PR TITLE
Fix nested component config discovery in codegen

### DIFF
--- a/.changeset/fix-nested-component-codegen.md
+++ b/.changeset/fix-nested-component-codegen.md
@@ -1,0 +1,7 @@
+---
+"@confect/cli": patch
+---
+
+Fix `confect codegen` and `confect dev` failing to load `convex/convex.config.ts` when an installed component's own definition installs other components (e.g. `@convex-dev/resend`, which nests rate-limiter and workpool components).
+
+Previously, evaluating the config threw "Component definition does not have the required componentDefinitionPath property. This code only works in Convex runtime." Component definitions are now recognized recursively, so components may nest other components to any depth.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ coverage/
 dist/
 node-compile-cache/
 node_modules/
+# Fake npm packages that component-discovery test fixtures resolve against.
+!packages/cli/test/fixtures/components/*/node_modules/
+!packages/cli/test/fixtures/components/*/node_modules/**/dist/
 opensrc/
 tsconfig.vitest-temp.json
 *.tsbuildinfo

--- a/packages/cli/src/ConvexConfig.ts
+++ b/packages/cli/src/ConvexConfig.ts
@@ -60,10 +60,20 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
   setup(build) {
     build.onResolve({ filter: /convex\.config/ }, (args) => {
       // The app's own `convex.config.ts` is the entry point; only imports of
-      // *component* definitions get wrapped. Skipping non-file namespaces
-      // also stops the wrapper's own import of the real module (whose
-      // importer lives in this plugin's namespace) from recursing.
+      // *component* definitions get wrapped.
       if (args.kind === "entry-point") return undefined;
+
+      // A wrapper's import of the real definition (its importer lives in
+      // this plugin's namespace) is claimed into the file namespace so the
+      // definition gets bundled: its own nested `convex.config` imports then
+      // re-enter this plugin and get stamped too, matching the Convex CLI's
+      // own `componentPlugin`. Left to `bundle-require`'s externalizer, an
+      // npm definition would be evaluated natively by Node — where no plugin
+      // can stamp its nested definitions, so a component that nests other
+      // components would throw from its top-level `component.use(...)`.
+      if (args.namespace === COMPONENT_CONFIG_NAMESPACE) {
+        return { path: args.path };
+      }
       if (args.namespace !== "file" && args.namespace !== "") return undefined;
 
       const importer =
@@ -120,12 +130,11 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
           ? String.replace(CONVEX_CONFIG_SUFFIX, "")(specifier)
           : path.dirname(args.path);
 
-        // The real module is imported (not inlined) so that an npm component
-        // definition is externalized by `bundle-require` and evaluated from
-        // its own on-disk location, while a locally-defined `.ts` component
-        // gets bundled. `defaultName` comes from `defineComponent(name)`'s
-        // `_name`, keeping `app.use`'s name resolution identical to the
-        // Convex runtime's.
+        // The real module is imported (not inlined) so it's loaded as its
+        // own file-namespace module: its nested `convex.config` imports then
+        // come from a file-namespace importer and re-enter this plugin.
+        // `defaultName` comes from `defineComponent(name)`'s `_name`, keeping
+        // `app.use`'s name resolution identical to the Convex runtime's.
         return {
           loader: "js",
           resolveDir: path.dirname(args.path),

--- a/packages/cli/src/ConvexConfig.ts
+++ b/packages/cli/src/ConvexConfig.ts
@@ -63,14 +63,11 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
       // *component* definitions get wrapped.
       if (args.kind === "entry-point") return undefined;
 
-      // A wrapper's import of the real definition (its importer lives in
-      // this plugin's namespace) is claimed into the file namespace so the
-      // definition gets bundled: its own nested `convex.config` imports then
-      // re-enter this plugin and get stamped too, matching the Convex CLI's
-      // own `componentPlugin`. Left to `bundle-require`'s externalizer, an
-      // npm definition would be evaluated natively by Node — where no plugin
-      // can stamp its nested definitions, so a component that nests other
-      // components would throw from its top-level `component.use(...)`.
+      // Claim a wrapper's import of the real definition into the file
+      // namespace: bundled, the definition's own nested `convex.config`
+      // imports re-enter this plugin and get stamped; externalized, an npm
+      // definition would be evaluated natively by Node, where its top-level
+      // `component.use(...)` of unstamped nested definitions throws.
       if (args.namespace === COMPONENT_CONFIG_NAMESPACE) {
         return { path: args.path };
       }
@@ -130,11 +127,11 @@ export const componentConfigPlugin = (path: Path.Path): esbuild.Plugin => ({
           ? String.replace(CONVEX_CONFIG_SUFFIX, "")(specifier)
           : path.dirname(args.path);
 
-        // The real module is imported (not inlined) so it's loaded as its
-        // own file-namespace module: its nested `convex.config` imports then
-        // come from a file-namespace importer and re-enter this plugin.
-        // `defaultName` comes from `defineComponent(name)`'s `_name`, keeping
-        // `app.use`'s name resolution identical to the Convex runtime's.
+        // The real module is imported (not inlined) so any nested
+        // `convex.config` imports resolve from the definition's own file
+        // rather than from this virtual wrapper. `defaultName` comes from
+        // `defineComponent(name)`'s `_name`, keeping `app.use`'s name
+        // resolution identical to the Convex runtime's.
         return {
           loader: "js",
           resolveDir: path.dirname(args.path),

--- a/packages/cli/test/ConvexConfig.test.ts
+++ b/packages/cli/test/ConvexConfig.test.ts
@@ -104,9 +104,8 @@ layer(TestLayer)("discoverInstalledComponents", (it) => {
           "convex/convex.config.ts",
         );
 
-        // Only directly installed components appear in the app's registry;
-        // the component nested inside `test-nested`'s definition is mounted
-        // on the component, not on the app.
+        // The workpool nested inside `test-nested` mounts on that component,
+        // not on the app, so it isn't listed.
         expect(components).toEqual([
           { name: "nested", componentDefinitionPath: "test-nested" },
         ]);

--- a/packages/cli/test/ConvexConfig.test.ts
+++ b/packages/cli/test/ConvexConfig.test.ts
@@ -94,6 +94,25 @@ layer(TestLayer)("discoverInstalledComponents", (it) => {
       }),
   );
 
+  it.effect(
+    "discovers a component whose own definition installs other components",
+    () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const components = yield* discoverInstalledComponents(
+          path.join(fixturesRoot, "nested", "convex", "convex.config.ts"),
+          "convex/convex.config.ts",
+        );
+
+        // Only directly installed components appear in the app's registry;
+        // the component nested inside `test-nested`'s definition is mounted
+        // on the component, not on the app.
+        expect(components).toEqual([
+          { name: "nested", componentDefinitionPath: "test-nested" },
+        ]);
+      }),
+  );
+
   it.effect("fails with a BuildError when the config throws on import", () =>
     Effect.gen(function* () {
       const path = yield* Path.Path;

--- a/packages/cli/test/fixtures/components/nested/convex/convex.config.ts
+++ b/packages/cli/test/fixtures/components/nested/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import nested from "test-nested/convex.config";
+import { defineApp } from "convex/server";
+
+const app = defineApp();
+app.use(nested);
+
+export default app;

--- a/packages/cli/test/fixtures/components/nested/node_modules/test-nested/dist/component/convex.config.d.ts
+++ b/packages/cli/test/fixtures/components/nested/node_modules/test-nested/dist/component/convex.config.d.ts
@@ -1,0 +1,2 @@
+declare const component: import("convex/server").ComponentDefinition<any>;
+export default component;

--- a/packages/cli/test/fixtures/components/nested/node_modules/test-nested/dist/component/convex.config.js
+++ b/packages/cli/test/fixtures/components/nested/node_modules/test-nested/dist/component/convex.config.js
@@ -1,0 +1,7 @@
+import workpool from "@convex-dev/workpool/convex.config";
+import { defineComponent } from "convex/server";
+
+const component = defineComponent("nested");
+component.use(workpool);
+
+export default component;

--- a/packages/cli/test/fixtures/components/nested/node_modules/test-nested/package.json
+++ b/packages/cli/test/fixtures/components/nested/node_modules/test-nested/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-nested",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "./package.json": "./package.json",
+    "./convex.config": {
+      "types": "./dist/component/convex.config.d.ts",
+      "default": "./dist/component/convex.config.js"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes `confect codegen` and `confect dev` failing to load `convex/convex.config.ts` when an installed component's own definition installs other components (e.g., `@convex-dev/resend`, which nests rate-limiter and workpool components).

Previously, evaluating the config threw "Component definition does not have the required componentDefinitionPath property. This code only works in Convex runtime." Component definitions are now recognized recursively, so components may nest other components to any depth.

## Key Changes

- **Plugin namespace handling**: Updated `componentConfigPlugin` to claim imports from the `COMPONENT_CONFIG_NAMESPACE` into the file namespace, allowing nested `convex.config` imports to be properly resolved and stamped by the plugin recursively.

- **Comment clarification**: Updated comments to explain that the real module is imported (not inlined) so nested `convex.config` imports resolve from the definition's own file rather than from the virtual wrapper, ensuring proper bundling and externalization behavior.

- **Test coverage**: Added a new test case `"discovers a component whose own definition installs other components"` with a fixture (`nested/`) that simulates a real-world scenario where an npm component (`test-nested`) itself uses another component (`@convex-dev/workpool`).

- **Fixture setup**: Added test fixtures including a fake npm package structure (`test-nested`) with proper `package.json` exports and component definition files to validate the recursive resolution behavior.

- **Gitignore update**: Updated `.gitignore` to preserve fake npm packages in test fixtures while maintaining the general `node_modules/` exclusion.

## Implementation Details

The fix works by ensuring that when the esbuild plugin encounters an import from within a component config wrapper (identified by `COMPONENT_CONFIG_NAMESPACE`), it claims that import into the file namespace. This allows the plugin's `onResolve` hook to re-enter and properly wrap any nested component definitions, creating a recursive resolution chain that handles components nesting other components at any depth.

https://claude.ai/code/session_01CJ55CFohtPcQuRy2FYSDC2