### PR TITLE
Widen esbuild version range to exclude 0.27.4

### DIFF
--- a/.changeset/widen-esbuild-range.md
+++ b/.changeset/widen-esbuild-range.md
@@ -1,0 +1,7 @@
+---
+"@confect/cli": patch
+---
+
+Widen the accepted `esbuild` version range from `^0.27.3` to `0.27.0 - 0.27.3 || ^0.27.5 || ^0.28.0`.
+
+The new range admits esbuild 0.27.0–0.27.2 (so package managers can dedupe against `convex`'s exact `0.27.0` pin) and the 0.28.x line, while explicitly excluding 0.27.4. That release has a metafile regression (fixed upstream in 0.27.5) that deadlocks esbuild's service on the first build error, hanging every subsequent bundle — which meant `confect dev` would stop rebuilding after a single failed build. Previously, the `^0.27.3` range allowed 0.27.4 to be installed.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
     "@effect/printer-ansi": "^0.49.0",
     "bundle-require": "^5.1.0",
     "code-block-writer": "^13.0.3",
-    "esbuild": "^0.27.3",
+    "esbuild": "0.27.0 - 0.27.3 || ^0.27.5 || ^0.28.0",
     "exsolve": "^1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,7 +175,7 @@ importers:
         specifier: ^13.0.3
         version: 13.0.3
       esbuild:
-        specifier: ^0.27.3
+        specifier: 0.27.0 - 0.27.3 || ^0.27.5 || ^0.28.0
         version: 0.27.3
       exsolve:
         specifier: ^1.1.0


### PR DESCRIPTION
## Summary

Adjusts the `esbuild` dependency range in `@confect/cli` to explicitly exclude version 0.27.4, which contains a metafile regression that causes esbuild's service to deadlock on the first build error, preventing subsequent rebuilds in `confect dev`.

## Changes

- Updated `esbuild` dependency from `^0.27.3` to `0.27.0 - 0.27.3 || ^0.27.5 || ^0.28.0`
  - Admits esbuild 0.27.0–0.27.2 to allow package manager deduplication against `convex`'s exact 0.27.0 pin
  - Explicitly excludes the problematic 0.27.4 release
  - Allows the 0.28.x line (fixed upstream in 0.27.5)
  - Prevents the previous `^0.27.3` range from inadvertently installing 0.27.4

## Details

The 0.27.4 release has a metafile regression that deadlocks esbuild's service on the first build error, which would hang every subsequent bundle operation. This made `confect dev` stop rebuilding after a single failed build. The new range ensures this problematic version cannot be installed while maintaining compatibility with working versions and allowing forward compatibility with 0.28.x.

https://claude.ai/code/session_01MSJpGQjBV9nFyoq6foLk8H