### PR TITLE
Upgrade convex to 1.44.0

### DIFF
--- a/.changeset/convex-1-44.md
+++ b/.changeset/convex-1-44.md
@@ -1,0 +1,10 @@
+---
+"@confect/cli": patch
+"@confect/core": patch
+"@confect/js": patch
+"@confect/react": patch
+"@confect/server": patch
+"@confect/test": patch
+---
+
+Build and test against `convex` 1.44.0. The published `convex` peer ranges are unchanged, so no consumer action is required.

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -8,7 +8,7 @@
     "@confect/server": "workspace:*",
     "@convex-dev/workpool": "0.4.9",
     "@effect/platform": "0.97.1",
-    "convex": "1.43.0",
+    "convex": "1.44.0",
     "convex-helpers": "0.1.123",
     "effect": "3.22.1",
     "react": "19.2.8",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "@effect/vitest": "0.30.0",
     "@types/node": "26.2.0",
     "@vitest/coverage-v8": "4.1.10",
-    "convex": "1.43.0",
+    "convex": "1.44.0",
     "effect": "3.22.1",
     "tsdown": "0.22.14",
     "typescript": "7.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
     "@types/node": "26.2.0",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
-    "convex": "1.43.0",
+    "convex": "1.44.0",
     "effect": "3.22.1",
     "happy-dom": "20.11.2",
     "react": "19.2.8",

--- a/packages/server/test/local-backend/fixtures/convex/_generated/server.d.ts
+++ b/packages/server/test/local-backend/fixtures/convex/_generated/server.d.ts
@@ -22,6 +22,17 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+type Env = {
+  readonly CONVEX_CLOUD_URL: string;
+  readonly CONVEX_SITE_URL: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +105,14 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/packages/server/test/local-backend/fixtures/convex/_generated/server.js
+++ b/packages/server/test/local-backend/fixtures/convex/_generated/server.js
@@ -91,3 +91,11 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export const env = process.env;

--- a/packages/server/test/mock-backend/fixtures/convex/_generated/server.d.ts
+++ b/packages/server/test/mock-backend/fixtures/convex/_generated/server.d.ts
@@ -22,6 +22,17 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+type Env = {
+  readonly CONVEX_CLOUD_URL: string;
+  readonly CONVEX_SITE_URL: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +105,14 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/packages/server/test/mock-backend/fixtures/convex/_generated/server.js
+++ b/packages/server/test/mock-backend/fixtures/convex/_generated/server.js
@@ -91,3 +91,11 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export const env = process.env;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  convex: 1.43.0
+  convex: 1.44.0
   effect: 3.22.1
   '@effect/platform-node-shared': 0.61.1
   '@effect/typeclass': 0.41.0
@@ -113,16 +113,16 @@ importers:
         version: link:../../packages/server
       '@convex-dev/workpool':
         specifier: 0.4.9
-        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.43.0(react@19.2.8))(react@19.2.8)
+        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.44.0(react@19.2.8))(react@19.2.8)
       '@effect/platform':
         specifier: 0.97.1
         version: 0.97.1(effect@3.22.1)
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
       convex-helpers:
         specifier: 0.1.123
-        version: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
+        version: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -196,7 +196,7 @@ importers:
     devDependencies:
       '@convex-dev/workpool':
         specifier: 0.4.9
-        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.43.0(react@19.2.8))(react@19.2.8)
+        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.44.0(react@19.2.8))(react@19.2.8)
       '@effect/tsgo':
         specifier: 0.36.5
         version: 0.36.5
@@ -210,8 +210,8 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -237,8 +237,8 @@ importers:
   packages/core:
     dependencies:
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
     devDependencies:
       '@effect/vitest':
         specifier: 0.30.0
@@ -274,8 +274,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
     devDependencies:
       '@effect/vitest':
         specifier: 0.30.0
@@ -321,8 +321,8 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -360,8 +360,8 @@ importers:
         specifier: ^0.108.1
         version: 0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
     devDependencies:
       '@effect/cluster':
         specifier: 0.60.2
@@ -398,7 +398,7 @@ importers:
         version: link:../../tools/bench-harness
       convex-test:
         specifier: 0.0.55
