### PR TITLE
Disable fiber yielding in module-scope sync runs

### DIFF
--- a/.changeset/prevent-scheduler-yield-in-module-scope-runs.md
+++ b/.changeset/prevent-scheduler-yield-in-module-scope-runs.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": patch
+---
+
+Fix the remaining "Can't use setTimeout in queries and mutations" crash for apps whose function registration or schema compilation performs enough Effect operations to trigger a cooperative fiber yield. Convex evaluates a function's modules inside the same timer-restricted isolate as the handler, and Confect's module-scope Effect runs (registration layer builds and schema-to-validator compilation) could still dispatch a yield through timer APIs there. These now run with cooperative yielding disabled.

--- a/packages/server/src/HttpRouter.ts
+++ b/packages/server/src/HttpRouter.ts
@@ -17,6 +17,7 @@ import * as HttpServer from "effect/unstable/http/HttpServer";
 import type * as ActionRunner from "./ActionRunner";
 import type * as Auth from "./Auth";
 import * as ConvexConfigProvider from "./ConvexConfigProvider";
+import { runSyncInIsolate } from "./internal/runSyncInIsolate";
 import type * as MutationRunner from "./MutationRunner";
 import type * as QueryRunner from "./QueryRunner";
 import * as RegisteredFunction from "./RegisteredFunction";
