### PR TITLE
docs: add dependency upgrade command guides

### DIFF
--- a/.claude/commands/upgrade-internal-deps.md
+++ b/.claude/commands/upgrade-internal-deps.md
@@ -1,5 +1,5 @@
 ---
-description: Upgrade internal-only dependencies (toolchain devDependencies and the private apps' deps) and open a PR — no changeset
+description: Upgrade internal-only dependencies (toolchain devDependencies and the private workspace packages' deps) and open a PR — no changeset
 ---
 
 Upgrade the dependencies that consumers of the `@confect/*` packages can never
@@ -7,12 +7,14 @@ see, and open a PR for review. Never merge it yourself.
 
 ## Scope
 
-Every `package.json` dependency that is **not** in the `dependencies` or
-`peerDependencies` of a published `@confect/*` package: the workspace's
-devDependencies (build/test/lint toolchain, types) and the private apps'
-dependencies (`apps/docs`, `apps/example`). Dependencies on the published
-surface belong to `/upgrade-published-deps` — skip them here even where they
-appear as devDependency pins, since their pins move with their ranges.
+Every `package.json` dependency that is **not** claimed by
+`/upgrade-published-deps` (whose scope covers the published packages'
+`dependencies`/`peerDependencies` plus their lockstep companions, such as
+`react-dom` with `react`): the workspace's devDependencies (build/test/lint
+toolchain, types) and the dependencies of every private workspace package —
+the apps under `apps/*` and the server-test fixture workspaces. Skip
+published-surface deps here even where they appear as devDependency pins,
+since their pins move with their ranges.
 
 ## Rules
 
@@ -21,7 +23,8 @@ appear as devDependency pins, since their pins move with their ranges.
   run `pnpm lint:fix` (Syncpack) to normalize.
 - Majors are fair game: attempt them, and if one requires more than mechanical
   changes to get green, drop it from the batch and explain what it would take
-  in the PR description.
+  in the PR description (or in your final report, if the run ends up applying
+  nothing and opens no PR).
 - These upgrades are not user-facing: **no changeset**.
 
 ## Delivering

--- a/.claude/commands/upgrade-internal-deps.md
+++ b/.claude/commands/upgrade-internal-deps.md
@@ -1,0 +1,35 @@
+---
+description: Upgrade internal-only dependencies (toolchain devDependencies and the private apps' deps) and open a PR — no changeset
+---
+
+Upgrade the dependencies that consumers of the `@confect/*` packages can never
+see, and open a PR for review. Never merge it yourself.
+
+## Scope
+
+Every `package.json` dependency that is **not** in the `dependencies` or
+`peerDependencies` of a published `@confect/*` package: the workspace's
+devDependencies (build/test/lint toolchain, types) and the private apps'
+dependencies (`apps/docs`, `apps/example`). Dependencies on the published
+surface belong to `/upgrade-published-deps` — skip them here even where they
+appear as devDependency pins, since their pins move with their ranges.
+
+## Rules
+
+- Discover updates with `pnpm outdated -r` and bump to latest. Don't restate
+  or hand-enforce the workspace's pinning conventions — apply the bumps, then
+  run `pnpm lint:fix` (Syncpack) to normalize.
+- Majors are fair game: attempt them, and if one requires more than mechanical
+  changes to get green, drop it from the batch and note it in the PR body (or
+  file a GitHub issue if it needs real planning).
+- These upgrades are not user-facing: **no changeset**.
+
+## Delivering
+
+1. If nothing in scope is outdated, say so and stop — no branch, no PR.
+2. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`).
+   Anything the local environment genuinely can't run, leave to the PR's CI —
+   and get it green.
+3. Push a branch (`deps/<short-description>`, unless this session was assigned
+   a branch) and open a PR against `main`. In the body, list what was bumped
+   and note anything deliberately skipped and why.

--- a/.claude/commands/upgrade-internal-deps.md
+++ b/.claude/commands/upgrade-internal-deps.md
@@ -20,13 +20,15 @@ appear as devDependency pins, since their pins move with their ranges.
   or hand-enforce the workspace's pinning conventions — apply the bumps, then
   run `pnpm lint:fix` (Syncpack) to normalize.
 - Majors are fair game: attempt them, and if one requires more than mechanical
-  changes to get green, drop it from the batch and note it in the PR body (or
-  file a GitHub issue if it needs real planning).
+  changes to get green, drop it from the batch and explain what it would take
+  in the PR description.
 - These upgrades are not user-facing: **no changeset**.
 
 ## Delivering
 
-1. If nothing in scope is outdated, say so and stop — no branch, no PR.
+1. If nothing gets applied, say so and stop — no branch, no PR, even if some
+   upgrades were spotted and deferred; the next scheduled run will surface
+   them again.
 2. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`).
    Anything the local environment genuinely can't run, leave to the PR's CI —
    and get it green.

--- a/.claude/commands/upgrade-published-deps.md
+++ b/.claude/commands/upgrade-published-deps.md
@@ -7,16 +7,21 @@ and open a PR for review. Never merge it yourself.
 
 ## Scope
 
-A dependency is in scope iff it appears in the `dependencies` or
-`peerDependencies` of any published `@confect/*` package (the Effect and
-Convex ecosystems, React, and the CLI's runtime deps). Everything else is
-handled by `/upgrade-internal-deps`.
+A package is published iff its `package.json` does not say `"private": true` —
+note that some private fixture workspaces also carry `@confect/*` names, so go
+by the field, not the name. A dependency is in scope iff it appears in the
+`dependencies` or `peerDependencies` of any published package, together with
+its lockstep companions: packages that must match its version (e.g.
+`react-dom` with `react`) and any `overrides` entry in `pnpm-workspace.yaml`
+that pins one of its transitive dependencies (e.g. `@effect/typeclass` with
+`effect`). Everything else is handled by `/upgrade-internal-deps`.
 
 When bumping an in-scope dependency, move every occurrence across the
-workspace together — the exact devDependency pins, the `overrides` block in
-`pnpm-workspace.yaml`, and the private apps. Don't try to enumerate the
-occurrences from memory; make the change, then let `pnpm lint` (Syncpack)
-catch any that drifted.
+workspace together — search the repo for the dependency's name rather than
+enumerating locations from memory. Syncpack (`pnpm lint`) polices consistency
+between `package.json` files, but **nothing lints the `overrides` block**, and
+a stale override silently forces the old version at install time. After
+bumping, confirm the new versions actually resolved (e.g. `pnpm why <dep>`).
 
 ## Rules
 
@@ -24,32 +29,33 @@ catch any that drifted.
   it. Treat minor bumps of `0.x` packages (most of the `@effect/*` ecosystem,
   `convex-test`) as potentially breaking, not routine.
 - **Never attempt a major of a peer ecosystem** (effect, convex, react).
-  Instead, summarize in the PR description what's available, what it breaks,
-  and a rough migration scope.
+  Instead, summarize what's available, what it breaks, and a rough migration
+  scope — in the PR description if this run opens one, otherwise in your final
+  report (the no-PR rule below still applies).
 - If a non-major upgrade snowballs into a real migration (API rewrites,
   behavioral changes beyond mechanical fixes), drop it from the batch and
-  document it in the PR description the same way.
+  document it the same way.
 - Leave peer ranges alone unless the upgraded code actually requires raising a
   floor. Raising or widening a published range is a deliberate act that must
   be called out in the changeset.
 - If the behavior of convex or the Confect CLI changed, re-run the server
   codegen scripts (`pnpm codegen:server:mock-backend` /
-  `codegen:server:local-backend`) and commit the fixture output — CI fails on
-  uncommitted codegen diffs.
+  `codegen:server:local-backend`) and commit the complete fixture output —
+  check `git status` for newly generated files, since CI's codegen check only
+  diffs tracked files.
 
 ## Delivering
 
 1. If nothing gets applied, say so and stop — no branch, no PR, even if
    deferred upgrades (e.g. a peer-ecosystem major) were spotted; the next
    scheduled run will surface them again.
-2. Add a changeset iff any published `package.json` changed — patch for the
-   fixed group unless behavior warrants more. Follow the existing changelog
-   convention of stating which upstream versions the new range was validated
-   against.
-3. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`)
+2. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`)
    plus the server backend suites (`pnpm test:server:mock-backend` and
-   `test:local-backend`). Anything the local environment genuinely can't run,
-   leave to the PR's CI — and get it green.
+   `pnpm test:server:local-backend`). Anything the local environment genuinely
+   can't run, leave to the PR's CI — and get it green. Drop upgrades that fail
+   here before moving on.
+3. Add a changeset iff any published `package.json` changed — use the
+   create-changeset agent.
 4. Push a branch (`deps/<short-description>`, unless this session was assigned
    a branch) and open a PR against `main`. In the body, list what was bumped
    with links to release notes, and note anything deliberately skipped and why.