-        version: 0.0.55(convex@1.43.0(react@19.2.8))
+        version: 0.0.55(convex@1.44.0(react@19.2.8))
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -436,8 +436,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -455,8 +455,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -480,11 +480,11 @@ importers:
         specifier: workspace:^
         version: link:../server
       convex:
-        specifier: 1.43.0
-        version: 1.43.0(react@19.2.8)
+        specifier: 1.44.0
+        version: 1.44.0(react@19.2.8)
       convex-test:
         specifier: '>=0.0.50 <0.1.0'
-        version: 0.0.50(convex@1.43.0(react@19.2.8))
+        version: 0.0.50(convex@1.44.0(react@19.2.8))
     devDependencies:
       '@types/node':
         specifier: 26.2.0
@@ -676,13 +676,13 @@ packages:
   '@convex-dev/batch-worker@0.2.0':
     resolution: {integrity: sha512-dn0L/5jqufXHzgzAhWqjGBmDGXbwRA0S6YVV5Z66y4pMXZ+YL3M4aHCk9iBInPp5zOtEPgVbfo/BYMxhLxVP+w==}
     peerDependencies:
-      convex: 1.43.0
+      convex: 1.44.0
       react: 19.2.8
 
   '@convex-dev/workpool@0.4.9':
     resolution: {integrity: sha512-2EauCO+fXqhBE0qN3aC2G/CA8Udc1nDiSha2uwdJi5SaElz6HmuM3Rv60AeQ3snMZ8PdHugKKlVeEFvAhSaokQ==}
     peerDependencies:
-      convex: 1.43.0
+      convex: 1.44.0
       convex-helpers: ^0.1.94
 
   '@effect/cli@0.77.0':
@@ -4109,7 +4109,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@standard-schema/spec': ^1.0.0
-      convex: 1.43.0
+      convex: 1.44.0
       hono: ^4.0.5
       react: 19.2.8
       typescript: ^5.5 || ^6.0.0 || ^7.0.0
@@ -4129,15 +4129,15 @@ packages:
   convex-test@0.0.50:
     resolution: {integrity: sha512-rMNfrgcKJGToYDqNns2n1AO9KUP1NyC/AF9ldYEuWwTfRbgC9RQiHjlZsZQ/sOjLIVPUyKKIjoI/fNJUzy1urw==}
     peerDependencies:
-      convex: 1.43.0
+      convex: 1.44.0
 
   convex-test@0.0.55:
     resolution: {integrity: sha512-ablJ6vR3WUpyTaYrrRQf8yxInGrhHyqBEQsCFzloda3G0MDEu2RMKNGUkvlBXYWPiiEP0UIKPS7gZuLbqGnvQw==}
     peerDependencies:
-      convex: 1.43.0
+      convex: 1.44.0
 
-  convex@1.43.0:
-    resolution: {integrity: sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==}
+  convex@1.44.0:
+    resolution: {integrity: sha512-84bBa1ufSX4qohXdycXuQl2c2kAmfVpTCpypcmIgxpS5rUBgv5qjhArYugTkJVbljMs5SH2mW30bjJo+SQwe1w==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -7696,16 +7696,16 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@convex-dev/batch-worker@0.2.0(convex@1.43.0(react@19.2.8))(react@19.2.8)':
+  '@convex-dev/batch-worker@0.2.0(convex@1.44.0(react@19.2.8))(react@19.2.8)':
     dependencies:
-      convex: 1.43.0(react@19.2.8)
+      convex: 1.44.0(react@19.2.8)
       react: 19.2.8
 
-  '@convex-dev/workpool@0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.43.0(react@19.2.8))(react@19.2.8)':
+  '@convex-dev/workpool@0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.44.0(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@convex-dev/batch-worker': 0.2.0(convex@1.43.0(react@19.2.8))(react@19.2.8)
-      convex: 1.43.0(react@19.2.8)
-      convex-helpers: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
+      '@convex-dev/batch-worker': 0.2.0(convex@1.44.0(react@19.2.8))(react@19.2.8)
+      convex: 1.44.0(react@19.2.8)
+      convex-helpers: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
     transitivePeerDependencies:
       - react
 
@@ -10588,24 +10588,24 @@ snapshots:
 
   convert-to-spaces@2.0.1: {}
 
-  convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.43.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6):
+  convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6):
     dependencies:
