### PR TITLE
Fix Effect scheduler in queries/mutations to use microtask queue

### DIFF
--- a/.changeset/microtask-scheduler-in-queries-and-mutations.md
+++ b/.changeset/microtask-scheduler-in-queries-and-mutations.md
@@ -2,4 +2,4 @@
 "@confect/server": patch
 ---
 
-Run query and mutation handlers on an Effect `Scheduler` that dispatches cooperative fiber yields on the microtask queue. Effect's default `MixedScheduler` dispatches yields — injected once a fiber exhausts its op budget (`MaxOpsBeforeYield`, 2048 operations) — through `setImmediate`, falling back to `setTimeout(f, 0)`; neither exists in Convex's query/mutation isolate, so any sufficiently long-running handler crashed with Convex's "Can't use setTimeout in queries and mutations" error. The scheduler is installed via `Effect.runPromise` run options so it sits in the fiber's root context and also covers Confect's own error-encoding wrappers. Actions are unchanged — timers are allowed there.
+Fix query and mutation handlers crashing with Convex's "Can't use setTimeout in queries and mutations" error once they performed enough Effect operations to trigger a cooperative fiber yield. Effect execution in queries and mutations now yields via the microtask queue instead of timer APIs, which Convex's isolate forbids. Actions are unchanged.

--- a/.changeset/microtask-scheduler-in-queries-and-mutations.md
+++ b/.changeset/microtask-scheduler-in-queries-and-mutations.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": patch
+---
+
+Run query and mutation handlers on an Effect `Scheduler` that dispatches cooperative fiber yields on the microtask queue. Effect's default `MixedScheduler` dispatches yields — injected once a fiber exhausts its op budget (`MaxOpsBeforeYield`, 2048 operations) — through `setImmediate`, falling back to `setTimeout(f, 0)`; neither exists in Convex's query/mutation isolate, so any sufficiently long-running handler crashed with Convex's "Can't use setTimeout in queries and mutations" error. The scheduler is installed via `Effect.runPromise` run options so it sits in the fiber's root context and also covers Confect's own error-encoding wrappers. Actions are unchanged — timers are allowed there.

--- a/packages/server/src/RegisteredConvexFunction.ts
+++ b/packages/server/src/RegisteredConvexFunction.ts
@@ -18,6 +18,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Schema from "effect/Schema";
+import * as EffectScheduler from "effect/Scheduler";
 import * as Auth from "./Auth";
 import * as ConvexConfigProvider from "./ConvexConfigProvider";
 import * as DatabaseReader from "./DatabaseReader";
@@ -131,6 +132,42 @@ const queryClock: Clock.Clock = {
     }),
 };
 
+/**
+ * Convex bans `setTimeout` in queries and mutations ("Can't use setTimeout in
+ * queries and mutations. Please consider using an action.") and their isolate
+ * has no `setImmediate`. Effect's default `MixedScheduler` dispatches
+ * cooperative fiber yields — injected once a fiber exhausts its op budget
+ * (`MaxOpsBeforeYield`, 2048 operations) — through `setImmediate`, falling
+ * back to `setTimeout(f, 0)`, so any handler that runs long enough to yield
+ * would crash. Queries and mutations therefore run on a `MixedScheduler` that
+ * dispatches on the microtask queue, which the isolate supports (Promises
+ * work everywhere Convex functions run). Actions keep the default scheduler —
+ * timers are allowed there.
+ *
+ * Sharing one instance across invocations is safe: `MixedScheduler` holds
+ * only immutable fields, and each fiber creates its own dispatcher via
+ * `makeDispatcher()`.
+ */
+const scheduleMicrotask: (f: () => void) => void =
+  typeof globalThis.queueMicrotask === "function"
+    ? globalThis.queueMicrotask.bind(globalThis)
+    : (f) => void Promise.resolve().then(f);
+
+const setImmediateMicrotask = (f: () => void): (() => void) => {
+  let cancelled = false;
+  scheduleMicrotask(() => {
+    if (!cancelled) {
+      f();
+    }
+  });
+  return () => {
+    cancelled = true;
+  };
+};
+
+const microtaskScheduler: EffectScheduler.Scheduler =
+  new EffectScheduler.MixedScheduler("async", setImmediateMicrotask);
+
 const queryFunction = <
   DatabaseSchema_ extends DatabaseSchema.AnyWithProps,
   Args,
