### PR TITLE
Correct the config provider claims in the environment variables docs

### DIFF
--- a/apps/docs/server/environment-variables.mdx
+++ b/apps/docs/server/environment-variables.mdx
@@ -4,7 +4,9 @@ title: "Environment Variables"
 description: "Read environment variables using Effect's Config module."
 ---
 
-Confect provides a `ConfigProvider` that is compatible with the Convex runtime, where `process.env` is not enumerable. This provider is automatically set for all Confect functions (queries, mutations, actions, and HTTP API handlers), so Effect's [`Config`](https://effect.website/docs/configuration/) module works out of the box.
+Confect provides a `ConfigProvider` that is compatible with the Convex runtime, where `process.env` is not enumerable. Confect sets it automatically for every function that runs in the Convex runtime—queries, mutations, actions, and HTTP API handlers—so Effect's [`Config`](https://effect.website/docs/configuration/) module works out of the box.
+
+[Node actions](/server/node-actions) are the exception. They run in the Node.js runtime, where `process.env` behaves like an ordinary object, so they use Effect's default [`ConfigProvider.fromEnv`](https://effect.website/docs/configuration/#loading-configuration-from-environment-variables) instead. Reading environment variables works the same way in both runtimes.
 
 ## Reading environment variables
 
@@ -32,6 +34,8 @@ Config.integer("MAX_RESULTS").pipe(Config.withDefault(100));
 ## Limitations
 
 Config operations that require enumerating `process.env` are unsupported in the Convex runtime. This includes `Config.hashMap` and other combinators that need to discover keys dynamically. Attempting to use them will result in an `Unsupported` config error.
+
+These combinators do work in [Node actions](/server/node-actions), since Effect's default provider can enumerate `process.env` in the Node.js runtime. Avoid depending on that if the handler might later move to the Convex runtime.
 
 ## Custom config provider
 

--- a/apps/docs/server/environment-variables.mdx
+++ b/apps/docs/server/environment-variables.mdx
@@ -25,7 +25,7 @@ const getApiKey = FunctionImpl.make(databaseSchema, settings, "getApiKey", () =>
 );
 ```
 
-All of Effect's `Config` combinators work as expected—`Config.string`, `Config.number`, `Config.boolean`, `Config.withDefault`, `Config.option`, etc.
+Combinators that read a single variable work as expected—`Config.string`, `Config.number`, `Config.boolean`, `Config.withDefault`, `Config.option`, and `Config.nested`, among others.
 
 ```ts
 Config.integer("MAX_RESULTS").pipe(Config.withDefault(100));
@@ -33,28 +33,52 @@ Config.integer("MAX_RESULTS").pipe(Config.withDefault(100));
 
 ## Limitations
 
-Config operations that require enumerating `process.env` are unsupported in the Convex runtime. This includes `Config.hashMap` and other combinators that need to discover keys dynamically. Attempting to use them will result in an `Unsupported` config error.
+Config operations that enumerate `process.env` are unsupported in the Convex runtime, and fail with an `Unsupported` config error. This covers every combinator that resolves a collection of keys rather than a single one:
+
+- `Config.array`, `Config.chunk`, and `Config.hashSet`
+- `Config.hashMap`
+
+`Config.array` is the surprising member of that list, since it looks like a way to read one comma-separated variable. Effect resolves a sequence by first looking for indexed keys (`ALLOWED_ORIGINS[0]`, `ALLOWED_ORIGINS[1]`, and so on), which requires enumeration, so it fails before it can fall back to splitting a delimited value.
+
+To read a delimited variable, parse it yourself:
+
+```ts
+Config.string("ALLOWED_ORIGINS").pipe(
+  Config.map((origins) => origins.split(",").map((origin) => origin.trim())),
+);
+```
 
 These combinators do work in [Node actions](/server/node-actions), since Effect's default provider can enumerate `process.env` in the Node.js runtime. Avoid depending on that if the handler might later move to the Convex runtime.
 
 ## Custom config provider
 
-The `ConvexConfigProvider` module is exported from `@confect/server` if you need to create a provider with custom options. It supports the same options as Effect's default [`ConfigProvider.fromEnv`](https://effect.website/docs/configuration/#loading-configuration-from-environment-variables).
+The `ConvexConfigProvider` module is exported from `@confect/server`. `ConvexConfigProvider.make()` takes the same options as Effect's [`ConfigProvider.fromEnv`](https://effect.website/docs/configuration/#loading-configuration-from-environment-variables), and both are optional—calling it with no arguments returns the provider Confect already installs for you.
 
 ```ts
 import { ConvexConfigProvider } from "@confect/server";
 
-const provider = ConvexConfigProvider.make({
-  pathDelim: "__",
-  seqDelim: ";",
-});
+const provider = ConvexConfigProvider.make({ pathDelim: "__" });
 ```
