### PR TITLE
Stop publishing the tsbuildinfo, and guard against the next one

### DIFF
--- a/.changeset/no-tsbuildinfo-in-tarball.md
+++ b/.changeset/no-tsbuildinfo-in-tarball.md
@@ -1,0 +1,9 @@
+---
+"@confect/core": patch
+"@confect/js": patch
+"@confect/react": patch
+"@confect/server": patch
+"@confect/test": patch
+---
+
+Stop publishing `dist/tsconfig.src.tsbuildinfo`. TypeScript's incremental build cache was being written into `dist` and swept into the tarball by `files: ["dist"]`; it now lives outside the published output. No runtime or type declarations changed.

--- a/.changeset/no-tsbuildinfo-in-tarball.md
+++ b/.changeset/no-tsbuildinfo-in-tarball.md
@@ -1,9 +1,0 @@
----
-"@confect/core": patch
-"@confect/js": patch
-"@confect/react": patch
-"@confect/server": patch
-"@confect/test": patch
----
-
-Stop publishing `dist/tsconfig.src.tsbuildinfo`. TypeScript's incremental build cache was being written into `dist` and swept into the tarball by `files: ["dist"]`; it now lives outside the published output. No runtime or type declarations changed.

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -131,6 +131,15 @@ jobs:
       - uses: ./.github/actions/confect-setup
       - run: pnpm --filter ${{ matrix.package }} bench
 
