### PR TITLE
Upgrade changesets/action to v2 and update prerelease docs

### DIFF
--- a/.claude/skills/managing-prereleases/SKILL.md
+++ b/.claude/skills/managing-prereleases/SKILL.md
@@ -71,7 +71,7 @@ These are from the Changesets docs but are easy to miss:
    +      - v9
    ```
 
-   The other two pieces of branch-awareness are permanent fixtures of `release.yml` (kept in place between prerelease cycles) — verify they are still present rather than adding them: `changesets/action` receives `branch: ${{ github.ref_name }}`, and the docs deployment step is gated with `if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'`. The prerelease cycle must not touch the docs `release` branch — that tracks the stable line.
+   The other pieces of branch-awareness are permanent fixtures of `release.yml` (kept in place between prerelease cycles) — verify they are still present rather than adding them: `changesets/action@v2` opens its Version Packages PR against the pushed branch by default (its `pr-base-branch` input defaults to `github.ref_name`, so no explicit input is needed), and the docs deployment step is gated with `if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'`. The prerelease cycle must not touch the docs `release` branch — that tracks the stable line.
 
 5. **Mirror the branch into the other CI workflows.** Add `- v9` to the `push.branches` and `pull_request.branches` lists in any CI workflows that gate `main` (typically `docs.yml`, `example.yml`, `packages.yml`) so PRs against `v9` run the same checks as PRs against `main`.
 
@@ -91,7 +91,7 @@ While `.changeset/pre.json` exists on `v9`:
 
 - Author changesets normally with `pnpm changeset` on feature branches targeting `v9`. Each merged PR is appended to the open `Version Packages (next)` PR.
 - Merging the `Version Packages (next)` PR bumps the next `X.0.0-next.N` and publishes under the `next` dist-tag.
-- The merged changeset files are kept around — Changesets needs them to compose the final stable changelog on exit. Do not delete them manually.
+- The merged changeset files are kept around (Changesets v3 moves consumed ones into `.changeset/pre/`) — Changesets needs them to compose the final stable changelog on exit. Do not delete them manually.
 
 There is no required cadence; ship as many `next.N`s as the major needs.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,10 @@ jobs:
 
       - name: Create release pull request or publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          version: pnpm version-packages
-          publish: pnpm release
-          branch: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version-script: pnpm version-packages
+          publish-script: pnpm release
 
       - name: Update docs deployment branch
         if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'


### PR DESCRIPTION
Updates the release workflow to use `changesets/action@v2` and adjusts documentation to reflect the new action's behavior.

## Changes

- **Upgrade changesets/action**: Updated from v1 to v2 in `.github/workflows/release.yml`
  - Renamed `version` input to `version-script`
  - Renamed `publish` input to `publish-script`
  - Removed explicit `branch: ${{ github.ref_name }}` input (v2 defaults to `github.ref_name` via `pr-base-branch`)
  - Removed explicit `GITHUB_TOKEN` environment variable (v2 handles this automatically)

- **Update prerelease management documentation**: Modified `.claude/skills/managing-prereleases/SKILL.md`
  - Updated explanation of branch-awareness in `release.yml` to reflect that v2 handles PR base branch selection by default
  - Added clarification that Changesets v3 moves consumed changeset files into `.changeset/pre/` during prerelease cycles

These changes simplify the release workflow configuration while maintaining the same functionality for managing stable and prerelease branches.

https://claude.ai/code/session_01U636EpgJtgS29g95Z97NNY