### PR TITLE
Merge sync PRs with a merge commit, not a squash

### DIFF
--- a/.claude/commands/upgrade-effect-beta.md
+++ b/.claude/commands/upgrade-effect-beta.md
@@ -20,16 +20,19 @@ works.)
   still check for `main` changes to propagate before stopping.
 - **Changes from `main`:** the prerelease line absorbs `main` continuously
   so the eventual `v10` → `main` merge stays small. Whether there's
-  anything to absorb is a **content** question, never an ancestry one:
-  sync PRs get squash-merged like every other PR in this repo, so
-  `git log origin/v10..origin/main` reports already-absorbed commits
-  forever and must not be used as the trigger. Instead, every run
-  performs the sync merge locally per the merge rules and keeps it only
-  if it changes content: `git diff origin/v10 HEAD` non-empty → deliver
-  it as a sync PR (see Branches and PRs); empty → `main` has nothing
-  new, discard the merge. Never open a PR whose only effect would be
-  recording merge ancestry. No beta to bump **and** no content to
-  propagate → say so and stop — no branch, no PR.
+  anything to absorb is a **content** question, never an ancestry one.
+  Sync PRs land with their merge commit intact (see the merge rules), so
+  ancestry converges from here on — but the line still carries a long
+  tail of earlier squash-merged syncs, and `git log origin/v10..origin/main`
+  cannot tell the two regimes apart. It is therefore not the trigger:
+  wrong for the squashed tail, and merely redundant once ancestry has
+  caught up. Instead, every run performs the sync merge locally per the
+  merge rules and keeps it only if it changes content:
+  `git diff origin/v10 HEAD` non-empty → deliver it as a sync PR (see
+  Branches and PRs); empty → `main` has nothing new, discard the merge.
+  Never open a PR whose only effect would be recording merge ancestry.
+  No beta to bump **and** no content to propagate → say so and stop —
+  no branch, no PR.
 - **In-scope packages:** `effect` plus its lockstep companions from the
   effect monorepo already present in the workspace (`@effect/platform-node`,
   `@effect/platform-bun`, `@effect/vitest`) — all move to the same beta
@@ -61,12 +64,19 @@ targets `main`.
 ## Rules
 
 - Perform the sync merge as a real `git merge` of `origin/main` — not a
-  rebase or cherry-picks — so each conflict is resolved exactly once.
-  But expect the PR to be squash-merged: the merge commit's second
-  parent won't survive, ancestry won't converge, and that's fine — what
-  the sync keeps converged is content, not history. Don't request
-  "Create a merge commit" for sync PRs, and don't re-merge to repair
-  ancestry. Take `main`'s side of conflicts except where it would undo
+  rebase or cherry-picks — so each conflict is resolved exactly once and
+  the resulting commit carries `main`'s tip as its second parent. Sync
+  PRs land with **"Create a merge commit"** — never squashed or rebased,
+  both of which discard that second parent, which is what has kept
+  `merge-base(v10, main)` pinned to an ancient commit and made every
+  sync PR's commit list open with ~20 commits it already absorbed.
+  Landing the merge intact moves the merge base up to `main`'s tip, so
+  the next sync PR lists only genuinely new work. State that requirement
+  in the sync PR body — you still never merge these yourself, and the
+  reviewer needs to know which button to press. Don't re-merge
+  afterwards to repair ancestry: the content is already correct, and a
+  second merge would only add noise.
+  Take `main`'s side of conflicts except where it would undo
   the prerelease line: keep
   `.changeset/pre.json`, `"baseBranch": "v10"` in `.changeset/config.json`,
   the `v10` entries in the workflow branch lists, the `X.0.0-next.N`
@@ -84,10 +94,11 @@ targets `main`.
   e.g. "Sync with `main`: this prerelease line now includes all changes
   released in `@confect/*` 9.3.2–9.4.0 — see those versions' changelog
   entries." Derive the range mechanically from changelogs, not from
-  `git merge-base` (squash merges leave the merge base permanently
-  stale): the versions absorbed are the stable `## 9.x.y` headings
-  present in `origin/main`'s CHANGELOG for a `@confect/*` package but
-  absent from `origin/v10`'s copy of the same file before the merge —
+  `git merge-base` (which is only as current as the last sync that was
+  merged with its merge commit intact): the versions absorbed are the
+  stable `## 9.x.y` headings present in `origin/main`'s CHANGELOG for a
+  `@confect/*` package but absent from `origin/v10`'s copy of the same
+  file before the merge —
   the fixed group versions together, so any one package's CHANGELOG
   suffices. No missing headings → no released changes absorbed → skip
   this changeset.
@@ -138,8 +149,10 @@ targets `main`.
 3. Push the branches (unless this session was assigned a branch) and
    open or refresh the PRs per Branches and PRs. Sync PR body: what the
    merge changes, summarized from the content diff against `origin/v10`
-   (not from `git log`, which lists already-absorbed commits), the
-   stable version range absorbed (matching the changeset), and any
-   migrations needed to keep the merge green at the current pin. Bump PR
-   body: old → new beta, links to the release notes covered, and a
-   summary of the source migrations made.
+   rather than from `git log` (which still lists the commits absorbed by
+   earlier squash-merged syncs), the stable version range absorbed
+   (matching the changeset), the requirement to merge with "Create a
+   merge commit" per the merge rules, and any migrations needed to keep
+   the merge green at the current pin. Bump PR body: old → new beta,
+   links to the release notes covered, and a summary of the source
+   migrations made.


### PR DESCRIPTION
Reverses the `upgrade-effect-beta` command's guidance on how `v10` sync PRs should land. It currently says *"Don't request 'Create a merge commit' for sync PRs"* and treats permanently-stale ancestry as acceptable; this makes the merge commit the required strategy.

## Why

Every sync PR opens with roughly twenty commits it already absorbed — [#534](https://github.com/rjdellecese/confect/pull/534) lists 26, of which only 7 are new. The sync branch head is a genuine merge commit carrying `main`'s tip as its second parent, but squashing discards that parent, so the merge base never advances.

Simulating both strategies against #534:

| | `merge-base(v10, main)` after | `main` commits still "unmerged" |
|---|---|---|
| today | `d0b50db` (#477) | 26 |
| squash-merge | `d0b50db` (#477) — unchanged | 25 |
| merge commit | `7b94ed6` (`main`'s tip) | **0** |

Both produce a byte-identical tree, so this is purely about ancestry — the file diff is unaffected either way.

## What changed

- **Merge rule** — sync PRs now land with *"Create a merge commit"*, stated as the strategy rather than hedged, with the reason spelled out: squash and rebase both drop the second parent. The run puts that requirement in the sync PR body so the reviewer knows which button to press; it still never merges these itself. The existing "don't re-merge to repair ancestry" instruction is retained.
- **Sync trigger** — deliberately still content-based. Ancestry converges from here on, but the line carries a long tail of earlier squash-merged syncs and `git log origin/v10..origin/main` can't tell the two regimes apart; `git diff origin/v10 HEAD` is correct under either history. The rationale is reworded from "squash merges make ancestry useless forever" to reflect the mixed history.
- **Changelog range derivation** and **PR-body guidance** — both justified themselves with "squash merges leave this permanently stale". Reworded rather than reversed, for the same reason as the trigger.

No changeset: `.claude/` tooling only, nothing on the published surface.