@@ -201,7 +238,9 @@ const queryFunction = <
       );
     }).pipe(
       Effect.provideService(Clock.Clock, queryClock),
-      RegisteredFunction.runHandlerPromise(error),
+      RegisteredFunction.runHandlerPromise(error, {
+        scheduler: microtaskScheduler,
+      }),
     ),
 });
 
@@ -282,7 +321,11 @@ const mutationFunction = <
         Schema.encodeEffect(returns),
         Effect.orDie,
       );
-    }).pipe(RegisteredFunction.runHandlerPromise(error)),
+    }).pipe(
+      RegisteredFunction.runHandlerPromise(error, {
+        scheduler: microtaskScheduler,
+      }),
+    ),
 });
 
 const convexActionFunction = <

--- a/packages/server/src/RegisteredFunction.ts
+++ b/packages/server/src/RegisteredFunction.ts
@@ -16,6 +16,7 @@ import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import type * as EffectScheduler from "effect/Scheduler";
 import * as ActionCtx from "./ActionCtx";
 import * as ActionRunner from "./ActionRunner";
 import * as Auth from "./Auth";
@@ -132,12 +133,24 @@ export type RegisteredFunction<
  * `Effect.orDie`, so nothing—not even a `ConvexError` the handler placed in its
  * error channel—reaches the client as a `ConvexError`. The fiber dies and
  * `runPromise` rejects with a generic failure.
+ *
+ * A `scheduler` in `runOptions` must be passed here as a run option rather
+ * than provided via `Effect.provideService` inside `effect`: the run option
+ * lands in the fiber's root context, while a service provided within `effect`
+ * pops before the `orDie`/`catch`/`result` wrappers this function adds. The
+ * fiber's op counter survives context pops, so a cooperative yield can fire
+ * inside those wrappers — only a root-context scheduler covers them.
  */
 export const runHandlerPromise =
-  (errorSchema: Schema.Codec<any, any> | undefined) =>
+  (
+    errorSchema: Schema.Codec<any, any> | undefined,
+    runOptions?: {
+      readonly scheduler?: EffectScheduler.Scheduler | undefined;
+    },
+  ) =>
   <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
     if (errorSchema === undefined) {
-      return Effect.runPromise(Effect.orDie(effect));
+      return Effect.runPromise(Effect.orDie(effect), runOptions);
     }
     const withConvexError = effect.pipe(
       Effect.catch((typedError) =>
@@ -150,7 +163,7 @@ export const runHandlerPromise =
         ),
       ),
     );
