### PR TITLE
Fix storage services URL decoding in Convex isolate

### DIFF
--- a/.changeset/spotty-carrots-brake.md
+++ b/.changeset/spotty-carrots-brake.md
@@ -1,0 +1,7 @@
+---
+"@confect/server": patch
+---
+
+Fix `StorageWriter.generateUploadUrl` and `StorageReader.getUrl` dying with `SchemaError: Expected URL, got "https://…"` on the URL strings Convex returns. Effect 4's `Schema.URL` is an `instanceof URL` check (in Effect 3 it was a string→URL transform), so the storage services now decode with `Schema.URLFromString` instead.
+
+`Schema.URLFromString` relies on `URL.canParse`, which the Convex UDF isolate's `URL` polyfill doesn't implement — so `@confect/server` now installs a spec-compliant `URL.canParse` polyfill when it's missing. The polyfill loads with the package's entry modules, so it also covers user schemas that use `Schema.URLFromString` (or `URL.canParse` directly) inside Convex queries and mutations.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -87,7 +87,9 @@
     "test:mock-backend": "vitest run --config vitest.mock-backend.config.ts",
     "typecheck": "tsc -b tsconfig.src.json"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "**/urlCanParsePolyfill.*"
+  ],
   "type": "module",
   "types": "./dist/index.d.ts"
 }

