### PR TITLE
Fail the build on Effect suggestions, and clear them

### DIFF
--- a/.changeset/finite-system-field-schemas.md
+++ b/.changeset/finite-system-field-schemas.md
@@ -1,0 +1,8 @@
+---
+"@confect/core": patch
+"@confect/server": patch
+---
+
+The schemas Confect uses for values Convex itself produces now reject `NaN` and `±Infinity`: `_creationTime`, a scheduled function's `scheduledTime` and `completedTime`, a stored file's `size`, and the fields of `PaginationOptions`. Convex cannot return a non-finite value for any of them, so this rules out states that were never reachable.
+
+The Convex validators these compile to are unchanged — each is still `v.float64()` — so nothing changes about what your deployment accepts. Only Confect's decoding is narrower. Your own table schemas are untouched: `Schema.Number` still accepts non-finite values wherever you use it, which matters because Convex stores them.

--- a/.changeset/generate-upload-url-effect.md
+++ b/.changeset/generate-upload-url-effect.md
@@ -1,0 +1,19 @@
+---
+"@confect/server": major
+---
+
+`StorageWriter.generateUploadUrl` is now an `Effect` rather than a function returning one. Yield it directly instead of calling it.
+
+Before:
+
+```ts
+const url = yield * storage.generateUploadUrl();
+```
+
+After:
+
+```ts
+const url = yield * storage.generateUploadUrl;
+```
+
+`StorageWriter.delete` is unchanged — it takes a storage ID, so it remains a function.

--- a/.changeset/generate-upload-url-effect.md
+++ b/.changeset/generate-upload-url-effect.md
@@ -7,13 +7,17 @@
 Before:
 
 ```ts
-const url = yield * storage.generateUploadUrl();
+Effect.gen(function* () {
+  const url = yield* storage.generateUploadUrl();
+});
 ```
 
 After:
 
 ```ts
-const url = yield * storage.generateUploadUrl;
+Effect.gen(function* () {
+  const url = yield* storage.generateUploadUrl;
+});
 ```
 
 `StorageWriter.delete` is unchanged — it takes a storage ID, so it remains a function.

--- a/.changeset/test-confect-layer-value.md
+++ b/.changeset/test-confect-layer-value.md
@@ -1,0 +1,37 @@
+---
+"@confect/test": major
+---
+
+`TestConfect.layer` now returns a `Layer` directly rather than a function returning one. Drop the trailing call.
+
+Before:
+
+```ts
+export const layer = TestConfect_.layer(
+  confectSchema,
+  convexSchema,
+  import.meta.glob("./convex/**/!(*.*.*)*.*s"),
+);
+
+// …then, per test:
+Effect.gen(function* () {
+  // …
+}).pipe(Effect.provide(TestConfect.layer()));
+```
+
+After:
+
+```ts
+export const layer = TestConfect_.layer(
+  confectSchema,
+  convexSchema,
+  import.meta.glob("./convex/**/!(*.*.*)*.*s"),
+);
+
+// …then, per test:
+Effect.gen(function* () {
+  // …
+}).pipe(Effect.provide(TestConfect.layer));
+```
+
+Each test still gets its own database. The layer is built once per `Effect.provide`, so providing the same value to several tests constructs a fresh test instance for each — the same isolation the extra call used to provide.