-    return Effect.runPromise(Effect.result(withConvexError)).then(
+    return Effect.runPromise(Effect.result(withConvexError), runOptions).then(
       Result.match({
         onFailure: (error) => {
           throw error;

--- a/packages/server/test/local-backend/fixtures/confect/_generated/registeredFunctions/groups/scheduling.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/registeredFunctions/groups/scheduling.ts
@@ -1,0 +1,5 @@
+import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";
+import databaseSchema from "../../schema";
+import scheduling from "../../../groups/scheduling.impl";
+
+export default RegisteredFunctions.buildForGroup<typeof import("../../../groups/scheduling.spec")["default"]>(databaseSchema, scheduling, RegisteredConvexFunction.make);

--- a/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
@@ -1,9 +1,10 @@
 import { GroupSpec, Spec } from "@confect/core";
 import groups_cacheControl from "../groups/cacheControl.spec";
 import groups_cacheStubbed from "../groups/cacheStubbed.spec";
+import groups_scheduling from "../groups/scheduling.spec";
 
 const spec: Spec.Spec<
-  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_cacheControl, "cacheControl"> | GroupSpec.NamedAt<typeof groups_cacheStubbed, "cacheStubbed">>, "groups">
-> = Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed));
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_cacheControl, "cacheControl"> | GroupSpec.NamedAt<typeof groups_cacheStubbed, "cacheStubbed"> | GroupSpec.NamedAt<typeof groups_scheduling, "scheduling">>, "groups">
+> = Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed).addGroupAt("scheduling", groups_scheduling));
 
 export default spec;

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.impl.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.impl.ts
@@ -1,0 +1,45 @@
+/**
+ * Handlers run one effect per element so the fiber burns several multiples
+ * of `MaxOpsBeforeYield` (2048) and is forced through cooperative scheduler
+ * yields mid-handler. Convex bans `setTimeout` in queries and mutations, so
+ * these functions only succeed if the scheduler never dispatches through
+ * timer APIs.
+ */
+
+import { FunctionImpl, GroupImpl } from "@confect/server";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import databaseSchema from "../_generated/schema";
+import scheduling from "./scheduling.spec";
+
+const sumToN = (n: number) =>
+  Effect.gen(function* () {
+    let sum = 0;
+    for (let i = 1; i <= n; i++) {
+      // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
+      // unwraps without touching the op counter) charges the fiber's op
+      // budget on every iteration.
+      sum += yield* Effect.sync(() => i);
+    }
+    return sum;
+  });
+
+const manyOpsQuery = FunctionImpl.make(
+  databaseSchema,
+  scheduling,
+  "manyOpsQuery",
+  () => sumToN(5000),
+);
+
+const manyOpsMutation = FunctionImpl.make(
+  databaseSchema,
+  scheduling,
+  "manyOpsMutation",
+  () => sumToN(5000),
+);
+
+export default GroupImpl.make(databaseSchema, scheduling).pipe(
+  Layer.provide(manyOpsQuery),
+  Layer.provide(manyOpsMutation),
+  GroupImpl.finalize,
+);

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -1,0 +1,18 @@
+import { FunctionSpec, GroupSpec } from "@confect/core";
+import * as Schema from "effect/Schema";
+
+export default GroupSpec.make()
+  .addFunction(
+    FunctionSpec.publicQuery({
+      name: "manyOpsQuery",
+      args: () => Schema.Struct({}),
+      returns: () => Schema.Number,
+    }),
+  )
+  .addFunction(
+    FunctionSpec.publicMutation({
+      name: "manyOpsMutation",
+      args: () => Schema.Struct({}),
+      returns: () => Schema.Number,
+    }),
+  );

--- a/packages/server/test/local-backend/fixtures/convex/_generated/api.d.ts
+++ b/packages/server/test/local-backend/fixtures/convex/_generated/api.d.ts
@@ -31,6 +31,10 @@ export declare const api: {
       confectWithRawDateNow: FunctionReference<"query", "public", {}, number>;
       confectWithSpan: FunctionReference<"query", "public", {}, number>;
     };
+    scheduling: {
+      manyOpsMutation: FunctionReference<"mutation", "public", {}, number>;
+      manyOpsQuery: FunctionReference<"query", "public", {}, number>;
+    };
   };
 };
 

--- a/packages/server/test/local-backend/fixtures/convex/groups/scheduling.ts
+++ b/packages/server/test/local-backend/fixtures/convex/groups/scheduling.ts
@@ -1,0 +1,4 @@
+import registeredFunctions from "../../confect/_generated/registeredFunctions/groups/scheduling";
+
+export const manyOpsMutation = registeredFunctions.manyOpsMutation;
+export const manyOpsQuery = registeredFunctions.manyOpsQuery;