--- a/packages/server/src/StorageReader.ts
+++ b/packages/server/src/StorageReader.ts
@@ -7,6 +7,8 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { BlobNotFoundError } from "./BlobNotFoundError";
+// oxlint-disable-next-line import/no-unassigned-import
+import "./internal/urlCanParsePolyfill";
 
 const make = (storageReader: ConvexStorageReader) => ({
   getUrl: (storageId: GenericId<"_storage">) =>
@@ -17,7 +19,11 @@ const make = (storageReader: ConvexStorageReader) => ({
           Option.match({
             onNone: () => Effect.fail(new BlobNotFoundError({ id: storageId })),
             onSome: (doc) =>
-              pipe(doc, Schema.decodeUnknownEffect(Schema.URL), Effect.orDie),
+              pipe(
+                doc,
+                Schema.decodeUnknownEffect(Schema.URLFromString),
+                Effect.orDie,
+              ),
           }),
         ),
       ),

--- a/packages/server/src/StorageWriter.ts
+++ b/packages/server/src/StorageWriter.ts
@@ -6,12 +6,18 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import { BlobNotFoundError } from "./BlobNotFoundError";
+// oxlint-disable-next-line import/no-unassigned-import
+import "./internal/urlCanParsePolyfill";
 
 const make = (storageWriter: ConvexStorageWriter) => ({
   generateUploadUrl: () =>
     Effect.promise(() => storageWriter.generateUploadUrl()).pipe(
       Effect.andThen((url) =>
-        pipe(url, Schema.decodeUnknownEffect(Schema.URL), Effect.orDie),
+        pipe(
+          url,
+          Schema.decodeUnknownEffect(Schema.URLFromString),
+          Effect.orDie,
+        ),
       ),
     ),
   delete: (storageId: GenericId<"_storage">) =>

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,3 +1,6 @@
+// oxlint-disable-next-line import/no-unassigned-import
+import "./internal/urlCanParsePolyfill";
+
 export * as ActionCtx from "./ActionCtx";
 export * as ActionRunner from "./ActionRunner";
 export * as Auth from "./Auth";

--- a/packages/server/src/internal/urlCanParsePolyfill.ts
+++ b/packages/server/src/internal/urlCanParsePolyfill.ts
@@ -1,0 +1,27 @@
+// Convex's UDF isolate provides a `URL` polyfill without the static
+// `URL.canParse`, which Effect's `Schema.URLFromString` decode relies on.
+// Install a spec-compliant fallback so string→URL schemas work in Convex
+// queries and mutations — for Confect's own storage services and user
+// schemas alike.
+export const installURLCanParsePolyfill = (): void => {
+  try {
+    if (typeof URL !== "undefined" && typeof URL.canParse !== "function") {
+      Object.defineProperty(URL, "canParse", {
+        value: (url: string | URL, base?: string | URL): boolean => {
+          try {
+            return Boolean(new URL(url, base));
+          } catch {
+            return false;
+          }
+        },
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  } catch {
+    // The global is not patchable in this runtime; leave it as-is.
+  }
+};
+
+installURLCanParsePolyfill();

--- a/packages/server/src/node.ts
+++ b/packages/server/src/node.ts
@@ -1,1 +1,4 @@
+// oxlint-disable-next-line import/no-unassigned-import
+import "./internal/urlCanParsePolyfill";
+
 export * as RegisteredNodeFunction from "./RegisteredNodeFunction";

--- a/packages/server/test/StorageReader.test.ts
+++ b/packages/server/test/StorageReader.test.ts
@@ -1,0 +1,46 @@
+import type { StorageReader as ConvexStorageReader } from "convex/server";
+import type { GenericId } from "convex/values";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { BlobNotFoundError } from "@confect/server/BlobNotFoundError";
+import { StorageReader } from "@confect/server/StorageReader";
+
+const storageId = "storage-id" as GenericId<"_storage">;
+
+const blobUrl =
+  "https://happy-animal-123.convex.cloud/api/storage/11111111-2222-3333-4444-555555555555";
+
+const fakeConvexStorageReader = (url: string | null) =>
+  ({
+    getUrl: () => Promise.resolve(url),
+  }) as unknown as ConvexStorageReader;
+
+describe("StorageReader", () => {
+  it.effect("getUrl decodes the string Convex returns", () =>
+    Effect.gen(function* () {
+      const storageReader = yield* StorageReader;
+
+      const url = yield* storageReader.getUrl(storageId);
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.href).toBe(blobUrl);
+    }).pipe(
+      Effect.provide(StorageReader.layer(fakeConvexStorageReader(blobUrl))),
+    ),
+  );
+
+  it.effect(
+    "getUrl fails with BlobNotFoundError when Convex returns null",
+    () =>
+      Effect.gen(function* () {
+        const storageReader = yield* StorageReader;
+
+        const error = yield* Effect.flip(storageReader.getUrl(storageId));
+
+        expect(error).toBeInstanceOf(BlobNotFoundError);
+        expect(error.id).toBe(storageId);
+      }).pipe(
+        Effect.provide(StorageReader.layer(fakeConvexStorageReader(null))),
+      ),
+  );
+});

--- a/packages/server/test/StorageWriter.test.ts
+++ b/packages/server/test/StorageWriter.test.ts
@@ -1,0 +1,53 @@
+import type { StorageWriter as ConvexStorageWriter } from "convex/server";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { StorageWriter } from "@confect/server/StorageWriter";
+import { installURLCanParsePolyfill } from "../src/internal/urlCanParsePolyfill";
+
+const uploadUrl =
+  "https://happy-animal-123.convex.cloud/api/storage/upload?token=abc123";
+
+const fakeConvexStorageWriter = {
+  generateUploadUrl: () => Promise.resolve(uploadUrl),
+} as unknown as ConvexStorageWriter;
+
+describe("StorageWriter", () => {
+  it.effect("generateUploadUrl decodes the string Convex returns", () =>
+    Effect.gen(function* () {
+      const storageWriter = yield* StorageWriter;
+
+      const url = yield* storageWriter.generateUploadUrl();
+
+      expect(url).toBeInstanceOf(URL);
+      expect(url.href).toBe(uploadUrl);
+    }).pipe(Effect.provide(StorageWriter.layer(fakeConvexStorageWriter))),
+  );
+
+  it.effect(
+    "generateUploadUrl decodes without a native URL.canParse, as in the Convex isolate",
+    () =>
+      Effect.gen(function* () {
+        const nativeCanParse = URL.canParse;
+        delete (URL as { canParse?: typeof URL.canParse }).canParse;
+        installURLCanParsePolyfill();
+
+        const storageWriter = yield* StorageWriter;
+
+        const url = yield* storageWriter.generateUploadUrl().pipe(
+          Effect.ensuring(
+            Effect.sync(() =>
+              Object.defineProperty(URL, "canParse", {
+                value: nativeCanParse,
+                writable: true,
+                enumerable: false,
+                configurable: true,
+              }),
+            ),
+          ),
+        );
+
+        expect(url).toBeInstanceOf(URL);
+        expect(url.href).toBe(uploadUrl);
+      }).pipe(Effect.provide(StorageWriter.layer(fakeConvexStorageWriter))),
+  );
+});

--- a/packages/server/test/internal/urlCanParsePolyfill.test.ts
+++ b/packages/server/test/internal/urlCanParsePolyfill.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { installURLCanParsePolyfill } from "../../src/internal/urlCanParsePolyfill";
+
+const nativeCanParse = URL.canParse;
+
+const deleteCanParse = () => {
+  delete (URL as { canParse?: typeof URL.canParse }).canParse;
+};
+
+afterEach(() => {
+  Object.defineProperty(URL, "canParse", {
+    value: nativeCanParse,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+});
+
+describe("installURLCanParsePolyfill", () => {
+  test("installs a spec-compliant canParse when missing", () => {
+    deleteCanParse();
+
+    installURLCanParsePolyfill();
+
+    expect(typeof URL.canParse).toBe("function");
+    expect(URL.canParse("https://example.com/path?query=1")).toBe(true);
+    expect(URL.canParse(new URL("https://example.com"))).toBe(true);
+    expect(URL.canParse("/relative", "https://example.com")).toBe(true);
+    expect(URL.canParse("/relative")).toBe(false);
+    expect(URL.canParse("not a url")).toBe(false);
+  });
+
+  test("leaves an existing canParse untouched", () => {
+    installURLCanParsePolyfill();
+
+    expect(URL.canParse).toBe(nativeCanParse);
+  });
+});

--- a/packages/server/test/local-backend/fixtures/confect/_generated/registeredFunctions/groups/storage.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/registeredFunctions/groups/storage.ts
@@ -1,0 +1,5 @@
+import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";
+import databaseSchema from "../../schema";
+import storage from "../../../groups/storage.impl";
+
+export default RegisteredFunctions.buildForGroup<typeof import("../../../groups/storage.spec")["default"]>(databaseSchema, storage, RegisteredConvexFunction.make);

--- a/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/_generated/spec.ts
@@ -2,9 +2,10 @@ import { GroupSpec, Spec } from "@confect/core";
 import groups_cacheControl from "../groups/cacheControl.spec";
 import groups_cacheStubbed from "../groups/cacheStubbed.spec";
 import groups_scheduling from "../groups/scheduling.spec";
+import groups_storage from "../groups/storage.spec";
 
 const spec: Spec.Spec<
-  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_cacheControl, "cacheControl"> | GroupSpec.NamedAt<typeof groups_cacheStubbed, "cacheStubbed"> | GroupSpec.NamedAt<typeof groups_scheduling, "scheduling">>, "groups">
-> = Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed).addGroupAt("scheduling", groups_scheduling));
+  | GroupSpec.NamedAt<GroupSpec.GroupSpec<"Convex", "groups", never, GroupSpec.NamedAt<typeof groups_cacheControl, "cacheControl"> | GroupSpec.NamedAt<typeof groups_cacheStubbed, "cacheStubbed"> | GroupSpec.NamedAt<typeof groups_scheduling, "scheduling"> | GroupSpec.NamedAt<typeof groups_storage, "storage">>, "groups">
+> = Spec.make().addAt("groups", GroupSpec.makeAt("groups").addGroupAt("cacheControl", groups_cacheControl).addGroupAt("cacheStubbed", groups_cacheStubbed).addGroupAt("scheduling", groups_scheduling).addGroupAt("storage", groups_storage));
 
 export default spec;

--- a/packages/server/test/local-backend/fixtures/confect/groups/storage.impl.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/storage.impl.ts
@@ -1,0 +1,47 @@
+/**
+ * Handlers exercise Confect's storage services inside the real Convex
+ * isolate, whose `URL` polyfill lacks `URL.canParse`. Both decode Convex's
+ * string return values with `Schema.URLFromString`, so they only succeed if
+ * the `URL.canParse` polyfill `@confect/server` installs is in effect.
+ */
+
+import { FunctionImpl, GroupImpl } from "@confect/server";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import databaseSchema from "../_generated/schema";
+import { StorageReader, StorageWriter } from "../_generated/services";
+import storage from "./storage.spec";
+
+const generateUploadUrl = FunctionImpl.make(
+  databaseSchema,
+  storage,
+  "generateUploadUrl",
+  () =>
+    Effect.gen(function* () {
+      const storageWriter = yield* StorageWriter;
+
+      const url = yield* storageWriter.generateUploadUrl();
+
+      return url.toString();
+    }),
+);
+
+const getUrl = FunctionImpl.make(
+  databaseSchema,
+  storage,
+  "getUrl",
+  ({ storageId }) =>
+    Effect.gen(function* () {
+      const storageReader = yield* StorageReader;
+
+      const url = yield* storageReader.getUrl(storageId);
+
+      return url.toString();
+    }).pipe(Effect.orDie),
+);
+
+export default GroupImpl.make(databaseSchema, storage).pipe(
+  Layer.provide(generateUploadUrl),
+  Layer.provide(getUrl),
+  GroupImpl.finalize,
+);

--- a/packages/server/test/local-backend/fixtures/confect/groups/storage.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/storage.spec.ts
@@ -1,0 +1,18 @@
+import { FunctionSpec, GenericId, GroupSpec } from "@confect/core";
+import * as Schema from "effect/Schema";
+
+export default GroupSpec.make()
+  .addFunction(
+    FunctionSpec.publicMutation({
+      name: "generateUploadUrl",
+      args: () => Schema.Struct({}),
+      returns: () => Schema.String,
+    }),
+  )
+  .addFunction(
+    FunctionSpec.publicQuery({
+      name: "getUrl",
+      args: () => Schema.Struct({ storageId: GenericId.GenericId("_storage") }),
+      returns: () => Schema.String,
+    }),
+  );

--- a/packages/server/test/local-backend/fixtures/convex/_generated/api.d.ts
+++ b/packages/server/test/local-backend/fixtures/convex/_generated/api.d.ts
@@ -35,6 +35,15 @@ export declare const api: {
       manyOpsMutation: FunctionReference<"mutation", "public", {}, number>;
       manyOpsQuery: FunctionReference<"query", "public", {}, number>;
     };
+    storage: {
+      generateUploadUrl: FunctionReference<"mutation", "public", {}, string>;
+      getUrl: FunctionReference<
+        "query",
+        "public",
+        { storageId: Id<"_storage"> },
+        string
+      >;
+    };
   };
 };
 

--- a/packages/server/test/local-backend/fixtures/convex/groups/storage.ts
+++ b/packages/server/test/local-backend/fixtures/convex/groups/storage.ts
@@ -1,0 +1,4 @@
+import registeredFunctions from "../../confect/_generated/registeredFunctions/groups/storage";
+
+export const generateUploadUrl = registeredFunctions.generateUploadUrl;
+export const getUrl = registeredFunctions.getUrl;

--- a/packages/server/test/local-backend/storage.test.ts
+++ b/packages/server/test/local-backend/storage.test.ts
@@ -1,0 +1,64 @@
+/**
+ * End-to-end test of Confect's storage services inside Convex's real UDF
+ * isolate. Convex returns storage URLs as plain strings, and the isolate's
+ * `URL` polyfill lacks the static `URL.canParse` that Effect's
+ * `Schema.URLFromString` decode relies on — so these only pass if the
+ * `URL.canParse` polyfill `@confect/server` installs takes effect in the
+ * isolate and the string→URL decode succeeds there.
+ */
+
+import { Ref } from "@confect/core";
+import { expect, layer } from "@effect/vitest";
+import type { GenericId } from "convex/values";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import refs from "./fixtures/confect/_generated/refs";
+import * as LocalBackend from "./LocalBackend";
+
+const UploadResponse = Schema.fromJsonString(
+  Schema.Struct({ storageId: Schema.String }),
+);
+
+layer(LocalBackend.layer, { timeout: "120 seconds" })(
+  "Storage services inside the Convex isolate",
+  (it) => {
+    it.effect(
+      "generateUploadUrl decodes the isolate's string URL, and getUrl resolves an uploaded blob",
+      () =>
+        Effect.gen(function* () {
+          const { client } = yield* LocalBackend.LocalBackend;
+
+          const uploadUrl = yield* Effect.promise(() =>
+            client.mutation(
+              Ref.getFunctionReference(
+                refs.public.groups.storage.generateUploadUrl,
+              ),
+              {},
+            ),
+          );
+          expect(new URL(uploadUrl).pathname).toContain("/api/storage/upload");
+
+          const uploadResponseBody = yield* Effect.promise(() =>
+            fetch(uploadUrl, {
+              method: "POST",
+              headers: { "Content-Type": "text/plain" },
+              body: "hello, storage",
+            }).then((response) => response.text()),
+          );
+          const { storageId } =
+            yield* Schema.decodeUnknownEffect(UploadResponse)(
+              uploadResponseBody,
+            );
+
+          const blobUrl = yield* Effect.promise(() =>
+            client.query(
+              Ref.getFunctionReference(refs.public.groups.storage.getUrl),
+              { storageId: storageId as GenericId<"_storage"> },
+            ),
+          );
+          expect(new URL(blobUrl).pathname).toContain("/api/storage/");
+        }),
+      60_000,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Fix `StorageWriter.generateUploadUrl` and `StorageReader.getUrl` failing with schema errors when decoding the URL strings Convex returns. The issue stems from Effect 4's `Schema.URL` being an `instanceof URL` check rather than a string→URL transform, combined with the Convex UDF isolate's `URL` polyfill lacking the `URL.canParse` static method that `Schema.URLFromString` relies on.

## Key Changes

- **URL decoding fix**: Updated `StorageWriter` and `StorageReader` to decode with `Schema.URLFromString` instead of `Schema.URL`, which properly handles string inputs
- **URL.canParse polyfill**: Added `urlCanParsePolyfill.ts` that installs a spec-compliant `URL.canParse` implementation when missing (as in the Convex isolate)
- **Automatic polyfill installation**: The polyfill loads automatically via `@confect/server`'s entry modules (`index.ts` and `node.ts`), ensuring it's available for both Confect's storage services and user schemas using `Schema.URLFromString` or `URL.canParse` directly
- **Side effects declaration**: Updated `package.json` to mark the polyfill as a side effect so it's not tree-shaken away
- **Comprehensive test coverage**: Added unit tests for the polyfill, storage services with and without native `URL.canParse`, and an end-to-end integration test exercising storage operations inside the real Convex isolate

## Implementation Details

The `URL.canParse` polyfill uses a try-catch approach to safely attempt URL construction, returning `true` if successful and `false` on any error. This matches the spec-compliant behavior while being defensive about runtime environments where the global might not be patchable.

The polyfill is installed at module load time in both the main entry point and the Node.js-specific entry point, ensuring it takes effect before any schema decoding occurs in Convex queries, mutations, or actions.

https://claude.ai/code/session_01Xz17AUBuMrAAU7gpQsbiCA