-      convex: 1.43.0(react@19.2.8)
+      convex: 1.44.0(react@19.2.8)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
       react: 19.2.8
       typescript: 7.0.2
       zod: 4.3.6
 
-  convex-test@0.0.50(convex@1.43.0(react@19.2.8)):
+  convex-test@0.0.50(convex@1.44.0(react@19.2.8)):
     dependencies:
-      convex: 1.43.0(react@19.2.8)
+      convex: 1.44.0(react@19.2.8)
 
-  convex-test@0.0.55(convex@1.43.0(react@19.2.8)):
+  convex-test@0.0.55(convex@1.44.0(react@19.2.8)):
     dependencies:
-      convex: 1.43.0(react@19.2.8)
+      convex: 1.44.0(react@19.2.8)
 
-  convex@1.43.0(react@19.2.8):
+  convex@1.44.0(react@19.2.8):
     dependencies:
       esbuild: 0.27.0
       prettier: 3.9.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ allowBuilds:
   sharp: true
 
 overrides:
-  convex: 1.43.0
+  convex: 1.44.0
   effect: 3.22.1
   "@effect/platform-node-shared": 0.61.1
   "@effect/typeclass": 0.41.0


### PR DESCRIPTION
Scheduled upgrade of the dependencies visible on the published surface of the `@confect/*` packages.

## Bumped

| Dependency | From | To | Notes |
| --- | --- | --- | --- |
| `convex` | 1.43.0 | 1.44.0 | [changelog](https://github.com/get-convex/convex-js/blob/main/CHANGELOG.md) |

Moved together across the workspace: the `overrides` pin in `pnpm-workspace.yaml` plus the dev pins in `@confect/cli`, `@confect/react`, and `apps/example`. `pnpm why -r convex` confirms a single resolved `convex@1.44.0` — worth checking explicitly because nothing lints the `overrides` block, so a stale entry would silently hold the old version.

Convex 1.44.0 is additive: `schema.doc()` / `schema.id()` validators, `CONVEX_SITE_URL` and `CONVEX_CLOUD_URL` as first-class server env vars, a `ConvexProviderWithAuth` referential-stability fix, and a `npx convex login status` fix.

### Regenerated fixtures

The env var work changes Convex's own codegen output, so `pnpm codegen:server:mock-backend` and `pnpm codegen:server:local-backend` were re-run. Both fixture `convex/_generated/server.{js,d.ts}` files pick up a new `env` export. No untracked files were produced.

### Peer ranges

Left alone. Nothing in this diff requires 1.44.0 at runtime, so the published `convex` peers stay at `^1.32.0` (`core`, `js`, `server`, `test`) and `^1.36.0` (`react`). The changeset is a `patch` and calls out that consumers need to do nothing.

## Not bumped

Every other in-scope dependency is already at its latest published version — `@effect/cli` 0.77.0, `@effect/platform` 0.97.1, `@effect/platform-node` 0.108.1, `@effect/platform-node-shared` 0.61.1, `@effect/printer` / `@effect/printer-ansi` 0.51.0, `@effect/typeclass` 0.41.0, `bundle-require` 5.1.0, `code-block-writer` 13.0.3, `exsolve` 1.1.1, `convex-test` 0.0.55, `effect` 3.22.1, `react` / `react-dom` 19.2.8. `esbuild` 0.28.2 already satisfies the CLI's declared range.

No stable major of a peer ecosystem is available. Effect publishes `4.0.0-rc.110` under the `rc` tag, but that line is prerelease and this repo tracks it separately on the v10 prerelease branch rather than through this upgrade path — nothing to migrate here.

## Verification

All run locally, all green:

- `pnpm build`
- `pnpm check`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`
- `pnpm test` — 1112 passed, no type errors
- `pnpm test:server:mock-backend` — 204 passed
- `pnpm test:server:local-backend` — 6 passed

The local-backend suite failed once on its first run with `convex dev exited before printing "Convex functions ready!"`, immediately after the codegen scripts had been driving a local backend on the same port; it passed on both subsequent runs. Reads as port contention with the just-finished codegen run, not a regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe5jQ3RvJfLZcvfMYkph3y)_