+  pack-contents:
+    name: Pack contents
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/confect-setup
+      - run: pnpm build
+      - run: pnpm check:pack-contents
+
   build:
     name: Build (${{ matrix.package }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "scripts": {
     "build": "vp run --cache --filter \"@confect/*\" build",
     "check": "vp check",
+    "check:pack-contents": "node scripts/checkPackContents.mjs",
     "circular": "dpdm --no-warning --no-tree --exit-code circular:1 -T \"packages/*/src/**/*.ts\"",
     "clean": "pnpm -r run clean && node scripts/clean.mjs node_modules",
     "codegen:server:local-backend": "pnpm --filter @confect/server codegen:local-backend",

--- a/packages/core/tsconfig.src.json
+++ b/packages/core/tsconfig.src.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "tsBuildInfoFile": "dist/tsconfig.src.tsbuildinfo",
+    "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.src.tsbuildinfo",
     "isolatedDeclarations": false,
     "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,

--- a/packages/js/tsconfig.src.json
+++ b/packages/js/tsconfig.src.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "tsBuildInfoFile": "dist/tsconfig.src.tsbuildinfo",
+    "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.src.tsbuildinfo",
     "isolatedDeclarations": false,
     "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,

--- a/packages/react/tsconfig.src.json
+++ b/packages/react/tsconfig.src.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "tsBuildInfoFile": "dist/tsconfig.src.tsbuildinfo",
+    "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.src.tsbuildinfo",
     "isolatedDeclarations": false,
     "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,

--- a/packages/server/tsconfig.src.json
+++ b/packages/server/tsconfig.src.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "tsBuildInfoFile": "dist/tsconfig.src.tsbuildinfo",
+    "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.src.tsbuildinfo",
     "isolatedDeclarations": false,
     "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,

--- a/packages/test/tsconfig.src.json
+++ b/packages/test/tsconfig.src.json
@@ -7,7 +7,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "tsBuildInfoFile": "dist/tsconfig.src.tsbuildinfo",
+    "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.src.tsbuildinfo",
     "isolatedDeclarations": false,
     "skipLibCheck": true,
     "exactOptionalPropertyTypes": true,

--- a/scripts/checkPackContents.mjs
+++ b/scripts/checkPackContents.mjs
@@ -1,0 +1,89 @@
+// Guards what actually ends up in the published tarballs.
+//
+// Every published package uses `files: ["dist", ...]`, which is an allowlist of
+// directories, not of files — so anything a build step happens to leave inside
+// `dist` ships to npm. That is how `dist/tsconfig.src.tsbuildinfo` went out in
+// every release until it was noticed by hand. This asks npm for the exact file
+// list it would pack and fails on anything that has no business being there.
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGES_DIR = "packages";
+
+/** Files that must never reach a consumer, with the reason shown on failure. */
+const DENIED = [
+  [/\.tsbuildinfo$/, "TypeScript incremental build cache"],
+  [/(^|\/)node_modules\//, "nested node_modules"],
+  [/(^|\/)coverage\//, "coverage report"],
+  [/\.(test|spec)\.[cm]?[jt]sx?$/, "test file"],
+  [/(^|\/)__tests__\//, "test directory"],
+  [/(^|\/)\.env(\.|$)/, "environment file"],
+  [/(^|\/)\.DS_Store$/, "macOS metadata"],
+  [/\.log$/, "log file"],
+  [/(^|\/)tsconfig(\..+)?\.json$/, "TypeScript config"],
+];
+
+const publishedPackages = () =>
+  readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(PACKAGES_DIR, entry.name))
+    .filter((dir) => {
+      try {
+        return (
+          JSON.parse(readFileSync(join(dir, "package.json"), "utf8"))
+            .private !== true
+        );
+      } catch {
+        return false;
+      }
+    });
+
+const packedFiles = (dir) => {
+  const stdout = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: dir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return JSON.parse(stdout)[0].files.map((file) => file.path);
+};
+
+let failed = false;
+
+for (const dir of publishedPackages()) {
+  const files = packedFiles(dir);
+  const problems = [];
+
+  // A package that packs no build output means the check ran before `pnpm
+  // build` — passing here would be vacuous, so treat it as a failure.
+  if (!files.some((path) => path.startsWith("dist/"))) {
+    problems.push([
+      "dist/",
+      "no build output packed — did this run before `pnpm build`?",
+    ]);
+  }
+
+  for (const path of files) {
+    const denial = DENIED.find(([pattern]) => pattern.test(path));
+    if (denial) problems.push([path, denial[1]]);
+  }
+
+  if (problems.length === 0) {
+    console.log(`ok  ${dir} (${files.length} files)`);
+    continue;
+  }
+
+  failed = true;
+  console.error(`FAIL ${dir}`);
+  for (const [path, reason] of problems)
+    console.error(`       ${path} — ${reason}`);
+}
+
+if (failed) {
+  console.error(
+    "\nThese files would be published to npm. Keep build artifacts out of the packed directories,",
+    "\nor narrow the `files` field in the offending package.json.",
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Noticed while investigating #581: every published tarball was shipping TypeScript's incremental build cache. Two commits — the fix, then a guard so the next stray file fails CI instead of reaching npm.

## 1. The fix

Published packages set `files: ["dist"]`, so anything the build leaves in `dist` goes to npm. The five packages with a composite `tsconfig.src.json` pointed `tsBuildInfoFile` at `dist/tsconfig.src.tsbuildinfo`, so each tarball carried a build cache full of local source paths that is meaningless to anyone installing the package.

`npm pack --dry-run` on `@confect/core` before this change: **94 files**, one of them the cache.

The root `tsconfig.json` already keeps its buildinfo at `node_modules/.cache/tsc/tsconfig.tsbuildinfo`. The five package configs now follow that convention:

```diff
-    "tsBuildInfoFile": "dist/tsconfig.src.tsbuildinfo",
+    "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.src.tsbuildinfo",
```

Nothing else needed changing: `pnpm clean` already removes `node_modules`, and the existing `*.tsbuildinfo` ignore rule keeps the file untracked wherever it lands. `@confect/cli` is unaffected — it ships only a binary, has no `tsconfig.src.json`, and never emitted a buildinfo.

It has to stay per-package, incidentally: setting `tsBuildInfoFile` in the shared `tsconfig.base.json` resolves relative to *that* file's directory, so all five packages would write to one buildinfo at the repo root and clobber each other's incremental state.

## 2. The guard

The fix removes one file; it does nothing about the next one. `files: ["dist"]` is an allowlist of directories, and nothing validated what actually lands in the tarball — which is why this shipped in every release until someone looked by hand.

`scripts/checkPackContents.mjs` asks npm for the exact list it would pack, per published package, and fails on a deny-list covering build caches, nested `node_modules`, coverage output, test files, env files, editor droppings, and logs. Each rule carries the reason printed on failure. It runs in CI as a new `Pack contents` job, and locally via `pnpm check:pack-contents`.

A passing run prints per-package file counts, which is the cheap version of catching the opposite failure — output silently going missing:

```
ok  packages/cli (54 files)      ok  packages/react (24 files)
ok  packages/core (93 files)     ok  packages/server (192 files)
ok  packages/js (18 files)       ok  packages/test (13 files)
```

A package that packs no `dist/` fails rather than passing, so the check can't report success over an empty tarball if it ever runs before `pnpm build`.

### Verified against real failures

Replanting the tsbuildinfo reproduces the original bug as a red build:

```
FAIL packages/core
       dist/tsconfig.src.tsbuildinfo — TypeScript incremental build cache
```

As do other junk classes:

```
FAIL packages/react
       dist/__tests__/helper.js — test directory
       dist/debug.log — log file
FAIL packages/server
       dist/.env — environment file
```

The deny patterns produce no false positives against the current tarballs, including the `src/` trees these packages ship alongside `dist/`.

### Why not an existing tool

[`npm-pkg-lint`](https://github.com/ext/npm-pkg-lint) is the closest off-the-shelf option, and its `no-disallowed-files` rule does **not** list `.tsbuildinfo` — on a fixture containing one it stays silent, while flagging `dist/index.test.js` and `dist/tsconfig.json` in the same tarball. It also crashes on this repo's `workspace:` ranges unless fed a `pnpm pack` tarball. [`publint`](https://www.npmjs.com/package/publint) reports "All good!" on that same fixture; it lints `exports` correctness, not contents. Both are worth adopting for what they *do* cover, but neither catches this.

## Verification

Rebuilt and diffed `dist/` against a build of the same tree before the fix — the five cache files are the **only** difference, every `.js`, `.mjs`, `.map`, and `.d.ts` byte-for-byte identical. `tsc -b` stays incremental (3.5s cold, 1.1s warm).

Full local checks green — `pnpm build`, `check`, `lint`, `format:check`, `typecheck`, `pnpm test` (1112 passed, no type errors), `test:server:mock-backend` (204), `test:server:local-backend` (6), plus the new `check:pack-contents`.

## No changeset

The tarball loses a file, but no runtime code, type declaration, or `package.json` field moves — nothing for a consumer to act on, and no reason to cut a release. The guard is CI-only. Both ride along in whatever release ships next.