--- a/packages/server/test/local-backend/schedulerIsolation.test.ts
+++ b/packages/server/test/local-backend/schedulerIsolation.test.ts
@@ -1,0 +1,52 @@
+/**
+ * End-to-end test of Effect's cooperative fiber yielding inside Convex's real
+ * query/mutation isolate, which bans `setTimeout` and has no `setImmediate`.
+ * The fixture handlers run well past `MaxOpsBeforeYield` (2048) fiber
+ * operations, forcing scheduler yields mid-handler; without the microtask
+ * scheduler that `RegisteredConvexFunction` installs, the backend rejects
+ * with "Can't use setTimeout in queries and mutations."
+ */
+
+import { Ref } from "@confect/core";
+import { expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import refs from "./fixtures/confect/_generated/refs";
+import * as LocalBackend from "./LocalBackend";
+
+// The fixtures sum 1..5000.
+const expectedSum = (5000 * 5001) / 2;
+
+layer(LocalBackend.layer, { timeout: "120 seconds" })(
+  "Effect scheduler inside the Convex isolate",
+  (it) => {
+    it.effect("a query exceeding the fiber op budget succeeds", () =>
+      Effect.gen(function* () {
+        const { client } = yield* LocalBackend.LocalBackend;
+        const result = yield* Effect.promise(() =>
+          client.query(
+            Ref.getFunctionReference(
+              refs.public.groups.scheduling.manyOpsQuery,
+            ),
+            {},
+          ),
+        );
+        expect(result).toBe(expectedSum);
+      }),
+    );
+
+    it.effect("a mutation exceeding the fiber op budget succeeds", () =>
+      Effect.gen(function* () {
+        const { client } = yield* LocalBackend.LocalBackend;
+        const result = yield* Effect.promise(() =>
+          client.mutation(
+            Ref.getFunctionReference(
+              refs.public.groups.scheduling.manyOpsMutation,
+            ),
+            {},
+          ),
+        );
+        expect(result).toBe(expectedSum);
+      }),
+    );
+  },
+);

--- a/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
+++ b/packages/server/test/mock-backend/__snapshots__/declarationEmit.test.ts.snap
@@ -69,9 +69,10 @@ import groups_notes from "../groups/notes.spec";
 import groups_random from "../groups/random.spec";
 import groups_random_stats from "../groups/random/stats.spec";
 import groups_runners from "../groups/runners.spec";
+import groups_scheduling from "../groups/scheduling.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 import typedErrorsNode from "../typedErrorsNode.spec";
-declare const spec: Spec.Spec<GroupSpec.NamedAt<typeof databaseReader, "databaseReader"> | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<GroupSpec.AddGroups<typeof groups_random, GroupSpec.NamedAt<typeof groups_random_stats, "stats">>, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups"> | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">>;
+declare const spec: Spec.Spec<GroupSpec.NamedAt<typeof databaseReader, "databaseReader"> | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<GroupSpec.AddGroups<typeof groups_random, GroupSpec.NamedAt<typeof groups_random_stats, "stats">>, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_scheduling, "scheduling"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups"> | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">>;
 export default spec;
 "
 `;

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/scheduling.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/registeredFunctions/groups/scheduling.ts
@@ -1,0 +1,5 @@
+import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";
+import databaseSchema from "../../schema";
+import scheduling from "../../../groups/scheduling.impl";
+
+export default RegisteredFunctions.buildForGroup<typeof import("../../../groups/scheduling.spec")["default"]>(databaseSchema, scheduling, RegisteredConvexFunction.make);

--- a/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/_generated/spec.ts
@@ -6,13 +6,14 @@ import groups_notes from "../groups/notes.spec";
 import groups_random from "../groups/random.spec";
 import groups_random_stats from "../groups/random/stats.spec";
 import groups_runners from "../groups/runners.spec";
+import groups_scheduling from "../groups/scheduling.spec";
 import groups_typedErrors from "../groups/typedErrors.spec";
 import typedErrorsNode from "../typedErrorsNode.spec";
 
 const spec: Spec.Spec<
   | GroupSpec.NamedAt<typeof databaseReader, "databaseReader">
-  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<GroupSpec.AddGroups<typeof groups_random, GroupSpec.NamedAt<typeof groups_random_stats, "stats">>, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups">
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_aliasImporter, "aliasImporter"> | GroupSpec.NamedAt<typeof groups_cjsImporter, "cjsImporter"> | GroupSpec.NamedAt<typeof groups_notes, "notes"> | GroupSpec.NamedAt<GroupSpec.AddGroups<typeof groups_random, GroupSpec.NamedAt<typeof groups_random_stats, "stats">>, "random"> | GroupSpec.NamedAt<typeof groups_runners, "runners"> | GroupSpec.NamedAt<typeof groups_scheduling, "scheduling"> | GroupSpec.NamedAt<typeof groups_typedErrors, "typedErrors">>, "groups">
   | GroupSpec.NamedAt<typeof typedErrorsNode, "typedErrorsNode">
-> = Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random.addGroupAt("stats", groups_random_stats)).addGroupAt("runners", groups_runners).addGroupAt("typedErrors", groups_typedErrors)).addAt("typedErrorsNode", typedErrorsNode);
+> = Spec.make().addAt("databaseReader", databaseReader).addAt("groups", GroupSpec.makeAt("groups").addGroupAt("aliasImporter", groups_aliasImporter).addGroupAt("cjsImporter", groups_cjsImporter).addGroupAt("notes", groups_notes).addGroupAt("random", groups_random.addGroupAt("stats", groups_random_stats)).addGroupAt("runners", groups_runners).addGroupAt("scheduling", groups_scheduling).addGroupAt("typedErrors", groups_typedErrors)).addAt("typedErrorsNode", typedErrorsNode);
 
 export default spec;

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.impl.ts
@@ -1,0 +1,45 @@
+/**
+ * Handlers run one effect per element so the fiber burns several multiples
+ * of `MaxOpsBeforeYield` (2048) and is forced through cooperative scheduler
+ * yields mid-handler. Convex bans `setTimeout` in queries and mutations, so
+ * these functions only succeed if the scheduler never dispatches through
+ * timer APIs.
+ */
+
+import { FunctionImpl, GroupImpl } from "@confect/server";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import databaseSchema from "../_generated/schema";
+import scheduling from "./scheduling.spec";
+
+const sumToN = (n: number) =>
+  Effect.gen(function* () {
+    let sum = 0;
+    for (let i = 1; i <= n; i++) {
+      // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
+      // unwraps without touching the op counter) charges the fiber's op
+      // budget on every iteration.
+      sum += yield* Effect.sync(() => i);
+    }
+    return sum;
+  });
+
+const manyOpsQuery = FunctionImpl.make(
+  databaseSchema,
+  scheduling,
+  "manyOpsQuery",
+  () => sumToN(5000),
+);
+
+const manyOpsMutation = FunctionImpl.make(
+  databaseSchema,
+  scheduling,
+  "manyOpsMutation",
+  () => sumToN(5000),
+);
+
+export default GroupImpl.make(databaseSchema, scheduling).pipe(
+  Layer.provide(manyOpsQuery),
+  Layer.provide(manyOpsMutation),
+  GroupImpl.finalize,
+);

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -1,0 +1,18 @@
+import { FunctionSpec, GroupSpec } from "@confect/core";
+import * as Schema from "effect/Schema";
+
+export default GroupSpec.make()
+  .addFunction(
+    FunctionSpec.publicQuery({
+      name: "manyOpsQuery",
+      args: () => Schema.Struct({}),
+      returns: () => Schema.Number,
+    }),
+  )
+  .addFunction(
+    FunctionSpec.publicMutation({
+      name: "manyOpsMutation",
+      args: () => Schema.Struct({}),
+      returns: () => Schema.Number,
+    }),
+  );

--- a/packages/server/test/mock-backend/fixtures/convex/_generated/api.d.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/_generated/api.d.ts
@@ -159,6 +159,10 @@ export declare const api: {
         Id<"notes">
       >;
     };
+    scheduling: {
+      manyOpsMutation: FunctionReference<"mutation", "public", {}, number>;
+      manyOpsQuery: FunctionReference<"query", "public", {}, number>;
+    };
     typedErrors: {
       deleteNoteOrFail: FunctionReference<
         "mutation",

--- a/packages/server/test/mock-backend/fixtures/convex/groups/scheduling.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/groups/scheduling.ts
@@ -1,0 +1,4 @@
+import registeredFunctions from "../../confect/_generated/registeredFunctions/groups/scheduling";
+
+export const manyOpsMutation = registeredFunctions.manyOpsMutation;
+export const manyOpsQuery = registeredFunctions.manyOpsQuery;

--- a/packages/server/test/mock-backend/schedulerIsolation.test.ts
+++ b/packages/server/test/mock-backend/schedulerIsolation.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="vite/client" />
+
+/**
+ * Regression test for Effect's cooperative fiber yielding inside Convex's
+ * query/mutation isolate, which bans `setTimeout` and has no `setImmediate`.
+ * The fixture handlers run well past `MaxOpsBeforeYield` (2048) fiber
+ * operations, forcing scheduler yields mid-handler; they only succeed if
+ * every yield dispatches through the microtask queue rather than timer APIs.
+ *
+ * Deliberately a plain async vitest test rather than `it.effect`/TestConfect:
+ * `@effect/vitest` runs the outer test fiber on Effect's default scheduler,
+ * which resolves `globalThis.setImmediate` at dispatch time — stubbing the
+ * globals would crash the harness fiber, not just the code under test. With
+ * `convexTest` used directly, the only Effect fiber alive inside the stub
+ * window is the handler fiber under test.
+ */
+
+import { Ref } from "@confect/core";
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import convexSchema from "./fixtures/confect/_generated/convexSchema";
+import refs from "./fixtures/confect/_generated/refs";
+
+// Same module glob as TestConfect.ts.
+const modules = import.meta.glob([
+  "./fixtures/convex/**/*.ts",
+  "./fixtures/convex/**/*.js",
+  "!./fixtures/convex/**/*.*.*",
+]);
+
+// The fixtures sum 1..5000.
+const expectedSum = (5000 * 5001) / 2;
+
+/**
+ * Simulate the Convex query/mutation isolate for the duration of `run`:
+ * `setTimeout` throws Convex's error, and `setImmediate` (absent in the
+ * isolate, so Effect's default scheduler would fall back to `setTimeout`)
+ * throws too, so any timer use surfaces as a test failure. Effect resolves
+ * both via `globalThis` property lookup at dispatch time, so swapping the
+ * properties intercepts it.
+ */
+const withConvexIsolateTimers = async <A>(
+  run: () => Promise<A>,
+): Promise<A> => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalSetImmediate = globalThis.setImmediate;
+  const ban = (name: string) => () => {
+    throw new Error(
+      `Can't use ${name} in queries and mutations. Please consider using an action.`,
+    );
+  };
+  globalThis.setTimeout = ban("setTimeout") as never;
+  globalThis.setImmediate = ban("setImmediate") as never;
+  try {
+    return await run();
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.setImmediate = originalSetImmediate;
+  }
+};
+
+describe("Effect scheduler inside the Convex isolate", () => {
+  it("runs a query handler exceeding the fiber op budget without timers", async () => {
+    const t = convexTest(convexSchema, modules);
+    const result = await withConvexIsolateTimers(() =>
+      t.query(
+        Ref.getFunctionReference(refs.public.groups.scheduling.manyOpsQuery),
+        {},
+      ),
+    );
+    expect(result).toBe(expectedSum);
+  });
+
+  it("runs a mutation handler exceeding the fiber op budget without timers", async () => {
+    const t = convexTest(convexSchema, modules);
+    const result = await withConvexIsolateTimers(() =>
+      t.mutation(
+        Ref.getFunctionReference(refs.public.groups.scheduling.manyOpsMutation),
+        {},
+      ),
+    );
+    expect(result).toBe(expectedSum);
+  });
+});

