### PR TITLE
Remove `maybeDecodeErrorSync`

### DIFF
--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -390,22 +390,6 @@ export const decodeErrorOption = <Ref_ extends Any>(
     Match.exhaustive,
   );
 
-export const maybeDecodeErrorSync = <Ref_ extends Any>(
-  ref: Ref_,
-  error: unknown,
-): unknown =>
-  isConvexError(error)
-    ? Match.value(ref.functionSpec.functionProvenance).pipe(
-        Match.tag("Confect", (confectFunctionProvenance) =>
-          "error" in confectFunctionProvenance
-            ? Schema.decodeSync(confectFunctionProvenance.error)(error.data)
-            : error,
-        ),
-        Match.tag("Convex", () => error),
-        Match.exhaustive,
-      )
-    : error;
-
 const missingPaginatedProvenanceError = (ref: Any) =>
   new globalThis.Error(
     `Paginated query ref "${getConvexFunctionName(ref)}" was not built with ` +

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -251,60 +251,6 @@ describe("isConvexError", () => {
   });
 });
 
-describe("maybeDecodeErrorSync", () => {
-  test("decodes ConvexError when error schema is present", () => {
-    class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
-      id: Schema.String,
-    }) {}
-
-    const spec = FunctionSpec.publicMutation({
-      name: "update",
-      args: () => Schema.Struct({}),
-      returns: () => Schema.Void,
-      error: () => NotFound,
-    });
-    const ref = Ref.make("test/mod", spec);
-
-    const convexError = new ConvexError({
-      _tag: "NotFound",
-      id: "abc",
-    });
-    const decoded = Ref.maybeDecodeErrorSync(ref, convexError);
-    expect(decoded).toBeInstanceOf(NotFound);
-    expect((decoded as NotFound).id).toBe("abc");
-  });
-
-  test("returns original error when no error schema", () => {
-    const spec = FunctionSpec.publicMutation({
-      name: "create",
-      args: () => Schema.Struct({}),
-      returns: () => Schema.Void,
-    });
-    const ref = Ref.make("test/mod", spec);
-
-    const convexError = new ConvexError({ code: "ERR" });
-    const result = Ref.maybeDecodeErrorSync(ref, convexError);
-    expect(result).toBe(convexError);
-  });
-
-  test("returns non-ConvexError errors unchanged", () => {
-    class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
-      id: Schema.String,
-    }) {}
-
-    const spec = FunctionSpec.publicMutation({
-      name: "update",
-      args: () => Schema.Struct({}),
-      returns: () => Schema.Void,
-      error: () => NotFound,
-    });
-    const ref = Ref.make("test/mod", spec);
-
-    const plainError = new Error("network error");
-    expect(Ref.maybeDecodeErrorSync(ref, plainError)).toBe(plainError);
-  });
-});
-
 describe("decodeError", () => {
   test("decodes error data using the error schema", async () => {
     class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {


### PR DESCRIPTION
`Ref.maybeDecodeErrorSync` decoded a caught `ConvexError` with `Schema.decodeSync`, which throws a `ParseError` when the payload doesn't match the ref's declared `error` schema.

That case is not exotic. Convex raises its own `ConvexError`s — an `InvalidCursor` from a paginated query being the obvious one — and their data never matches a user-declared schema. The `"error" in provenance` guard only proves a schema *exists*, not that this particular value conforms to it. So any ref that declared a typed error turned every foreign `ConvexError` into an opaque `ParseError`, discarding the one diagnostic worth having. A ref that declared *no* error schema was already handled correctly, which made the failure look arbitrary from the outside.

This is the same defect fixed in `decodeErrorSync` (now `decodeErrorOption`) in #528. This was the last caller of the unsafe pattern.

## Removed rather than repaired

Nothing calls it. The only references anywhere in the repo were its own definition and its own tests — no usage in the other packages, and none in `apps/docs` or `apps/example`. Undocumented exports aren't treated as public API here, so this doesn't need a deprecation cycle or a major bump.

Callers wanting this shape already have two safe options:

- `decodeErrorOrElse(ref, fallback)` — this function exactly, with the fallback named at the call site instead of hardcoded to "return the input"
- `decodeErrorOption(ref, data)` — for handling the undecodable case yourself

The name was wrong in both halves too, which is some evidence it was never load-bearing: `maybe` spells an optionality the `unknown` return type never carried, and `Sync` is the suffix Effect reserves for decoders that throw — precisely the behavior being deleted.

## Changeset

None. The export appears in neither the docs nor the example app, so it isn't counted as public API.

## Verification

Deleted the function and its three tests; confirmed no dangling references remain outside `dist/`. `pnpm typecheck` clean, 1095 tests passing with no type errors, lint and format clean. (The suite runs each test twice, runtime plus typecheck, so removing 3 tests drops the count by 6.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oXPZ6bvGsVEg74BUg3XME