+
+| Option      | Default | Description                                                                                                                                                                   |
+| ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pathDelim` | `"_"`   | Joins the segments of a nested config path into a variable name. With `"__"`, `Config.nested(Config.string("HOST"), "DB")` reads `DB__HOST`.                                  |
+| `seqDelim`  | `","`   | Separates the elements of a sequence. This has no effect in the Convex runtime, because the sequence combinators that would consume it are [unsupported](#limitations) there. |
 
 To use a custom provider in a function handler, pass it to `Effect.withConfigProvider`.
 
-```ts
+```ts confect/settings.impl.ts
+import { ConvexConfigProvider, FunctionImpl } from "@confect/server";
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+
+import databaseSchema from "./_generated/schema";
+import settings from "./settings.spec";
+
+const provider = ConvexConfigProvider.make({ pathDelim: "__" });
+
 const getApiKey = FunctionImpl.make(databaseSchema, settings, "getApiKey", () =>
-  Config.string("API_KEY").pipe(
+  Config.nested(Config.string("KEY"), "API").pipe(
     Effect.withConfigProvider(provider),
     Effect.orDie,
   ),


### PR DESCRIPTION
The environment variables page made three claims that don't hold. Two of them would send a reader down a path that silently doesn't work, so this corrects all three and documents `ConvexConfigProvider.make` properly. Docs only — no source changes.

## Which functions get `ConvexConfigProvider`

The page said the provider is "automatically set for all Confect functions (queries, mutations, actions, and HTTP API handlers)." Node actions were never in that set. `RegisteredNodeFunction` builds its layer from `actionLayer` plus `NodeContext.layer` and never merges in `Layer.setConfigProvider`, unlike its Convex-runtime sibling.

That's fine, and the page now says so rather than implying otherwise: node actions run in the Node.js runtime, where `process.env` is an ordinary enumerable object, so Effect's default `ConfigProvider.fromEnv` is the right provider for them. The two agree on `pathDelim` and `seqDelim`, so reading a variable behaves identically either way.

## `seqDelim` cannot do anything in the Convex runtime

The custom-provider section led with `seqDelim: ";"` as its headline example. That option is unreachable.

`seqDelim` is only consumed by the `split: true` branch of the provider's `load`. The only configs that reach it are sequences — and Effect resolves a sequence by calling `enumerateChildren` first, to look for indexed keys like `ORIGINS[0]`, falling back to splitting a delimited value only when that returns zero indices. `ConvexConfigProvider`'s `enumerateChildren` always fails, so the fallback is never reached. A reader following the old example would set a delimiter and never observe an effect.

The example now demonstrates `pathDelim`, which genuinely works — nested paths are joined with it before lookup, so `Config.nested(Config.string("HOST"), "DB")` reads `DB__HOST` under `pathDelim: "__"`.

## `Config.array` is unsupported, not just `Config.hashMap`

The limitations section named `Config.hashMap` and "combinators that need to discover keys dynamically." Nobody reads that as covering `Config.array`. But `array`, `chunk`, and `hashSet` are all sequences, so the same enumeration call kills all three:

| Config | `ConvexConfigProvider` | `ConfigProvider.fromEnv` |
| --- | --- | --- |
| `Config.string("LIST")` | `"a,b,c"` | `"a,b,c"` |
| `Config.array(Config.string(), "LIST")` | `Unsupported` | `["a","b","c"]` |
| `Config.chunk(Config.string(), "LIST")` | `Unsupported` | `["a","b","c"]` |
| `Config.hashSet(Config.string(), "LIST")` | `Unsupported` | `["a","b","c"]` |
| `Config.hashMap(Config.string(), "DB")` | `Unsupported` | supported |
| `Config.nested`, `Config.all`, `Config.withDefault`, `Config.option` | supported | supported |

`Config.array("ALLOWED_ORIGINS")` is exactly what someone reaches for to read a comma-separated variable, so it's now called out by name with the mechanism behind it and a parse-it-yourself workaround.

## Other changes

- Documented both `make` options in a table with their defaults (`pathDelim` `"_"`, `seqDelim` `","`), and noted the argument is optional — `make()` returns the provider Confect already installs.
- Made the custom-provider handler snippet a complete file with imports, matching the one above it.
- Softened "All of Effect's `Config` combinators work as expected," which contradicted the limitations section directly below it.

## No changeset

Only `apps/docs` changed, which is a private workspace app. Nothing in the published `@confect/*` surface moved, so there's no version to bump.

## Verification

Everything above was measured against `effect@3.22.1` rather than read off the types:

- Ran each combinator in the table through the built `ConvexConfigProvider` and through `ConfigProvider.fromEnv` to produce both columns.
- Confirmed the `seqDelim` claim by tracing `OP_SEQUENCE` in `effect/internal/configProvider`, where `enumerateChildren` is called unconditionally ahead of the split fallback.
- Typechecked both documented snippets — the custom-provider handler and the delimited-variable workaround — by compiling them in `apps/example` with `tsc -p apps/example/tsconfig.json --noEmit`.
- `pnpm format:check` clean; all 42 CI checks green on `c30d5f7`, including Broken Links, which covers the two new `/server/node-actions` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LgEqccR5Q3bkNNuAK78Lg