### PR TITLE
Bump pinned pnpm to 11.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "effect"
   ],
   "license": "ISC",
-  "packageManager": "pnpm@11.0.9",
+  "packageManager": "pnpm@11.18.0",
   "scripts": {
     "build": "vp run --cache --filter \"@confect/*\" build",
     "check": "vp check",


### PR DESCRIPTION
Routine refresh of the runtime version pins that live outside `package.json` dependency maps. One pin moved.

## What moved

| Pin | Location | Before | After |
| --- | --- | --- | --- |
| pnpm | root `package.json` → `packageManager` | `11.0.9` | `11.18.0` |

Release notes: [pnpm releases](https://github.com/pnpm/pnpm/releases) — the range spans 11.1.0 → 11.18.0 ([11.18.0](https://github.com/pnpm/pnpm/releases/tag/v11.18.0), [11.17.0](https://github.com/pnpm/pnpm/releases/tag/v11.17.0), [11.16.0](https://github.com/pnpm/pnpm/releases/tag/v11.16.0), [11.15.0](https://github.com/pnpm/pnpm/releases/tag/v11.15.0), [11.14.0](https://github.com/pnpm/pnpm/releases/tag/v11.14.0), [11.13.0](https://github.com/pnpm/pnpm/releases/tag/v11.13.0), [11.12.0](https://github.com/pnpm/pnpm/releases/tag/v11.12.0), [11.11.0](https://github.com/pnpm/pnpm/releases/tag/v11.11.0), [11.10.0](https://github.com/pnpm/pnpm/releases/tag/v11.10.0), [11.9.0](https://github.com/pnpm/pnpm/releases/tag/v11.9.0), [11.8.0](https://github.com/pnpm/pnpm/releases/tag/v11.8.0), [11.7.0](https://github.com/pnpm/pnpm/releases/tag/v11.7.0), [11.6.0](https://github.com/pnpm/pnpm/releases/tag/v11.6.0), [11.5.0](https://github.com/pnpm/pnpm/releases/tag/v11.5.0), [11.4.0](https://github.com/pnpm/pnpm/releases/tag/v11.4.0), [11.3.0](https://github.com/pnpm/pnpm/releases/tag/v11.3.0), [11.2.0](https://github.com/pnpm/pnpm/releases/tag/v11.2.0), [11.1.0](https://github.com/pnpm/pnpm/releases/tag/v11.1.0)).

The pin had been at `11.0.9` since the v9 branch merged in June. Reading the whole range, nothing in it is breaking for this repo: `lockfileVersion` is still `9.0`, no install or workspace default changed, and the new supply-chain gates (`minimumReleaseAge`, `trustPolicy`) only activate when configured — this repo sets neither. The fixes worth having are on the install path: peer-resolution determinism (11.2.2, the lockfile flipping between two equally valid forms across consecutive installs — relevant here because `autoInstallPeers` is on), peer-context reuse during lockfile regeneration (11.5.3), and the metadata-cache fix in 11.9.0.

Staying on the 11 line deliberately: `pnpm@12` exists only as `12.0.0-beta.2` behind the `next-12` tag.

## Pins already current

- **bun** — `mise.toml` pins `1.3.14`, which is the published `latest`. No change.
- **Node** — `.node-version` holds a bare major (`22`), so there is no patch to move within the line.

### The available Node jump, not taken

Node 24 is Active LTS and 26 is Current; moving `.node-version` to `24` is the available major-line jump. It's left alone here because the published packages all declare `engines.node: ">=22"`, and moving the dev pin alone would mean CI stops exercising the floor those packages promise. Changing the floor is a deliberate, changeset-recorded decision — out of scope for a pin refresh, and worth doing as one deliberate change rather than half of one. Node 22 is in maintenance until April 2027, so there's no deadline pressure.

## Where these versions are actually resolved — and what this bump does *not* reach

Not every consumer reads the file that moved:

**Reached:**

- `.github/actions/confect-setup` — `pnpm/action-setup@v4` with no `version:`, so it reads `packageManager` from the root `package.json`. This is the action behind every job in `packages.yml`, so the bump takes effect across the main CI workflow.
- `.github/workflows/release.yml` — `pnpm/action-setup@v6`, likewise no `version:`, so it also reads `packageManager`.
- `mise.toml` — `idiomatic_version_file_enable_tools = ["node", "pnpm"]`, so mise resolves pnpm from `packageManager` for local shells.

**Not reached — and currently broken independently of this change:**

`.github/actions/docs-setup`, `.github/actions/example-setup`, and `.github/actions/package-setup` each resolve pnpm with:

```yaml
run: echo "pnpm_version=$(node -p 'require(`./package.json`).engines.pnpm')" >> $GITHUB_OUTPUT
```

and Node with `node-version-file: "package.json"`, which reads `engines.node`. The root `package.json` has **no `engines` field at all** — only the six published packages under `packages/*` declare one. So neither expression resolves to anything: the `node -p` call dereferences `undefined` and the setup-node step has no version to read.

That's pre-existing and orthogonal to this bump, but it means the docs and example workflows do not pick up the pnpm version from anywhere this routine controls. Two of these actions are live (`docs.yml` → `docs-setup`, `example.yml` → `example-setup`); `package-setup` is referenced by no workflow at all and looks like dead code.

Worth a follow-up, and deliberately not folded in here: the fix is either to point those three actions at `packageManager`/`.node-version` the way `confect-setup` already does, or to add an `engines` block to the root manifest. The first is the smaller change and makes all four actions agree on one source of truth. Either way it's a CI change, not a version bump, and it shouldn't ride along in a pin refresh.

## Verification

Reinstalled from scratch on 11.18.0 — `pnpm-lock.yaml` comes back byte-identical, no churn to review. Then, all on the new version:

- `pnpm build` — 11/11 packages built
- `pnpm check` — 335 files formatted, 238 files linted, clean
- `pnpm format:check` / `pnpm lint` — clean, including the syncpack passes that `vp check` doesn't cover
- `pnpm typecheck` — clean
- `pnpm test` — 73 files passed, 982 tests, no type errors
- `pnpm test:server:mock-backend` — 15 files passed, 201 tests

The server local-backend suite needs a running Convex backend and wasn't run here; leaving it to CI.

No changeset: this touches no published `@confect/*` surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KK55P6eW7eF6hjWBTB7QnU)_