### PR TITLE
Decode `unknown` inputs with the `decodeUnknown*` codecs

### DIFF
--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -252,7 +252,7 @@ export const decodeReturns = <Ref_ extends Any>(
 ): Effect.Effect<Returns<Ref_>, ParseResult.ParseError> =>
   Match.value(ref.functionSpec.functionProvenance).pipe(
     Match.tag("Confect", (confectFunctionProvenance) =>
-      Schema.decode(confectFunctionProvenance.returns)(returns),
+      Schema.decodeUnknown(confectFunctionProvenance.returns)(returns),
     ),
     Match.tag("Convex", () => Effect.succeed(returns)),
     Match.exhaustive,
@@ -276,7 +276,7 @@ export const decodeArgsSync = <Ref_ extends Any>(
 ): Args<Ref_> =>
   Match.value(ref.functionSpec.functionProvenance).pipe(
     Match.tag("Confect", (confectFunctionProvenance) =>
-      Schema.decodeSync(confectFunctionProvenance.args)(encodedArgs),
+      Schema.decodeUnknownSync(confectFunctionProvenance.args)(encodedArgs),
     ),
     Match.tag("Convex", () => encodedArgs),
     Match.exhaustive,
@@ -300,7 +300,9 @@ export const decodeReturnsSync = <Ref_ extends Any>(
 ): Returns<Ref_> =>
   Match.value(ref.functionSpec.functionProvenance).pipe(
     Match.tag("Confect", (confectFunctionProvenance) =>
-      Schema.decodeSync(confectFunctionProvenance.returns)(encodedReturns),
+      Schema.decodeUnknownSync(confectFunctionProvenance.returns)(
+        encodedReturns,
+      ),
     ),
     Match.tag("Convex", () => encodedReturns),
     Match.exhaustive,
@@ -350,7 +352,7 @@ export const decodeError = <Ref_ extends Any>(
     Match.tag("Confect", (confectFunctionProvenance) =>
       "error" in confectFunctionProvenance
         ? Effect.map(
-            Schema.decode(confectFunctionProvenance.error)(encodedError),
+            Schema.decodeUnknown(confectFunctionProvenance.error)(encodedError),
             Option.some,
           )
         : Effect.succeed(Option.none<Error<Ref_>>()),
@@ -512,7 +514,7 @@ export const runWithCodec = <Ref_ extends Any, E = never>(
             confectFunctionProvenance.args,
           )(args);
           const encodedReturns = yield* invoke(encodedArgs);
-          return yield* Schema.decode(confectFunctionProvenance.returns)(
+          return yield* Schema.decodeUnknown(confectFunctionProvenance.returns)(
             encodedReturns,
           );
         }),


### PR DESCRIPTION
Effect draws the `decode` / `decodeUnknown` distinction by input type: `decodeUnknown*` accepts `unknown`, while `decode*` declares that the caller has already produced the schema's `Encoded` type.

Every decode helper in `Ref` takes `unknown` — args and returns arrive off the wire, error payloads come out of a caught `ConvexError` — but five of them reached for the `Encoded` variant anyway.

| Site | Was | Now |
| --- | --- | --- |
| `decodeReturns` | `Schema.decode` | `Schema.decodeUnknown` |
| `decodeArgsSync` | `Schema.decodeSync` | `Schema.decodeUnknownSync` |
| `decodeReturnsSync` | `Schema.decodeSync` | `Schema.decodeUnknownSync` |
| `decodeError` | `Schema.decode` | `Schema.decodeUnknown` |
| `runWithCodec` | `Schema.decode` | `Schema.decodeUnknown` |

This compiled only by accident: provenance stores its schemas as `Schema.Schema.AnyNoContext`, so `Encoded` is `any` and any input satisfies it. The `unknown` was never checked against anything, and the mismatch would have started producing real type errors the moment those schemas gained a concrete `Encoded` type.

## No behavior change, and no changeset

Not merely "unchanged in practice" — in Effect 3.22 these are literally the same functions under two type signatures:

```ts
// Schema.ts
export const decode: <A, I, R>(…) => … = decodeUnknown

// ParseResult.ts
export const decodeSync: <A, I>(…) => … = decodeUnknownSync
```

So this is a type-level correction with no observable delta, and the parameters were already `unknown` — no signature moved. Hence no changeset.

## Scope

The encode helpers already pair correctly and stay as they are: they take `Args<Ref_>` and `Returns<Ref_>`, which are the `Type` side, so `encode`/`encodeSync` is the right choice there.

This brings the older helpers in line with the paginated ones added in #528, which already used the `Unknown` variants.

`maybeDecodeErrorSync` is the one remaining `decodeSync` on an `unknown` input. It is deliberately untouched here because #530 rewrites that call entirely — keeping the two PRs conflict-free.

## Verification

`pnpm typecheck` clean, 1101 tests passing with no type errors, lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oXPZ6bvGsVEg74BUg3XME

---
_Generated by [Claude Code](https://claude.ai/code/session_018oXPZ6bvGsVEg74BUg3XME)_