--- a/packages/server/vitest.local-backend.config.ts
+++ b/packages/server/vitest.local-backend.config.ts
@@ -21,9 +21,6 @@ export default defineConfig({
     name: "@confect/server (local-backend)",
     include: ["test/local-backend/**/*.test.ts"],
     exclude: [...configDefaults.exclude, "**/*.spec.ts"],
-    // Each test file's `LocalBackend.layer` spawns its own `convex dev` bound
-    // to a fixed port from the shared fixtures deployment, so files must not
-    // run concurrently — the loser of the port race exits before ready.
     fileParallelism: false,
     globalSetup: ["./test/local-backend/setup.ts"],
     testTimeout: 60_000,

--- a/packages/server/vitest.local-backend.config.ts
+++ b/packages/server/vitest.local-backend.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
     name: "@confect/server (local-backend)",
     include: ["test/local-backend/**/*.test.ts"],
     exclude: [...configDefaults.exclude, "**/*.spec.ts"],
+    // Each test file's `LocalBackend.layer` spawns its own `convex dev` bound
+    // to a fixed port from the shared fixtures deployment, so files must not
+    // run concurrently — the loser of the port race exits before ready.
+    fileParallelism: false,
     globalSetup: ["./test/local-backend/setup.ts"],
     testTimeout: 60_000,
     hookTimeout: 120_000,


### PR DESCRIPTION
## Summary

Fix query and mutation handlers crashing with Convex's "Can't use setTimeout in queries and mutations" error when they perform enough Effect operations to trigger a cooperative fiber yield. Effect execution in queries and mutations now yields via the microtask queue instead of timer APIs, which Convex's isolate forbids.

## Changes

- **RegisteredConvexFunction.ts**: Install a custom `MixedScheduler` that dispatches cooperative yields through `queueMicrotask` (or Promise.then as fallback) instead of `setImmediate`/`setTimeout`. This scheduler is applied only to queries and mutations via a run option; actions retain the default scheduler since timers are allowed there.

- **RegisteredFunction.ts**: Accept an optional `scheduler` in `runOptions` parameter to `runHandlerPromise` and pass it through to `Effect.runPromise`. The scheduler must be provided as a run option (not via `Effect.provideService`) so it covers the fiber's root context, including any cooperative yields that fire inside error-handling wrappers.

- **Test fixtures**: Add `scheduling` group with `manyOpsQuery` and `manyOpsMutation` handlers that sum 1..5000 using `Effect.sync`, forcing multiple cooperative yields mid-handler (well past the 2048 op budget). These handlers only succeed if the scheduler never dispatches through timer APIs.

- **Integration tests**: 
  - `mock-backend/schedulerIsolation.test.ts`: Vitest suite that stubs `setTimeout` and `setImmediate` to simulate Convex's isolate and verify handlers complete without timer use.
  - `local-backend/schedulerIsolation.test.ts`: End-to-end test against the real Convex local backend to confirm the fix works in practice.

## Implementation Details

The microtask scheduler is created once and reused across all query/mutation invocations. `MixedScheduler` holds only immutable fields, and each fiber creates its own dispatcher via `makeDispatcher()`, so sharing is safe. The implementation prefers `globalThis.queueMicrotask` (available in all modern runtimes) and falls back to `Promise.resolve().then()` for compatibility.

https://claude.ai/code/session_01SJTWHm93xoX2yxk9uXgzfD