@@ -111,7 +112,7 @@ export const make = (routes: Routes): ConvexHttpRouter => {
   const httpAction = httpActionGeneric((ctx, request): Promise<Response> => {
     // The ctx-backed service layers are all synchronous and finalizer-free,
     // so the scope can close as soon as the context is built.
-    const services = Effect.runSync(
+    const services = runSyncInIsolate(
       Effect.scoped(Layer.build(RegisteredFunction.baseActionLayer(ctx))),
     );
     return handler(request, services);

--- a/packages/server/src/RegisteredFunctions.ts
+++ b/packages/server/src/RegisteredFunctions.ts
@@ -7,6 +7,7 @@ import * as Effect from "effect/Effect";
 import * as Ref from "effect/Ref";
 import type * as DatabaseSchema from "./DatabaseSchema";
 import type * as GroupImpl from "./GroupImpl";
+import { runSyncInIsolate } from "./internal/runSyncInIsolate";
 import { mapLeaves } from "./internal/utils";
 import type * as RegisteredFunction from "./RegisteredFunction";
 import * as RegistryItem from "./RegistryItem";
@@ -97,7 +98,7 @@ export const buildForGroup = <Group extends GroupSpec.AnyWithProps>(
       Registry.Registry,
       Ref.makeUnsafe<Registry.RegistryItems>({}),
     ),
-    Effect.runSync,
+    runSyncInIsolate,
   );
 
   return mapLeaves<RegistryItem.AnyWithProps, RegisteredFunction.Any>(

--- a/packages/server/src/SchemaToValidator.ts
+++ b/packages/server/src/SchemaToValidator.ts
@@ -19,10 +19,8 @@ import type {
 import { v } from "convex/values";
 import { pipe } from "effect/Function";
 import * as Array from "effect/Array";
-import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import * as Match from "effect/Match";
 import * as Number from "effect/Number";
 import * as Option from "effect/Option";
@@ -32,6 +30,7 @@ import * as SchemaAST from "effect/SchemaAST";
 import * as String from "effect/String";
 
 import * as GenericId from "@confect/core/GenericId";
+import { runSyncThrowInIsolate } from "./internal/runSyncInIsolate";
 import type {
   IsAny,
   IsOptional,
@@ -58,7 +57,7 @@ export const compileArgsSchema = <ConfectValue, ConvexValue>(
         : Effect.fail(new IndexSignaturesAreNotSupportedError()),
     ),
     Match.orElse(() => Effect.fail(new TopLevelMustBeObjectError())),
-    runSyncThrow,
+    runSyncThrowInIsolate,
   );
 };
 
@@ -67,7 +66,7 @@ export const compileArgsSchema = <ConfectValue, ConvexValue>(
 export const compileReturnsSchema = <ConfectValue, ConvexValue>(
   schema: Schema.Codec<ConfectValue, ConvexValue>,
 ): Validator<any, any, any> =>
-  runSyncThrow(compileAst(Schema.toEncoded(schema).ast));
+  runSyncThrowInIsolate(compileAst(Schema.toEncoded(schema).ast));
 
 // Table
 
@@ -98,7 +97,7 @@ export const compileTableSchema = <TableSchema extends Schema.Codec<any, any>>(
     ),
     Match.tag("Union", (unionAst) => compileAst(unionAst)),
     Match.orElse(() => Effect.fail(new TopLevelMustBeObjectOrUnionError())),
-    runSyncThrow,
+    runSyncThrowInIsolate,
   );
 };
 
@@ -252,7 +251,7 @@ type ValueTupleToValidatorTuple<VlTuple extends ReadonlyArray<ReadonlyValue>> =
 export const compileSchema = <T, E>(
   schema: Schema.Codec<T, E>,
 ): ValueToValidator<(typeof schema)["Encoded"]> =>
-  runSyncThrow(compileAst(schema.ast)) as any;
+  runSyncThrowInIsolate(compileAst(schema.ast)) as any;
 
 export const isRecursive = (ast: SchemaAST.AST): boolean =>
   pipe(
@@ -507,18 +506,6 @@ const handlePropertySignatures = (objectsAst: SchemaAST.Objects) =>
   );
 
 // Errors
-
-const runSyncThrow = <A, E>(effect: Effect.Effect<A, E>) =>
-  pipe(
-    effect,
-    Effect.runSyncExit,
-    Exit.match({
-      onSuccess: (validator) => validator,
-      onFailure: (cause) => {
-        throw Cause.squash(cause);
-      },
-    }),
-  );
 
 export class TopLevelMustBeObjectError extends Data.TaggedError(
   "TopLevelMustBeObjectError",

--- a/packages/server/src/internal/runSyncInIsolate.ts
+++ b/packages/server/src/internal/runSyncInIsolate.ts
@@ -1,0 +1,50 @@
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { pipe } from "effect/Function";
+import * as Scheduler from "effect/Scheduler";
+
+/**
+ * Convex bans `setTimeout` in queries and mutations and their isolate has no
+ * `setImmediate` — and it evaluates a function's module graph inside that same
+ * isolate, so Effects run at module scope (registration layer builds, schema →
+ * validator compiles) face the same restrictions as handlers.
+ *
+ * `Effect.runSync` is unsafe there: it forks its fiber with its own
+ * `MixedScheduler("sync")` (passed as a run option, so it overrides any
+ * scheduler provided within the effect), and once a synchronous fiber exhausts
+ * its op budget (`MaxOpsBeforeYield`, 2048 operations) the run loop injects a
+ * cooperative yield whose dispatcher eagerly arms `setImmediate`/`setTimeout`
+ * — crashing the isolate even though `runSync`'s trailing flush would have
+ * drained the task. Registration work scales with app size, so large apps
+ * cross the budget while small ones never do.
+ *
+ * These runners instead put `Scheduler.PreventSchedulerYield` in the fiber's
+ * base context via `Effect.runSyncWith`: it sits in the root context (below
+ * `runSync`'s scheduler run option, which it composes with rather than
+ * fights), never pops, and makes the run loop skip yield checks entirely — the
+ * correct semantic for a synchronous module-scope computation, which has
+ * nothing to cooperatively yield to.
+ */
+const preventYieldContext = Context.make(Scheduler.PreventSchedulerYield, true);
+
+export const runSyncInIsolate: <A, E>(effect: Effect.Effect<A, E>) => A =
+  Effect.runSyncWith(preventYieldContext);
+
+export const runSyncExitInIsolate: <A, E>(
+  effect: Effect.Effect<A, E>,
+) => Exit.Exit<A, E> = Effect.runSyncExitWith(preventYieldContext);
+
+/** `runSyncExitInIsolate`, squashing failures into a thrown error. */
+export const runSyncThrowInIsolate = <A, E>(effect: Effect.Effect<A, E>): A =>
+  pipe(
+    effect,
+    runSyncExitInIsolate,
+    Exit.match({
+      onSuccess: (value) => value,
+      onFailure: (cause) => {
+        throw Cause.squash(cause);
+      },
+    }),
+  );

--- a/packages/server/test/internal/runSyncInIsolate.test.ts
+++ b/packages/server/test/internal/runSyncInIsolate.test.ts
@@ -1,0 +1,95 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { describe, expect, test } from "vitest";
+import {
+  runSyncExitInIsolate,
+  runSyncInIsolate,
+  runSyncThrowInIsolate,
+} from "../../src/internal/runSyncInIsolate";
+
+/**
+ * A purely synchronous program that burns several multiples of
+ * `MaxOpsBeforeYield` (2048), like a large app's registration layer build or
+ * schema → validator compile. `Effect.sync` (unlike `Effect.succeed`, which
+ * the generator runtime unwraps without touching the op counter) charges the
+ * fiber's op budget on every iteration.
+ */
+const sumToN = (n: number) =>
+  Effect.gen(function* () {
+    let sum = 0;
+    for (let i = 1; i <= n; i++) {
+      sum += yield* Effect.sync(() => i);
+    }
+    return sum;
+  });
+
+const expectedSum = (5000 * 5001) / 2;
+
+/**
+ * Simulate the Convex query/mutation isolate for the duration of `run`:
+ * `setTimeout` throws Convex's error, and `setImmediate` (absent in the
+ * isolate, so Effect's default scheduler would fall back to `setTimeout`)
+ * throws too, so any timer use surfaces as a test failure. Only synchronous
+ * code runs inside the stub window.
+ */
+const withConvexIsolateTimers = <A>(run: () => A): A => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalSetImmediate = globalThis.setImmediate;
+  const ban = (name: string) => () => {
+    throw new Error(
+      `Can't use ${name} in queries and mutations. Please consider using an action.`,
+    );
+  };
+  globalThis.setTimeout = ban("setTimeout") as never;
+  globalThis.setImmediate = ban("setImmediate") as never;
+  try {
+    return run();
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.setImmediate = originalSetImmediate;
+  }
+};
+
+describe("runSyncInIsolate", () => {
+  // Documents why these runners exist: `Effect.runSync` forks with its own
+  // `MixedScheduler("sync")` whose dispatcher eagerly arms
+  // `setImmediate`/`setTimeout` when the fiber's op budget forces a yield. If
+  // this test ever fails, Effect has made `runSync` timer-free and the
+  // isolate-safe runners can be retired.
+  test("Effect.runSync uses banned timer APIs past the fiber op budget", () => {
+    expect(() =>
+      withConvexIsolateTimers(() => Effect.runSync(sumToN(5000))),
+    ).toThrow(/Can't use set(Timeout|Immediate)/);
+  });
+
+  test("runSyncInIsolate runs past the fiber op budget without timers", () => {
+    const result = withConvexIsolateTimers(() =>
+      runSyncInIsolate(sumToN(5000)),
+    );
+    expect(result).toBe(expectedSum);
+  });
+
+  test("runSyncExitInIsolate runs past the fiber op budget without timers", () => {
+    const exit = withConvexIsolateTimers(() =>
+      runSyncExitInIsolate(sumToN(5000)),
+    );
+    expect(exit._tag).toBe("Success");
+  });
+
+  test("runSyncThrowInIsolate runs past the fiber op budget without timers", () => {
+    const result = withConvexIsolateTimers(() =>
+      runSyncThrowInIsolate(sumToN(5000)),
+    );
+    expect(result).toBe(expectedSum);
+  });
+
+  test("runSyncThrowInIsolate throws the squashed failure", () => {
+    class BoomError extends Data.TaggedError("BoomError")<{
+      message: string;
+    }> {}
+
+    expect(() =>
+      runSyncThrowInIsolate(Effect.fail(new BoomError({ message: "boom" }))),
+    ).toThrow("boom");
+  });
+});


### PR DESCRIPTION
Follow-up to #509, which fixed Effect's cooperative fiber yielding for **handler execution** but missed Confect's **module-scope** Effect runs. Convex evaluates a function's modules inside the same timer-banned isolate as the handler, so apps whose registration or schema compilation crosses the 2048-op yield budget still crashed with:

> Error: Can't use setTimeout in queries and mutations. Please consider using an action.

with a stack ending in Effect's `Yield` primitive inside `runForkWith`'s initial synchronous evaluate — before any handler ran.

## Root cause

`Effect.runSync` is unsafe under Convex's timer ban: it forks its fiber with its own `MixedScheduler("sync")` (passed as a run option, overriding anything provided within the effect), and once a synchronous fiber exhausts its op budget (`MaxOpsBeforeYield`, 2048), the run loop injects a cooperative yield whose dispatcher **eagerly arms `setImmediate`/`setTimeout`** — even though `runSync`'s trailing `flush()` would have drained the task.

Confect runs `Effect.runSync`/`runSyncExit` at module scope in `RegisteredFunctions.buildForGroup` (registration layer build, invoked by every generated `convex/groups/*.ts`) and `SchemaToValidator` (schema → validator compiles). Registration work scales with app size, so large apps crossed the budget while the small test fixtures never did.

## Fix

New internal `runSyncInIsolate` runners put `Scheduler.PreventSchedulerYield: true` in the fiber's **base context** via the public `Effect.runSyncWith`: it sits in the root context (composing with, rather than being overridden by, `runSync`'s scheduler run option), never pops, and makes the run loop skip yield checks entirely — the correct semantic for a synchronous module-scope computation, which has nothing to cooperatively yield to.

Switched call sites:

- `RegisteredFunctions.buildForGroup`
- `SchemaToValidator` (`compileArgsSchema` / `compileReturnsSchema` / `compileTableSchema`, replacing the local `runSyncThrow` helper)
- `HttpRouter`'s per-request service build (HTTP actions allow timers, so this one was safe either way; switched for uniformity)

## Tests

`test/internal/runSyncInIsolate.test.ts` runs a 5000-op synchronous effect through each runner with `setTimeout`/`setImmediate` stubbed to throw Convex's exact error. It includes a control test asserting plain `Effect.runSync` *does* trip the banned timers past the op budget — if a future Effect version makes `runSync` timer-free, that test failing signals these runners can be retired.

Full suite, typecheck, lint, and format all pass. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJTWHm93xoX2yxk9uXgzfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJTWHm93xoX2yxk9uXgzfD)_