### PR TITLE
Bump the setup actions and let Dependabot see them

### DIFF
--- a/.github/actions/confect-setup/action.yml
+++ b/.github/actions/confect-setup/action.yml
@@ -6,10 +6,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: ".node-version"
         cache: "pnpm"

--- a/.github/actions/docs-setup/action.yml
+++ b/.github/actions/docs-setup/action.yml
@@ -6,10 +6,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: ".node-version"
         cache: "pnpm"

--- a/.github/actions/example-setup/action.yml
+++ b/.github/actions/example-setup/action.yml
@@ -6,10 +6,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version-file: ".node-version"
         cache: "pnpm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
+  # `directory: "/"` reaches only `.github/workflows` and a root `action.yml`,
+  # so the composite actions under `.github/actions/*` went unscanned — which
+  # is how they drifted to v4 while `release.yml` was kept current.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,5 @@
 version: 2
 updates:
-  # `directory: "/"` reaches only `.github/workflows` and a root `action.yml`,
-  # so the composite actions under `.github/actions/*` went unscanned — which
-  # is how they drifted to v4 while `release.yml` was kept current.
   - package-ecosystem: "github-actions"
     directories:
       - "/"


### PR DESCRIPTION
The three composite actions under `.github/actions/` pinned `pnpm/action-setup@v4` and `actions/setup-node@v4`, while `release.yml` — the one workflow that inlines its setup rather than using a composite action — was on `@v6` and `@v7`.

That skew is a Dependabot blind spot, not an oversight. For the `github-actions` ecosystem, [`directory: "/"` reaches `.github/workflows` and an `action.yml` at the repository root](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference), and nothing else — composite actions nested under `.github/actions/` are never scanned. So Dependabot kept `release.yml` current while the three actions every other workflow depends on sat untouched since they were written.

## Changes

- `pnpm/action-setup@v4` → `@v6` and `actions/setup-node@v4` → `@v7` in `confect-setup`, `docs-setup`, and `example-setup`, matching what `release.yml` already uses.
- `.github/dependabot.yml`'s `github-actions` entry switches from `directory` to `directories` (which, unlike `directory`, accepts globs) and adds `/.github/actions/*`, so the next drift gets caught rather than found by hand.

## Verification

Both major tags exist upstream (`git ls-remote --tags` shows `v6` for `pnpm/action-setup` and `v7` for `actions/setup-node`). Beyond that, CI on this PR is the check — every job in `packages.yml`, `example.yml`, and `docs.yml` routes through one of these three composite actions, so a bad major fails immediately and visibly.

## Notes

- The pinned Node version is unchanged; both actions still read `node-version-file: ".node-version"`.
- Split out of the Windows-support branch, where these bumps were originally bundled in as a drive-by. They aren't related to Windows and belong on their own.
- Not addressed here: the `devcontainers` entry points at `/`, but the repo has no `.devcontainer` directory — that entry appears to be dead config.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgF5T3LBp2GiHnmQDUjr7F)_