### PR TITLE
Upgrade changesets/action to v2 for Changesets v3 (main)

### DIFF
--- a/.claude/skills/managing-prereleases/SKILL.md
+++ b/.claude/skills/managing-prereleases/SKILL.md
@@ -61,7 +61,7 @@ These are from the Changesets docs but are easy to miss:
    pnpm changeset pre enter next
    ```
 
-4. **Extend `release.yml` to publish from `vN`.** Add the release branch to the existing workflow's `push.branches`, pass the triggering branch to `changesets/action`, and gate any stable-only post-publish steps (such as the docs `release` branch push) to `main` only:
+4. **Extend `release.yml` to publish from `vN`.** Add the release branch to the existing workflow's `push.branches`:
 
    ```diff
     on:
@@ -71,21 +71,7 @@ These are from the Changesets docs but are easy to miss:
    +      - v9
    ```
 
-   ```diff
-        - uses: changesets/action@v1
-          with:
-            publish: pnpm release
-   -        branch: main
-   +        branch: ${{ github.ref_name }}
-   ```
-
-   ```diff
-        - name: Update docs deployment branch
-   -      if: steps.changesets.outputs.published == 'true'
-   +      if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'
-   ```
-
-   The prerelease cycle must not touch the docs `release` branch — that tracks the stable line.
+   The other pieces of branch-awareness are permanent fixtures of `release.yml` (kept in place between prerelease cycles) — verify they are still present rather than adding them: `changesets/action@v2` opens its Version Packages PR against the pushed branch by default (its `pr-base-branch` input defaults to `github.ref_name`, so no explicit input is needed), and the docs deployment step is gated with `if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'`. The prerelease cycle must not touch the docs `release` branch — that tracks the stable line.
 
 5. **Mirror the branch into the other CI workflows.** Add `- v9` to the `push.branches` and `pull_request.branches` lists in any CI workflows that gate `main` (typically `docs.yml`, `example.yml`, `packages.yml`) so PRs against `v9` run the same checks as PRs against `main`.
 
@@ -105,7 +91,7 @@ While `.changeset/pre.json` exists on `v9`:
 
 - Author changesets normally with `pnpm changeset` on feature branches targeting `v9`. Each merged PR is appended to the open `Version Packages (next)` PR.
 - Merging the `Version Packages (next)` PR bumps the next `X.0.0-next.N` and publishes under the `next` dist-tag.
-- The merged changeset files are kept around — Changesets needs them to compose the final stable changelog on exit. Do not delete them manually.
+- The merged changeset files are kept around (Changesets v3 moves consumed ones into `.changeset/pre/`) — Changesets needs them to compose the final stable changelog on exit. Do not delete them manually.
 
 There is no required cadence; ship as many `next.N`s as the major needs.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,10 @@ jobs:
 
       - name: Create release pull request or publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v2
         with:
-          version: pnpm version-packages
-          publish: pnpm release
-          branch: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version-script: pnpm version-packages
+          publish-script: pnpm release
 
       - name: Update docs deployment branch
         if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'


### PR DESCRIPTION
Cherry-pick of #587 onto `main`.

`main` runs the same `@changesets/cli` 3.0.0 as `v10` (upgraded in #576), so its `release.yml` is exposed to the same incompatibility that broke every Release run on `v10`: `changesets/action@v1` bundles a pre-v3 `@changesets/read` that can't handle Changesets v3's on-disk format. `main` isn't in pre mode today, so it hasn't hit the `.changeset/pre/` crash — but the next prerelease cycle (or any other v3 format divergence) would. This brings `main`'s workflow onto `changesets/action@v2`, which understands the v3 layout.

Changes, mirroring #587:

- `changesets/action@v1` → `@v2` in `release.yml`, with the renamed inputs: `version` → `version-script`, `publish` → `publish-script`. The explicit `branch: ${{ github.ref_name }}` input and `GITHUB_TOKEN` env var are dropped — v2's `pr-base-branch` defaults to `github.ref_name`, and its `github-token` input defaults to `github.token`.
- The `managing-prereleases` skill doc is updated to match: the `branch`-input instructions are replaced with the v2 behavior, and a note is added that Changesets v3 moves consumed changesets into `.changeset/pre/` during a prerelease cycle. The conflict resolution also removes `main`'s now-obsolete step-4 diff blocks (they described editing the v1 `branch` input during cycle entry).

No changeset: workflow and internal docs only, no published `@confect/*` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U636EpgJtgS29g95Z97NNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01U636EpgJtgS29g95Z97NNY)_