### PR TITLE
Re-baseline type instantiation counts

### DIFF
--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -347,15 +347,15 @@ void ({} as Refs.Refs<any>);
 
 bench("Refs<Spec> (unfiltered)", () => {
   return {} as Refs.Refs<MediumSpec>;
-}).types([2125, "instantiations"]);
+}).types([2015, "instantiations"]);
 
 bench("Refs<Spec, AnyPublic> (public-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>;
-}).types([2042, "instantiations"]);
+}).types([1942, "instantiations"]);
 
 bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyInternal>;
-}).types([2070, "instantiations"]);
+}).types([1966, "instantiations"]);
 
 // Laziness: accessing one leaf should be cheaper than accessing all leaves.
 // If the type were eagerly evaluated, both benchmarks would have the same
@@ -363,7 +363,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2314, "instantiations"]);
+}).types([2190, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -374,50 +374,50 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([2712, "instantiations"]);
+}).types([2561, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
 bench("small: Refs (unfiltered)", () => {
   return {} as Refs.Refs<SmallSpec>;
-}).types([655, "instantiations"]);
+}).types([624, "instantiations"]);
 
 bench("small: Refs (public-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
-}).types([655, "instantiations"]);
+}).types([624, "instantiations"]);
 
 bench("small: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
-}).types([631, "instantiations"]);
+}).types([603, "instantiations"]);
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([891, "instantiations"]);
+}).types([836, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([971, "instantiations"]);
+}).types([910, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
 bench("large: Refs (unfiltered)", () => {
   return {} as Refs.Refs<LargeSpec>;
-}).types([4104, "instantiations"]);
+}).types([3896, "instantiations"]);
 
 bench("large: Refs (public-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>;
-}).types([3963, "instantiations"]);
+}).types([3771, "instantiations"]);
 
 bench("large: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyInternal>;
-}).types([3979, "instantiations"]);
+}).types([3784, "instantiations"]);
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4261, "instantiations"]);
+}).types([4045, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -439,4 +439,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([5551, "instantiations"]);
+}).types([5257, "instantiations"]);

--- a/packages/server/test/SchemaToValidator.bench.ts
+++ b/packages/server/test/SchemaToValidator.bench.ts
@@ -71,21 +71,21 @@ bench('ValueToValidator<GenericId<"users">>', () => {
 
 bench("ValueToValidator<string[]>", () => {
   return {} as ValueToValidator<string[]>;
-}).types([3333, "instantiations"]);
+}).types([3340, "instantiations"]);
 
 bench("ValueToValidator<string[][]>", () => {
   return {} as ValueToValidator<string[][]>;
-}).types([3883, "instantiations"]);
+}).types([3893, "instantiations"]);
 
 bench("ValueToValidator<any[]>", () => {
   return {} as ValueToValidator<any[]>;
-}).types([3295, "instantiations"]);
+}).types([3302, "instantiations"]);
 
 // --- Objects (small/medium/large) ---
 
 bench("small object", () => {
   return {} as ValueToValidator<{ foo: string }>;
-}).types([740, "instantiations"]);
+}).types([670, "instantiations"]);
 
 bench("medium object", () => {
   return {} as ValueToValidator<{
@@ -94,7 +94,7 @@ bench("medium object", () => {
     baz: boolean;
     items: string[];
   }>;
-}).types([4397, "instantiations"]);
+}).types([4148, "instantiations"]);
 
 bench("large object", () => {
   return {} as ValueToValidator<{
@@ -109,37 +109,37 @@ bench("large object", () => {
     i?: string | undefined;
     j: "admin" | "user";
   }>;
-}).types([6991, "instantiations"]);
+}).types([6196, "instantiations"]);
 
 // --- Optional fields ---
 
 bench("ValueToValidator<{ foo?: string | undefined }>", () => {
   return {} as ValueToValidator<{ foo?: string | undefined }>;
-}).types([1006, "instantiations"]);
+}).types([920, "instantiations"]);
 
 bench("ValueToValidator<{ foo?: { bar?: number | undefined } | undefined }>", () => {
   return {} as ValueToValidator<{
     foo?: { bar?: number | undefined } | undefined;
   }>;
-}).types([9373, "instantiations"]);
+}).types([9260, "instantiations"]);
 
 // --- Unions ---
 
 bench("ValueToValidator<string | number>", () => {
   return {} as ValueToValidator<string | number>;
-}).types([1296, "instantiations"]);
+}).types([1307, "instantiations"]);
 
 bench('ValueToValidator<"admin" | "user">', () => {
   return {} as ValueToValidator<"admin" | "user">;
-}).types([1301, "instantiations"]);
+}).types([1312, "instantiations"]);
 
 bench("ValueToValidator<string | number | boolean[]>", () => {
   return {} as ValueToValidator<string | number | boolean[]>;
-}).types([4745, "instantiations"]);
+}).types([4756, "instantiations"]);
 
 bench("ValueToValidator<{ foo: string } | { bar: number }>", () => {
   return {} as ValueToValidator<{ foo: string } | { bar: number }>;
-}).types([9893, "instantiations"]);
+}).types([9854, "instantiations"]);
 
 // --- Recursive types ---
 
