### PR TITLE
Rename the Effect upgrade command to match the rc tag

### DIFF
--- a/.claude/commands/upgrade-effect-rc.md
+++ b/.claude/commands/upgrade-effect-rc.md
@@ -7,9 +7,10 @@ current with `main`, and open PRs for review against `v10`. Never merge them
 yourself. (The managing-prereleases skill explains how the prerelease line
 itself works.)
 
-Effect v4 left beta for release candidates in August 2026; this file is still
-named `upgrade-effect-beta` only so the scheduled routine that invokes
-`/upgrade-effect-beta` keeps resolving. Rename both together or neither.
+A scheduled routine invokes this command by name, and the name is resolved
+against this directory when the routine fires. Renaming this file therefore
+means updating that schedule in the same pass — otherwise the routine stops
+resolving and goes quiet.
 
 ## Scope
 


### PR DESCRIPTION
Follow-up to #564: `.claude/commands/upgrade-effect-beta.md` → `.claude/commands/upgrade-effect-rc.md`. Git records it as a pure rename plus a three-line note change (97% similarity).

> [!IMPORTANT]
> **The schedule has to be updated to `/upgrade-effect-rc` for this to be safe to merge.** Command names resolve against `.claude/commands/` when the routine fires — I confirmed this by watching the command list re-resolve to `upgrade-effect-rc` the moment the file was renamed locally. So from the merge commit onward, `/upgrade-effect-beta` resolves to nothing and the routine goes quiet rather than failing loudly. Merge this once the schedule points at the new name.

#564 deliberately kept the old filename for exactly this reason; with the schedule moving too, the misnomer can go.

## The note at the top

The old note explained why the name didn't match the content. That's obsolete now, so it's replaced with the part worth keeping:

> A scheduled routine invokes this command by name, and the name is resolved against this directory when the routine fires. Renaming this file therefore means updating that schedule in the same pass — otherwise the routine stops resolving and goes quiet.

Worth signposting rather than rediscovering, because the command already anticipates one more rewrite: it stops itself when Effect 4.0 goes stable and the `rc` tag stops moving, which is the natural moment for a third rename.

## Scope

Nothing outside the file referenced the old name — I grepped the repo, and the only hits were the file's own self-references, both in the replaced note. No changeset: this touches a slash command only, nothing on the published surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_014gGDABGv1CL6eLy5o18qSj)_