--- a/.claude/commands/upgrade-published-deps.md
+++ b/.claude/commands/upgrade-published-deps.md
@@ -1,0 +1,53 @@
+---
+description: Upgrade dependencies on the published surface of the @confect/* packages (their dependencies/peerDependencies), with a changeset and a PR
+---
+
+Upgrade the dependencies that consumers of the `@confect/*` packages can see,
+and open a PR for review. Never merge it yourself.
+
+## Scope
+
+A dependency is in scope iff it appears in the `dependencies` or
+`peerDependencies` of any published `@confect/*` package (the Effect and
+Convex ecosystems, React, and the CLI's runtime deps). Everything else is
+handled by `/upgrade-internal-deps`.
+
+When bumping an in-scope dependency, move every occurrence across the
+workspace together — the exact devDependency pins, the `overrides` block in
+`pnpm-workspace.yaml`, and the private apps. Don't try to enumerate the
+occurrences from memory; make the change, then let `pnpm lint` (Syncpack)
+catch any that drifted.
+
+## Rules
+
+- Read the release notes/changelogs for each pending update before applying
+  it. Treat minor bumps of `0.x` packages (most of the `@effect/*` ecosystem,
+  `convex-test`) as potentially breaking, not routine.
+- **Never attempt a major of a peer ecosystem** (effect, convex, react). File
+  a GitHub issue instead, summarizing what's available, what it breaks, and a
+  rough migration scope.
+- If a non-major upgrade snowballs into a real migration (API rewrites,
+  behavioral changes beyond mechanical fixes), drop it from the batch and file
+  an issue the same way.
+- Leave peer ranges alone unless the upgraded code actually requires raising a
+  floor. Raising or widening a published range is a deliberate act that must
+  be called out in the changeset.
+- If the behavior of convex or the Confect CLI changed, re-run the server
+  codegen scripts (`pnpm codegen:server:mock-backend` /
+  `codegen:server:local-backend`) and commit the fixture output — CI fails on
+  uncommitted codegen diffs.
+
+## Delivering
+
+1. If nothing in scope is outdated, say so and stop — no branch, no PR.
+2. Add a changeset iff any published `package.json` changed — patch for the
+   fixed group unless behavior warrants more. Follow the existing changelog
+   convention of stating which upstream versions the new range was validated
+   against.
+3. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`)
+   plus the server backend suites (`pnpm test:server:mock-backend` and
+   `test:local-backend`). Anything the local environment genuinely can't run,
+   leave to the PR's CI — and get it green.
+4. Push a branch (`deps/<short-description>`, unless this session was assigned
+   a branch) and open a PR against `main`. In the body, list what was bumped
+   with links to release notes, and note anything deliberately skipped and why.

--- a/.claude/commands/upgrade-published-deps.md
+++ b/.claude/commands/upgrade-published-deps.md
@@ -23,12 +23,12 @@ catch any that drifted.
 - Read the release notes/changelogs for each pending update before applying
   it. Treat minor bumps of `0.x` packages (most of the `@effect/*` ecosystem,
   `convex-test`) as potentially breaking, not routine.
-- **Never attempt a major of a peer ecosystem** (effect, convex, react). File
-  a GitHub issue instead, summarizing what's available, what it breaks, and a
-  rough migration scope.
+- **Never attempt a major of a peer ecosystem** (effect, convex, react).
+  Instead, summarize in the PR description what's available, what it breaks,
+  and a rough migration scope.
 - If a non-major upgrade snowballs into a real migration (API rewrites,
-  behavioral changes beyond mechanical fixes), drop it from the batch and file
-  an issue the same way.
+  behavioral changes beyond mechanical fixes), drop it from the batch and
+  document it in the PR description the same way.
 - Leave peer ranges alone unless the upgraded code actually requires raising a
   floor. Raising or widening a published range is a deliberate act that must
   be called out in the changeset.
@@ -39,7 +39,9 @@ catch any that drifted.
 
 ## Delivering
 
-1. If nothing in scope is outdated, say so and stop — no branch, no PR.
+1. If nothing gets applied, say so and stop — no branch, no PR, even if
+   deferred upgrades (e.g. a peer-ecosystem major) were spotted; the next
+   scheduled run will surface them again.
 2. Add a changeset iff any published `package.json` changed — patch for the
    fixed group unless behavior warrants more. Follow the existing changelog
    convention of stating which upstream versions the new range was validated

--- a/.claude/commands/upgrade-runtime-pins.md
+++ b/.claude/commands/upgrade-runtime-pins.md
@@ -9,16 +9,19 @@ merge it yourself.
 
 Version pins that live outside `package.json` dependency maps: `.node-version`,
 the `packageManager` field in the root `package.json`, and the tool versions in
-`mise.toml`. CI and mise read these files directly, so updating them is the
-whole change — do not touch workflow files (Dependabot owns GitHub Actions and
-devcontainer versions).
+`mise.toml`. Not every consumer reads these files — some CI setup actions under
+`.github/actions/` resolve Node or pnpm from other sources — so after updating
+a pin, check where each version is actually resolved and call out any consumer
+the bump doesn't reach in the PR description. Do not touch GitHub Actions
+`uses:` versions or devcontainer config — Dependabot owns those.
 
 ## Rules
 
 - Bump within each tool's current major line. Take a major line (a new Node
   LTS, a pnpm or bun major) only if the release notes show nothing that
   affects this repo and the checks stay green; otherwise describe the
-  available jump in the PR description.
+  available jump in the PR description (or in your final report, if the run
+  ends up applying nothing and opens no PR).
 - **Never change `engines` floors** in the published packages — those are
   published-surface policy and belong to a deliberate, changeset-recorded
   decision, not this routine.

--- a/.claude/commands/upgrade-runtime-pins.md
+++ b/.claude/commands/upgrade-runtime-pins.md
@@ -1,0 +1,34 @@
+---
+description: Upgrade the runtime version pins that live outside package.json dependency maps (Node, pnpm, bun) and open a PR
+---
+
+Upgrade the repo's pinned runtime versions and open a PR for review. Never
+merge it yourself.
+
+## Scope
+
+Version pins that live outside `package.json` dependency maps: `.node-version`,
+the `packageManager` field in the root `package.json`, and the tool versions in
+`mise.toml`. CI and mise read these files directly, so updating them is the
+whole change — do not touch workflow files (Dependabot owns GitHub Actions and
+devcontainer versions).
+
+## Rules
+
+- Bump within each tool's current major line. Take a major line (a new Node
+  LTS, a pnpm or bun major) only if the release notes show nothing that
+  affects this repo and the checks stay green; otherwise file a GitHub issue
+  describing the jump.
+- **Never change `engines` floors** in the published packages — those are
+  published-surface policy and belong to a deliberate, changeset-recorded
+  decision, not this routine.
+
+## Delivering
+
+1. If everything is already current, say so and stop — no branch, no PR.
+2. Verify by reinstalling with the new versions and running the full repo
+   checks (`pnpm check`, `pnpm test`, `pnpm build`). Anything the local
+   environment genuinely can't run, leave to the PR's CI — and get it green.
+3. Push a branch (`deps/<short-description>`, unless this session was assigned
+   a branch) and open a PR against `main`, noting in the body which pins moved
+   and linking their release notes.

--- a/.claude/commands/upgrade-runtime-pins.md
+++ b/.claude/commands/upgrade-runtime-pins.md
@@ -17,15 +17,17 @@ devcontainer versions).
 
 - Bump within each tool's current major line. Take a major line (a new Node
   LTS, a pnpm or bun major) only if the release notes show nothing that
-  affects this repo and the checks stay green; otherwise file a GitHub issue
-  describing the jump.
+  affects this repo and the checks stay green; otherwise describe the
+  available jump in the PR description.
 - **Never change `engines` floors** in the published packages — those are
   published-surface policy and belong to a deliberate, changeset-recorded
   decision, not this routine.
 
 ## Delivering
 
-1. If everything is already current, say so and stop — no branch, no PR.
+1. If nothing gets applied, say so and stop — no branch, no PR, even if a
+   major-line jump was spotted and deferred; the next scheduled run will
+   surface it again.
 2. Verify by reinstalling with the new versions and running the full repo
    checks (`pnpm check`, `pnpm test`, `pnpm build`). Anything the local
    environment genuinely can't run, leave to the PR's CI — and get it green.


### PR DESCRIPTION
Add three new Claude command guides to document the dependency upgrade workflows for the monorepo:

- **`upgrade-published-deps.md`** — Upgrade dependencies visible to consumers of `@confect/*` packages (their `dependencies` and `peerDependencies`, plus lockstep companions and workspace overrides). Includes rules for handling breaking changes in peer ecosystems (Effect, Convex, React), managing peer ranges, and regenerating server codegen when needed.

- **`upgrade-internal-deps.md`** — Upgrade internal-only dependencies (workspace devDependencies and private package deps). Covers the toolchain, build/test/lint tools, and app dependencies. Majors are fair game here since they're not user-facing.

- **`upgrade-runtime-pins.md`** — Upgrade runtime version pins outside `package.json` (Node, pnpm, bun in `.node-version`, `packageManager`, and `mise.toml`). Restricts changes to within current major lines unless release notes show no impact.

Each guide specifies scope, rules, and delivery steps (verification, changeset creation where applicable, and PR opening). These formalize the upgrade process and ensure consistency across dependency maintenance runs.

https://claude.ai/code/session_01FmCgLvgSA7yn8eGn3DTKda