@@ -166,7 +166,7 @@ type SmallTableSchema = typeof SmallTableSchema;
 
 bench("TableSchemaToTableValidator (small struct)", () => {
   return {} as TableSchemaToTableValidator<SmallTableSchema>;
-}).types([10566, "instantiations"]);
+}).types([10366, "instantiations"]);
 
 const MediumTableSchema = Schema.Struct({
   text: Schema.String,
@@ -185,7 +185,7 @@ type MediumTableSchema = typeof MediumTableSchema;
 
 bench("TableSchemaToTableValidator (medium struct with optional)", () => {
   return {} as TableSchemaToTableValidator<MediumTableSchema>;
-}).types([15013, "instantiations"]);
+}).types([14438, "instantiations"]);
 
 const LargeTableSchema = Schema.Struct({
   name: Schema.String,
@@ -208,4 +208,4 @@ type LargeTableSchema = typeof LargeTableSchema;
 
 bench("TableSchemaToTableValidator (large struct)", () => {
   return {} as TableSchemaToTableValidator<LargeTableSchema>;
-}).types([17367, "instantiations"]);
+}).types([16406, "instantiations"]);


### PR DESCRIPTION
Stacked on #562 — **merge that first.** This PR targets its branch so the diff here is only the baseline numbers; once #562 lands and its branch is deleted, GitHub retargets this to `v10`. If the branch isn't deleted on merge, retarget this to `v10` manually before merging.

> [!NOTE]
> **This PR shows no checks, and that's expected.** `packages.yml` triggers on pull requests whose base is `main` or `v10`, and this one is based on #562's branch. CI runs as soon as it's retargeted to `v10`. See the verification section below for what was run locally in the meantime.

## Why

The committed instantiation counts on this line were measured before `confect-bench-harness` existed, back when `effect-language-service patch` injected the Effect plugin into the JavaScript compiler that `@ark/attest` loads. The counts therefore included instantiations the *plugin* performed, not just Confect's own types. The harness `main` introduced takes `@ark/attest` off that path — `main` re-baselined for it in the same change, and the harness README documents the expected 8–15% drop.

The `v10` line inherited the harness through the sync merge but kept its old numbers, so every bench now sits ~5% under baseline.

That still passes — the drift is inside `@ark/attest`'s 20% threshold, and the bench jobs on #562 are green. But a baseline that is uniformly 5% high is one that has to move 25% before it reports anything, which is most of the value of committing it. The numbers here are measured under the harness, so a future delta means Confect's types moved rather than the measurement regime did.

## What changed

Only `.types([…])` baselines, in `packages/core/test/Refs.bench.ts` and `packages/server/test/SchemaToValidator.bench.ts`. Regenerated with `@ark/attest`'s `--update`, then `pnpm format` (attest's own formatter is Prettier, which this repo doesn't use).

Representative moves — most drop a few percent, a handful of array cases tick up slightly:

| Benchmark | Before | After |
| --- | ---: | ---: |
| `large: Refs (resolve all leaves)` | 5551 | 5257 |
| `TableSchemaToTableValidator (large struct)` | 17367 | 16406 |
| `large object` | 6991 | 6196 |
| `ValueToValidator<string[]>` | 3333 | 3340 |

## What deliberately did not change

The runtime `.median([…, "us"])` baselines in `Document.bench.ts`. Those measure wall-clock time, so they're only meaningful against hardware comparable to whatever set them. CI is currently happy with them, and this container is far too noisy to produce a replacement worth committing — the same benchmark measured 23.5us and 38.2us on consecutive runs here. Left for a re-baseline on a machine that can actually measure them.

## Verification

`pnpm --filter @confect/core bench` passes with `Delta: 0.00%` on all 15 benchmarks. The `@confect/server` type benchmarks likewise report `0.00%` across all 29. Its runtime benchmarks are unchanged by this PR and, as above, don't reproduce reliably in this environment — they passed on #562's CI, which is the meaningful signal for them.

No changeset: this touches committed test baselines only, nothing on the published surface.