--- a/apps/docs/guides/testing.mdx
+++ b/apps/docs/guides/testing.mdx
@@ -76,7 +76,7 @@ describe("notes", () => {
 
       assertEquals(notes.length, 1);
       assertEquals(notes[0]?.text, "Hello");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 ```
@@ -125,7 +125,7 @@ describe("notes", () => {
         .pipe(Effect.result);
 
       assertFailure(result, new NoteNotFound({ noteId: "missing" }));
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 ```

--- a/apps/docs/server/storage.mdx
+++ b/apps/docs/server/storage.mdx
@@ -38,8 +38,6 @@ Effect.gen(function* () {
 
 #### Generate an upload URL
 
-`generateUploadUrl` is an `Effect`, not a method — yield it rather than calling it.
-
 ```ts
 storage.generateUploadUrl;
 ```

--- a/apps/docs/server/storage.mdx
+++ b/apps/docs/server/storage.mdx
@@ -38,10 +38,10 @@ Effect.gen(function* () {
 
 #### Generate an upload URL
 
-`generateUploadUrl` is an `Effect`, not a method — yield it directly.
+`generateUploadUrl` is an `Effect`, not a method — yield it rather than calling it.
 
 ```ts
-yield * storage.generateUploadUrl;
+storage.generateUploadUrl;
 ```
 
 #### Delete a blob

--- a/apps/docs/server/storage.mdx
+++ b/apps/docs/server/storage.mdx
@@ -38,8 +38,10 @@ Effect.gen(function* () {
 
 #### Generate an upload URL
 
+`generateUploadUrl` is an `Effect`, not a method — yield it directly.
+
 ```ts
-storage.generateUploadUrl();
+yield * storage.generateUploadUrl;
 ```
 
 #### Delete a blob

--- a/apps/example/convex/tsconfig.json
+++ b/apps/example/convex/tsconfig.json
@@ -7,7 +7,8 @@
     /* These settings are not required by Convex and can be modified. */
     "plugins": [
       {
-        "name": "@effect/language-service"
+        "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false
       }
     ],
     "allowJs": true,

--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compilerOptions": {
-    "plugins": [{ "name": "@effect/language-service" }],
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false
+      }
+    ],
     "composite": true,
     "lib": ["ESNext", "DOM"],
     "types": ["node"],

--- a/packages/cli/test/FunctionPaths.test.ts
+++ b/packages/cli/test/FunctionPaths.test.ts
@@ -171,7 +171,7 @@ describe("FunctionPaths.make", () => {
       FunctionSpec.publicQuery({
         name: "deepQuery",
         args: () => Schema.Struct({}),
-        returns: () => Schema.Number,
+        returns: () => Schema.Finite,
       }),
     );
 
@@ -214,7 +214,7 @@ describe("FunctionPaths.make", () => {
       FunctionSpec.publicAction({
         name: "getNumber",
         args: () => Schema.Struct({}),
-        returns: () => Schema.Number,
+        returns: () => Schema.Finite,
       }),
     );
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
     "plugins": [
       {
         "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "diagnosticSeverity": {
           "deterministicKeys": "error"
         }

--- a/packages/core/src/PaginationOptions.ts
+++ b/packages/core/src/PaginationOptions.ts
@@ -14,10 +14,10 @@ import * as Schema from "effect/Schema";
  * `paginate`.
  */
 export const PaginationOptions = Schema.Struct({
-  numItems: Schema.Number,
+  numItems: Schema.Finite,
   cursor: Schema.Union([Schema.String, Schema.Null]),
   endCursor: Schema.optionalKey(Schema.Union([Schema.String, Schema.Null])),
-  id: Schema.optionalKey(Schema.Number),
-  maximumRowsRead: Schema.optionalKey(Schema.Number),
-  maximumBytesRead: Schema.optionalKey(Schema.Number),
+  id: Schema.optionalKey(Schema.Finite),
+  maximumRowsRead: Schema.optionalKey(Schema.Finite),
+  maximumBytesRead: Schema.optionalKey(Schema.Finite),
 });

--- a/packages/core/src/SystemFields.ts
+++ b/packages/core/src/SystemFields.ts
@@ -18,7 +18,7 @@ import * as GenericId from "./GenericId";
 export const SystemFields = <TableName extends string>(tableName: TableName) =>
   Schema.Struct({
     _id: GenericId.GenericId(tableName),
-    _creationTime: Schema.Number,
+    _creationTime: Schema.Finite,
   });
 
 /**

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -147,7 +147,7 @@ describe("laziness invariant", () => {
 });
 
 describe("paginated queries", () => {
-  const item = Schema.Struct({ value: Schema.NumberFromString });
+  const item = Schema.Struct({ value: Schema.FiniteFromString });
 
   describe("laziness invariant", () => {
     const makePaginatedSpec = (track: {
@@ -282,7 +282,7 @@ describe("paginated queries", () => {
         // @ts-expect-error — paginationOpts must not be declared in user args
         args: () =>
           Schema.Struct({
-            paginationOpts: Schema.Struct({ numItems: Schema.Number }),
+            paginationOpts: Schema.Struct({ numItems: Schema.Finite }),
           }),
         item: () => item,
       });

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -95,7 +95,7 @@ describe("FunctionReference", () => {
     const _spec = FunctionSpec.publicQuery({
       name: "get",
       args: () => Schema.Struct({ id: Schema.String }),
-      returns: () => Schema.Array(Schema.Number),
+      returns: () => Schema.Array(Schema.Finite),
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
     expectTypeOf<Ref.Args<Ref_>>().toEqualTypeOf<{ readonly id: string }>();
@@ -441,13 +441,13 @@ describe("hasErrorSchema", () => {
 });
 
 describe("paginated queries", () => {
-  const paginatedDoc = Schema.Struct({ value: Schema.NumberFromString });
+  const paginatedDoc = Schema.Struct({ value: Schema.FiniteFromString });
 
   const paginatedRef = Ref.make(
     "notes",
     FunctionSpec.publicPaginatedQuery({
       name: "listPaginated",
-      args: () => Schema.Struct({ count: Schema.NumberFromString }),
+      args: () => Schema.Struct({ count: Schema.FiniteFromString }),
       item: () => paginatedDoc,
     }),
   );
@@ -472,7 +472,7 @@ describe("paginated queries", () => {
       name: "listPaginated",
       args: () =>
         Schema.Struct({
-          count: Schema.NumberFromString,
+          count: Schema.FiniteFromString,
           paginationOpts: PaginationOptions.PaginationOptions,
         }),
       returns: () => PaginationResult.PaginationResult(paginatedDoc),

--- a/packages/core/test/Refs.test.ts
+++ b/packages/core/test/Refs.test.ts
@@ -257,7 +257,7 @@ describe("make", () => {
     type ConvexQueryArgs = { cursor: string };
     type ConvexQueryReturns = string[];
 
-    const ConfectQueryArgs = Schema.Struct({ limit: Schema.Number });
+    const ConfectQueryArgs = Schema.Struct({ limit: Schema.Finite });
     type ConfectQueryArgs = typeof ConfectQueryArgs.Type;
 
     const ConfectQueryReturns = Schema.Array(Schema.String);

--- a/packages/core/test/SystemFields.test.ts
+++ b/packages/core/test/SystemFields.test.ts
@@ -26,7 +26,7 @@ describe("extendWithSystemFields", () => {
       };
 
       expect(() =>
-        Schema.decodeUnknownSync(ExtendedNoteSchema)(extendedNote),
+        Schema.decodeSync(ExtendedNoteSchema)(extendedNote),
       ).not.toThrow();
     });
 
@@ -83,10 +83,10 @@ describe("extendWithSystemFields", () => {
       };
 
       expect(() =>
-        Schema.decodeUnknownSync(ExtendedItemSchema)(extendedNote),
+        Schema.decodeSync(ExtendedItemSchema)(extendedNote),
       ).not.toThrow();
       expect(() =>
-        Schema.decodeUnknownSync(ExtendedItemSchema)(extendedImage),
+        Schema.decodeSync(ExtendedItemSchema)(extendedImage),
       ).not.toThrow();
     });
 
@@ -125,7 +125,7 @@ describe("extendWithSystemFields", () => {
 
   describe("a transformed table (Schema.decodeTo)", () => {
     const StoredNote = Schema.Struct({ content: Schema.String });
-    const Note = Schema.Struct({ length: Schema.Number });
+    const Note = Schema.Struct({ length: Schema.Finite });
 
     const NoteSchema = StoredNote.pipe(
       Schema.decodeTo(Note, {
@@ -150,7 +150,7 @@ describe("extendWithSystemFields", () => {
 
     test("carries the system fields through the transformation when decoding", () => {
       expect(
-        Schema.decodeUnknownSync(ExtendedNoteSchema)({
+        Schema.decodeSync(ExtendedNoteSchema)({
           content: "Hello",
           ...systemFields,
         }),
@@ -199,7 +199,7 @@ describe("extendWithSystemFields", () => {
 
     test("decodes from the encoded key, keeping the system fields", () => {
       expect(
-        Schema.decodeUnknownSync(ExtendedNoteSchema)({
+        Schema.decodeSync(ExtendedNoteSchema)({
           full_name: "Ada",
           ...systemFields,
         }),
@@ -218,7 +218,7 @@ describe("extendWithSystemFields", () => {
 
   describe("a union containing a transformed member", () => {
     const TransformedMember = Schema.Struct({ content: Schema.String }).pipe(
-      Schema.decodeTo(Schema.Struct({ length: Schema.Number }), {
+      Schema.decodeTo(Schema.Struct({ length: Schema.Finite }), {
         decode: SchemaGetter.transform((stored: { content: string }) => ({
           length: stored.content.length,
         })),
@@ -245,13 +245,13 @@ describe("extendWithSystemFields", () => {
 
     test("decodes a document for each union member", () => {
       expect(
-        Schema.decodeUnknownSync(ExtendedItemSchema)({
+        Schema.decodeSync(ExtendedItemSchema)({
           content: "Hello",
           ...systemFields,
         }),
       ).toStrictEqual({ length: 5, ...systemFields });
       expect(
-        Schema.decodeUnknownSync(ExtendedItemSchema)({
+        Schema.decodeSync(ExtendedItemSchema)({
           url: "https://example.com",
           ...systemFields,
         }),

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,6 +3,7 @@
     "plugins": [
       {
         "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "diagnosticSeverity": {
           "deterministicKeys": "error"
         }

--- a/packages/react/test/convexVersion.test.ts
+++ b/packages/react/test/convexVersion.test.ts
@@ -30,7 +30,7 @@ const paginatedQuery = Ref.make(
   "notes",
   FunctionSpec.publicPaginatedQuery({
     name: "listPaginated",
-    item: () => Schema.Struct({ value: Schema.Number }),
+    item: () => Schema.Struct({ value: Schema.Finite }),
   }),
 );
 

--- a/packages/react/test/index.test.ts
+++ b/packages/react/test/index.test.ts
@@ -403,13 +403,13 @@ describe("useAction", () => {
 });
 
 describe("usePaginatedQuery", () => {
-  const paginatedDoc = Schema.Struct({ value: Schema.NumberFromString });
+  const paginatedDoc = Schema.Struct({ value: Schema.FiniteFromString });
 
   const paginatedQuery = Ref.make(
     "notes",
     FunctionSpec.publicPaginatedQuery({
       name: "listPaginated",
-      args: () => Schema.Struct({ count: Schema.NumberFromString }),
+      args: () => Schema.Struct({ count: Schema.FiniteFromString }),
       item: () => paginatedDoc,
     }),
   );

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,6 +3,7 @@
     "plugins": [
       {
         "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "diagnosticSeverity": {
           "deterministicKeys": "error"
         }

--- a/packages/server/src/StorageReader.ts
+++ b/packages/server/src/StorageReader.ts
@@ -19,7 +19,7 @@ const make = (storageReader: ConvexStorageReader) => ({
             onSome: (doc) =>
               pipe(
                 doc,
-                Schema.decodeUnknownEffect(Schema.URLFromString),
+                Schema.decodeEffect(Schema.URLFromString),
                 Effect.orDie,
               ),
           }),

--- a/packages/server/src/StorageWriter.ts
+++ b/packages/server/src/StorageWriter.ts
@@ -11,11 +11,7 @@ const make = (storageWriter: ConvexStorageWriter) => ({
   generateUploadUrl: () =>
     Effect.promise(() => storageWriter.generateUploadUrl()).pipe(
       Effect.andThen((url) =>
-        pipe(
-          url,
-          Schema.decodeUnknownEffect(Schema.URLFromString),
-          Effect.orDie,
-        ),
+        pipe(url, Schema.decodeEffect(Schema.URLFromString), Effect.orDie),
       ),
     ),
   delete: (storageId: GenericId<"_storage">) =>

--- a/packages/server/src/StorageWriter.ts
+++ b/packages/server/src/StorageWriter.ts
@@ -8,12 +8,13 @@ import * as Schema from "effect/Schema";
 import { BlobNotFoundError } from "./BlobNotFoundError";
 
 const make = (storageWriter: ConvexStorageWriter) => ({
-  generateUploadUrl: () =>
-    Effect.promise(() => storageWriter.generateUploadUrl()).pipe(
-      Effect.andThen((url) =>
-        pipe(url, Schema.decodeEffect(Schema.URLFromString), Effect.orDie),
-      ),
+  generateUploadUrl: Effect.promise(() =>
+    storageWriter.generateUploadUrl(),
+  ).pipe(
+    Effect.andThen((url) =>
+      pipe(url, Schema.decodeEffect(Schema.URLFromString), Effect.orDie),
     ),
+  ),
   delete: (storageId: GenericId<"_storage">) =>
     Effect.tryPromise({
       try: () => storageWriter.delete(storageId),

--- a/packages/server/src/Table.ts
+++ b/packages/server/src/Table.ts
@@ -515,8 +515,8 @@ export const scheduledFunctionsTable = make(() =>
   Schema.Struct({
     name: Schema.String,
     args: Schema.Array(Schema.Any),
-    scheduledTime: Schema.Number,
-    completedTime: Schema.optionalKey(Schema.Number),
+    scheduledTime: Schema.Finite,
+    completedTime: Schema.optionalKey(Schema.Finite),
     state: Schema.Union([
       Schema.Struct({ kind: Schema.Literal("pending") }),
       Schema.Struct({ kind: Schema.Literal("inProgress") }),
@@ -533,7 +533,7 @@ export const scheduledFunctionsTable = make(() =>
 export const storageTable = make(() =>
   Schema.Struct({
     sha256: Schema.String,
-    size: Schema.Number,
+    size: Schema.Finite,
     contentType: Schema.optionalKey(Schema.String),
   }),
 )("_storage");

--- a/packages/server/test/Document.bench.ts
+++ b/packages/server/test/Document.bench.ts
@@ -31,14 +31,14 @@ const extendedSchema = SystemFields.extendWithSystemFields(
 
 const cachedDecoder = Schema.decodeUnknownSync(extendedSchema);
 
-const decodedNote = Schema.decodeUnknownSync(extendedSchema)(convexNote);
+const decodedNote = Schema.decodeSync(extendedSchema)(convexNote);
 
 const cachedEncoder = Schema.encodeSync(NoteSchema);
 
 bench("decode document (recompile decoder each call)", () => {
-  Schema.decodeUnknownSync(
-    SystemFields.extendWithSystemFields(tableName, NoteSchema),
-  )(convexNote);
+  Schema.decodeSync(SystemFields.extendWithSystemFields(tableName, NoteSchema))(
+    convexNote,
+  );
 }).median([21.71, "us"]);
 
 bench("decode document (cached decoder)", () => {

--- a/packages/server/test/Document.test.ts
+++ b/packages/server/test/Document.test.ts
@@ -22,7 +22,7 @@ const decodeUncached = (
   tableSchema: typeof NoteSchema,
   convexDocument: typeof convexNote,
 ) =>
-  Schema.decodeUnknownSync(
+  Schema.decodeSync(
     SystemFields.extendWithSystemFields(tableName, tableSchema),
   )(convexDocument);
 
@@ -74,7 +74,7 @@ describe("Document.decode", () => {
       Document.decode(convexPost, "posts", SharedSchema),
     );
 
-    const expectedPost = Schema.decodeUnknownSync(
+    const expectedPost = Schema.decodeSync(
       SystemFields.extendWithSystemFields("posts", SharedSchema),
     )(convexPost);
 

--- a/packages/server/test/SchemaToValidator.bench.ts
+++ b/packages/server/test/SchemaToValidator.bench.ts
@@ -1,3 +1,7 @@
+// These benchmarks measure `Schema.Number`'s compilation to a Convex
+// validator, so the finiteness advice does not apply — and the committed
+// baselines below were measured against it.
+// @effect-diagnostics schemaNumber:off
 import { bench } from "confect-bench-harness";
 import type { GenericId } from "@confect/core/GenericId";
 import * as Schema from "effect/Schema";

--- a/packages/server/test/SchemaToValidator.bench.ts
+++ b/packages/server/test/SchemaToValidator.bench.ts
@@ -1,6 +1,3 @@
-// These benchmarks measure `Schema.Number`'s compilation to a Convex
-// validator, so the finiteness advice does not apply — and the committed
-// baselines below were measured against it.
 // @effect-diagnostics schemaNumber:off
 import { bench } from "confect-bench-harness";
 import type { GenericId } from "@confect/core/GenericId";

--- a/packages/server/test/SchemaToValidator.test.ts
+++ b/packages/server/test/SchemaToValidator.test.ts
@@ -1,3 +1,7 @@
+// `Schema.Number` is the subject here: these cases assert how it and the
+// other number APIs compile to Convex validators, so the finiteness advice
+// does not apply — swapping in `Schema.Finite` would test something else.
+// @effect-diagnostics schemaNumber:off
 import { describe, effect, expect, expectTypeOf, test } from "@effect/vitest";
 import { paginationOptsValidator } from "convex/server";
 import { v, type VBoolean, type VString, type VUnion } from "convex/values";

--- a/packages/server/test/SchemaToValidator.test.ts
+++ b/packages/server/test/SchemaToValidator.test.ts
@@ -1,6 +1,3 @@
-// `Schema.Number` is the subject here: these cases assert how it and the
-// other number APIs compile to Convex validators, so the finiteness advice
-// does not apply — swapping in `Schema.Finite` would test something else.
 // @effect-diagnostics schemaNumber:off
 import { describe, effect, expect, expectTypeOf, test } from "@effect/vitest";
 import { paginationOptsValidator } from "convex/server";

--- a/packages/server/test/StorageWriter.test.ts
+++ b/packages/server/test/StorageWriter.test.ts
@@ -15,7 +15,7 @@ describe("StorageWriter", () => {
     Effect.gen(function* () {
       const storageWriter = yield* StorageWriter;
 
-      const url = yield* storageWriter.generateUploadUrl();
+      const url = yield* storageWriter.generateUploadUrl;
 
       expect(url).toBeInstanceOf(URL);
       expect(url.href).toBe(uploadUrl);

--- a/packages/server/test/Table.test.ts
+++ b/packages/server/test/Table.test.ts
@@ -24,7 +24,7 @@ describe("Table", () => {
             name: Schema.String,
           }),
         ),
-        embedding: Schema.optionalKey(Schema.Array(Schema.Number)),
+        embedding: Schema.optionalKey(Schema.Array(Schema.Finite)),
       }),
     )
       .index("by_text", ["text"])
@@ -274,7 +274,7 @@ describe("Table", () => {
         Schema.Struct({
           text: Schema.String,
           tag: Schema.optional(Schema.String),
-          embedding: Schema.optional(Schema.Array(Schema.Number)),
+          embedding: Schema.optional(Schema.Array(Schema.Finite)),
         }),
       )
         .index("by_text", ["text"])

--- a/packages/server/test/local-backend/fixtures/confect/groups/cacheStubbed.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/cacheStubbed.spec.ts
@@ -6,34 +6,34 @@ export default GroupSpec.make()
     FunctionSpec.publicQuery({
       name: "confectNoTime",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithClock",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithRawDateNow",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithSpan",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithLog",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -6,13 +6,13 @@ export default GroupSpec.make()
     FunctionSpec.publicQuery({
       name: "manyOpsQuery",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "manyOpsMutation",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/storage.impl.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/storage.impl.ts
@@ -20,7 +20,7 @@ const generateUploadUrl = FunctionImpl.make(
     Effect.gen(function* () {
       const storageWriter = yield* StorageWriter;
 
-      const url = yield* storageWriter.generateUploadUrl();
+      const url = yield* storageWriter.generateUploadUrl;
 
       return url.toString();
     }),

--- a/packages/server/test/local-backend/storage.test.ts
+++ b/packages/server/test/local-backend/storage.test.ts
@@ -44,9 +44,7 @@ layer(LocalBackend.layer, { timeout: "120 seconds" })(
             }).then((response) => response.text()),
           );
           const { storageId } =
-            yield* Schema.decodeUnknownEffect(UploadResponse)(
-              uploadResponseBody,
-            );
+            yield* Schema.decodeEffect(UploadResponse)(uploadResponseBody);
 
           const blobUrl = yield* Effect.promise(() =>
             client.query(

--- a/packages/server/test/mock-backend/TestConfect.ts
+++ b/packages/server/test/mock-backend/TestConfect.ts
@@ -15,9 +15,6 @@ import confectSchema from "./fixtures/confect/_generated/schema";
 
 export const TestConfect = TestConfect_.TestConfect<typeof confectSchema>();
 
-// `TestConfect_.layer(…)` returns a thunk over `Layer.sync`, which is already
-// lazy — nothing is constructed until the layer is built — so the thunk is
-// called here and this module exports the `Layer` itself.
 export const layer = TestConfect_.layer(
   confectSchema,
   convexSchema,
@@ -26,4 +23,4 @@ export const layer = TestConfect_.layer(
     "./fixtures/convex/**/*.js",
     "!./fixtures/convex/**/*.*.*",
   ]),
-)();
+);

--- a/packages/server/test/mock-backend/TestConfect.ts
+++ b/packages/server/test/mock-backend/TestConfect.ts
@@ -15,6 +15,9 @@ import confectSchema from "./fixtures/confect/_generated/schema";
 
 export const TestConfect = TestConfect_.TestConfect<typeof confectSchema>();
 
+// `TestConfect_.layer(…)` returns a thunk over `Layer.sync`, which is already
+// lazy — nothing is constructed until the layer is built — so the thunk is
+// called here and this module exports the `Layer` itself.
 export const layer = TestConfect_.layer(
   confectSchema,
   convexSchema,
@@ -23,4 +26,4 @@ export const layer = TestConfect_.layer(
     "./fixtures/convex/**/*.js",
     "!./fixtures/convex/**/*.*.*",
   ]),
-);
+)();

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random.spec.ts
@@ -5,6 +5,6 @@ export default GroupSpec.make().addFunction(
   FunctionSpec.publicAction({
     name: "getNumber",
     args: () => Schema.Struct({}),
-    returns: () => Schema.Number,
+    returns: () => Schema.Finite,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
@@ -5,6 +5,6 @@ export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "count",
     args: () => Schema.Struct({}),
-    returns: () => Schema.Number,
+    returns: () => Schema.Finite,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/runners.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/runners.spec.ts
@@ -14,13 +14,13 @@ export default GroupSpec.make()
     FunctionSpec.publicAction({
       name: "getNumberViaRunner",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "countNotesViaRunner",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -6,13 +6,13 @@ export default GroupSpec.make()
     FunctionSpec.publicQuery({
       name: "manyOpsQuery",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "manyOpsMutation",
       args: () => Schema.Struct({}),
-      returns: () => Schema.Number,
+      returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/tables/events.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/tables/events.ts
@@ -4,6 +4,6 @@ import * as Schema from "effect/Schema";
 export default Table.make(() =>
   Schema.Union([
     Schema.Struct({ kind: Schema.Literal("a"), a: Schema.String }),
-    Schema.Struct({ kind: Schema.Literal("b"), b: Schema.Number }),
+    Schema.Struct({ kind: Schema.Literal("b"), b: Schema.Finite }),
   ]),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/tables/notes.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/tables/notes.ts
@@ -13,7 +13,7 @@ export default Table.make(() =>
         name: Schema.String,
       }),
     ),
-    embedding: Schema.optionalKey(Schema.Array(Schema.Number)),
+    embedding: Schema.optionalKey(Schema.Array(Schema.Finite)),
   }),
 )
   .index("by_text", ["text"])

--- a/packages/server/test/mock-backend/http.test.ts
+++ b/packages/server/test/mock-backend/http.test.ts
@@ -34,7 +34,7 @@ describe("HttpRouter", () => {
         }>;
         assertEquals(body.length, 1);
         assertEquals(body[0]?.text, text);
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("serves a second HttpApi merged onto the same router", () =>
@@ -44,7 +44,7 @@ describe("HttpRouter", () => {
       const response = yield* c.fetch("/meta/ping");
       assertEquals(response.status, 200);
       assertEquals(yield* Effect.promise(() => response.json()), "pong");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("serves a plain HttpRouter.add route", () =>
@@ -54,7 +54,7 @@ describe("HttpRouter", () => {
       const response = yield* c.fetch("/health");
       assertEquals(response.status, 200);
       assertEquals(yield* Effect.promise(() => response.text()), "OK");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("global middleware modifies responses", () =>
@@ -63,7 +63,7 @@ describe("HttpRouter", () => {
 
       const response = yield* c.fetch("/health");
       assertEquals(response.headers.get("x-confect-middleware"), "applied");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("serves the Scalar docs page", () =>
@@ -73,7 +73,7 @@ describe("HttpRouter", () => {
       const response = yield* c.fetch("/api/docs");
       assertEquals(response.status, 200);
       expect(response.headers.get("content-type")).toContain("text/html");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect(
@@ -87,7 +87,7 @@ describe("HttpRouter", () => {
         assertEquals(yield* Effect.promise(() => response.text()), "native");
         // The Effect router (and so its global middleware) never ran.
         assertEquals(response.headers.get("x-confect-middleware"), null);
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("unmatched paths get the Effect router's 404", () =>
@@ -96,7 +96,7 @@ describe("HttpRouter", () => {
 
       const response = yield* c.fetch("/no-such-route");
       assertEquals(response.status, 404);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 

--- a/packages/server/test/mock-backend/integration.test.ts
+++ b/packages/server/test/mock-backend/integration.test.ts
@@ -38,7 +38,7 @@ describe("DatabaseReader", () => {
         .pipe(Effect.map((note) => note.text));
 
       assertEquals(retrievedText, text);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("collect", () =>
@@ -62,7 +62,7 @@ describe("DatabaseReader", () => {
       assertEquals(notes.length, 10);
       assertEquals(notes[0]?.text, "10");
       assertEquals(notes[9]?.text, "1");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 
@@ -83,7 +83,7 @@ describe("MutationRunner", () => {
       });
       expectTypeOf(note).toEqualTypeOf<(typeof notes.Doc)["Type"]>();
       assertEquals(note.text, text);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 
@@ -98,7 +98,7 @@ describe("ActionRunner", () => {
 
       expectTypeOf(result).toEqualTypeOf<number>();
       assertEquals(typeof result, "number");
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 
@@ -116,7 +116,7 @@ describe("QueryRunner", () => {
 
       expectTypeOf(count).toEqualTypeOf<number>();
       assertEquals(count, 2);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 
@@ -148,7 +148,7 @@ describe("paginate", () => {
 
       assertEquals(result2.page.length, 2);
       assertEquals(result2.isDone, true);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("accepts the protocol fields Convex's client sends", () =>
@@ -174,7 +174,7 @@ describe("paginate", () => {
 
       assertEquals(result.page.length, 3);
       assertEquals(result.isDone, true);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("paginate with filter", () =>
@@ -205,7 +205,7 @@ describe("paginate", () => {
       assertEquals(texts.has("a"), true);
       assertEquals(texts.has("c"), true);
       assertEquals(texts.has("e"), true);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("paginate with filter returns empty when no matches", () =>
@@ -228,7 +228,7 @@ describe("paginate", () => {
 
       assertEquals(result.page.length, 0);
       assertEquals(result.isDone, true);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("paginate with filter paginates correctly", () =>
@@ -257,7 +257,7 @@ describe("paginate", () => {
       for (const note of page1.page) {
         assertEquals(note.tag, "even");
       }
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("surfaces the declared typed error", () =>
@@ -284,7 +284,7 @@ describe("paginate", () => {
 
       assertEquals(result.page.length, 0);
       assertEquals(result.isDone, true);
-    }).pipe(Effect.provide(TestConfect.layer())),
+    }).pipe(Effect.provide(TestConfect.layer)),
   );
 });
 
@@ -325,7 +325,7 @@ describe("typed errors", () => {
         const error = expectFailure(result);
         expect(error).toBeInstanceOf(NotFound);
         expect((error as NotFound).id).toBe(missingId);
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect(
@@ -345,7 +345,7 @@ describe("typed errors", () => {
           const error = expectFailure(result);
           expect(error).toBeInstanceOf(NotFound);
           expect((error as NotFound).id).toBe(missingId);
-        }).pipe(Effect.provide(TestConfect.layer())),
+        }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect(
@@ -365,7 +365,7 @@ describe("typed errors", () => {
           const error = expectFailure(result);
           expect(error).toBeInstanceOf(Forbidden);
           expect((error as Forbidden).reason).toBe("admin required");
-        }).pipe(Effect.provide(TestConfect.layer())),
+        }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("action handler typed error surfaces as the typed error", () =>
@@ -381,7 +381,7 @@ describe("typed errors", () => {
         const error = expectFailure(result);
         expect(error).toBeInstanceOf(Forbidden);
         expect((error as Forbidden).reason).toBe("no access");
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
   });
 
@@ -397,7 +397,7 @@ describe("typed errors", () => {
         );
 
         expect(result).toStrictEqual({ _tag: "NotFound", id: missingId });
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("QueryRunner Ok path: returns the decoded note text", () =>
@@ -418,7 +418,7 @@ describe("typed errors", () => {
         );
 
         expect(result).toStrictEqual({ _tag: "Ok", text: "hello" });
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("MutationRunner decodes NotFound to tagged result", () =>
@@ -432,7 +432,7 @@ describe("typed errors", () => {
         );
 
         expect(result).toStrictEqual({ _tag: "NotFound", id: missingId });
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("MutationRunner decodes Forbidden to tagged result", () =>
@@ -449,7 +449,7 @@ describe("typed errors", () => {
           _tag: "Forbidden",
           reason: "admin required",
         });
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("MutationRunner Ok path: deletes the existing note", () =>
@@ -473,7 +473,7 @@ describe("typed errors", () => {
 
         const remaining = yield* c.query(refs.public.databaseReader.listNotes);
         assertEquals(remaining.length, 0);
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("ActionRunner decodes NotFound to tagged result", () =>
@@ -486,7 +486,7 @@ describe("typed errors", () => {
         );
 
         expect(result).toStrictEqual({ _tag: "NotFound", id: "missing" });
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
 
     it.effect("ActionRunner decodes Forbidden to tagged result", () =>
@@ -502,7 +502,7 @@ describe("typed errors", () => {
           _tag: "Forbidden",
           reason: "no access",
         });
-      }).pipe(Effect.provide(TestConfect.layer())),
+      }).pipe(Effect.provide(TestConfect.layer)),
     );
   });
 
@@ -532,7 +532,7 @@ describe("typed errors", () => {
           const forbidden = expectFailure(mutationResult);
           expect(forbidden).toBeInstanceOf(Forbidden);
           expect((forbidden as Forbidden).reason).toBe("admin required");
-        }).pipe(Effect.provide(TestConfect.layer())),
+        }).pipe(Effect.provide(TestConfect.layer)),
     );
   });
 
@@ -555,7 +555,7 @@ describe("typed errors", () => {
 
           const notes = yield* c.query(refs.public.databaseReader.listNotes);
           assertEquals(notes.length, 0);
-        }).pipe(Effect.provide(TestConfect.layer())),
+        }).pipe(Effect.provide(TestConfect.layer)),
     );
   });
 
@@ -573,7 +573,7 @@ describe("typed errors", () => {
           );
 
           expect(result).toStrictEqual({ _tag: "NotFound", id: missingId });
-        }).pipe(Effect.provide(TestConfect.layer())),
+        }).pipe(Effect.provide(TestConfect.layer)),
     );
   });
 
@@ -593,7 +593,7 @@ describe("typed errors", () => {
           const error = expectFailure(result);
           expect(error).toBeInstanceOf(NodeNotFound);
           expect((error as NodeNotFound).id).toBe("abc");
-        }).pipe(Effect.provide(TestConfect.layer())),
+        }).pipe(Effect.provide(TestConfect.layer)),
     );
   });
 });

--- a/packages/test/src/TestConfect.ts
+++ b/packages/test/src/TestConfect.ts
@@ -253,18 +253,16 @@ class TestConfectImpl<
     );
 }
 
-export const layer =
-  <DatabaseSchema_ extends DatabaseSchema.AnyWithProps>(
-    databaseSchema: DatabaseSchema_,
-    convexSchemaDefinition: SchemaDefinition<GenericSchema, true>,
-    modules: Record<string, () => Promise<any>>,
-  ) =>
-  (): Layer.Layer<TestConfect<DatabaseSchema_>> =>
-    Layer.sync(
-      TestConfect<DatabaseSchema_>(),
-      () =>
-        new TestConfectImpl(
-          databaseSchema,
-          convexTest(convexSchemaDefinition, modules) as any,
-        ),
-    );
+export const layer = <DatabaseSchema_ extends DatabaseSchema.AnyWithProps>(
+  databaseSchema: DatabaseSchema_,
+  convexSchemaDefinition: SchemaDefinition<GenericSchema, true>,
+  modules: Record<string, () => Promise<any>>,
+): Layer.Layer<TestConfect<DatabaseSchema_>> =>
+  Layer.sync(
+    TestConfect<DatabaseSchema_>(),
+    () =>
+      new TestConfectImpl(
+        databaseSchema,
+        convexTest(convexSchemaDefinition, modules) as any,
+      ),
+  );

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -3,6 +3,7 @@
     "plugins": [
       {
         "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "diagnosticSeverity": {
           "deterministicKeys": "error"
         }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
     "plugins": [
       {
         "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "diagnosticSeverity": {
           "deterministicKeys": "error"
         }

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -31,7 +31,7 @@ const discoverPackageAliases = Effect.gen(function* () {
         return [];
       }
 
-      const { name } = yield* Schema.decodeUnknownEffect(PackageManifest)(
+      const { name } = yield* Schema.decodeEffect(PackageManifest)(
         yield* fs.readFileString(path.join(packagesDir, entry, "package.json")),
       );
 


### PR DESCRIPTION
`effect-tsgo` prints suggestion-level diagnostics during `pnpm build` and `pnpm typecheck` but leaves the exit code alone, so **85 of them had accumulated unread** across the workspace. This sets `ignoreEffectSuggestionsInTscExitCode: false` and clears every one.

Stacked on #562 — **merge that first.** This targets its branch so the diff here is only the diagnostics work; once #562 lands and its branch is deleted, GitHub retargets this to `v10`.

> [!NOTE]
> **No checks will appear until this is retargeted.** `packages.yml` triggers on PRs based on `main` or `v10`. See Verification below for what was run locally.

## The config

Worth knowing: the repo had **zero** warning-level diagnostics. `effect-tsgo` already fails on warnings (`ignoreEffectWarningsInTscExitCode` defaults to `false`) and nothing tripped it. Everything advisory was *suggestion*-level, so `ignoreEffectSuggestionsInTscExitCode` is the knob.

The flag is repeated across **seven** plugin blocks. TypeScript replaces `plugins` rather than merging it, so the six configs declaring their own array inherit nothing from `tsconfig.base.json` — which is why `deterministicKeys` was already duplicated across them.

## Two breaking API changes

Both come from `effect(lazyEffect)`: a zero-argument function wrapping a value that was already lazy.

**`StorageWriter.generateUploadUrl` is now an `Effect`.** Yield it rather than calling it. Docs and both call sites updated.

**`TestConfect.layer` now returns a `Layer`.** Drop the trailing `()`. `Layer.sync` already deferred everything the thunk was deferring.

The second one was worth checking rather than assuming, because the testing guide promises that *"every time the `TestConfect` layer is constructed, a new test database is created"* — and per-test isolation was the plausible reason for the thunk. It isn't: a `Layer` is built once per `Effect.provide`, so one shared value still constructs a fresh `convexTest` per test.

I confirmed that by making the sharing real — swapping `Layer.sync` for `Layer.succeed`, which hands every build the same instance:

| | Result |
| --- | --- |
| `Layer.sync` (this PR) | 216 passed |
| `Layer.succeed` (shared instance) | **8 failed** — `collect`, `countNotesViaRunner`, all four `paginate` cases |

Those are exactly the tests that assert on database contents, so the suite genuinely enforces the isolation the guide describes, and this change preserves it.

## What else was fixed (74 sites)

**`preferTypedSchemaDecoder` (15)** — decodes whose input was already the schema's Encoded type, so `decodeUnknown*` was discarding a type the compiler had. Now `decodeEffect` / `decodeSync`.

**`schemaNumber` (57)** — `Schema.Number` accepts `NaN` and `±Infinity`. Where the value comes from Convex and cannot be non-finite, it becomes `Schema.Finite`: `_creationTime`, `scheduledTime`, `completedTime`, a stored file's `size`, and `PaginationOptions`. I confirmed against `compileSchema` that this **does not change the compiled validator** — both produce `v.float64()` — so deployments accept exactly what they did before; only Confect's decode narrows.

`SchemaToValidator.test.ts` and `SchemaToValidator.bench.ts` are the deliberate exception. `Schema.Number` is their *subject* — they assert how it compiles to a Convex validator — so rewriting them would test something else and move the benchmark baselines re-based in #563. They carry a file-level `@effect-diagnostics schemaNumber:off`.

## Changesets

Three, kept separate because they're distinct topics for a changelog reader:

- `generate-upload-url-effect` — `major` on `@confect/server`
- `test-confect-layer-value` — `major` on `@confect/test`, noting that per-test isolation is unaffected
- `finite-system-field-schemas` — `patch`, noting validators are unchanged and your own `Schema.Number` fields still accept non-finite values, since Convex stores them

## Verification

`pnpm check`, `pnpm typecheck`, `pnpm build`, `pnpm test` (1153), `pnpm test:server:mock-backend` (216), `pnpm test:server:local-backend` (9), and codegen for both fixture sets — all clean, no drift. Core benchmarks unchanged at 0.00%.

One bench fails locally: `Document.bench.ts`'s "recompile decoder each call" exceeds its baseline. It does so **equally on the unmodified file** — three runs each way, 30.9–34.7us with this change against 32.9–36.7us without, overlapping distributions against a 21.71us baseline set on other hardware. Container timing noise rather than the decoder swap, consistent with the 23.5/38.2us swing this benchmark showed before any of these changes. CI passed it on #562.