### PR TITLE
Stop stripping internal members from declarations

### DIFF
--- a/.changeset/unstripped-declarations.md
+++ b/.changeset/unstripped-declarations.md
@@ -1,0 +1,6 @@
+---
+"@confect/core": minor
+"@confect/server": minor
+---
+
+Stop stripping `@internal` members from the published type declarations. `@confect/core`'s ref types (`Ref.ConfectRef` / `Ref.ConvexRef`) now declare all of their members, so the `Ref.Ref` union can be narrowed by its `_tag`, and `@confect/server`'s `CronJobs.cronToConvexCronString` and `CronJobs.durationToConvexIntervalSchedule` — previously exported at runtime but absent from the declarations — are now typed.

--- a/.changeset/unstripped-declarations.md
+++ b/.changeset/unstripped-declarations.md
@@ -1,6 +1,0 @@
----
-"@confect/core": minor
-"@confect/server": minor
----
-
-Stop stripping `@internal` members from the published type declarations. `@confect/core`'s ref types (`Ref.ConfectRef` / `Ref.ConvexRef`) now declare all of their members, so the `Ref.Ref` union can be narrowed by its `_tag`, and `@confect/server`'s `CronJobs.cronToConvexCronString` and `CronJobs.durationToConvexIntervalSchedule` — previously exported at runtime but absent from the declarations — are now typed.

--- a/packages/core/src/FunctionProvenance.ts
+++ b/packages/core/src/FunctionProvenance.ts
@@ -13,9 +13,7 @@ export type FunctionProvenance = Data.TaggedEnum<{
     kind: ConfectKind;
   };
   Convex: {
-    /** @internal */
     "~args": DefaultFunctionArgs;
-    /** @internal */
     "~returns": any;
   };
 }>;

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -29,7 +29,6 @@ export interface Base<
   readonly "~Args": Args_;
   readonly "~Returns": Returns_;
   readonly "~Error": Error_;
-  /** @internal */
   readonly convexFunctionName: string;
 }
 
@@ -73,17 +72,11 @@ export interface ConfectRef<
   Returns_,
   Error_
 > {
-  /** @internal */
   readonly _tag: "Confect";
-  /** @internal */
   readonly args: Schema.Codec<any, any>;
-  /** @internal */
   readonly returns: Schema.Codec<any, any>;
-  /** @internal */
   readonly kind: FunctionProvenance.ConfectKind;
-  /** @internal */
   readonly middlewareSpecs: ReadonlyArray<MiddlewareSpec.AnyMiddlewareSpec>;
-  /** @internal */
   readonly error?: Schema.Codec<any, any>;
 }
 
@@ -100,7 +93,6 @@ export interface ConvexRef<
   Returns_,
   Error_
 > {
-  /** @internal */
   readonly _tag: "Convex";
 }
 

--- a/packages/server/src/CronJobs.ts
+++ b/packages/server/src/CronJobs.ts
@@ -76,7 +76,6 @@ const makeProto = (
 
 export const make = (): CronJobs => makeProto({}, makeConvexCrons());
 
-/** @internal */
 export const cronToConvexCronString = (cron: Cron.Cron): string => {
   pipe(
     cron.tz,
@@ -129,7 +128,6 @@ const setToField = (set: ReadonlySet<number>): string => {
   );
 };
 
-/** @internal */
 export const durationToConvexIntervalSchedule = (
   duration: Duration.Duration,
 ): IntervalSchedule => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,6 @@
     "noUncheckedIndexedAccess": false,
     "strictNullChecks": true,
     "removeComments": false,
-    "stripInternal": true,
     "plugins": [
       {
         "name": "@effect/language-service",


### PR DESCRIPTION
Removes `stripInternal: true` from `tsconfig.base.json` and all twelve `/** @internal */` tags (core&#39;s `Ref` and `FunctionProvenance`, server&#39;s `CronJobs`), so the published type declarations match the runtime.

What the stripping was costing:

- `Ref.ConfectRef` and `Ref.ConvexRef` shipped with **empty bodies**, so the `Ref.Ref` union was structurally undiscriminatable for consumers — downstream packages had to reach `_tag`/`args`/`kind` through untyped structural casts that silently break when the ref shape changes (this bit `@confect/foldkit` during the core ref flattening).
- `@confect/server`&#39;s `CronJobs.cronToConvexCronString` and `CronJobs.durationToConvexIntervalSchedule` were exported at runtime but absent from the declarations — untyped for every consumer.
- Core&#39;s published `FunctionProvenance` declarations were internally inconsistent: the TaggedEnum&#39;s `Convex` variant lost its phantom fields while the constructor&#39;s return type kept them.

There was no other machinery keyed to the tag (no api-extractor, no lint rule, no script) — the compiler option was the whole mechanism. No changeset: none of the newly visible members are documented APIs.

Stacked under #584, which builds `@confect/foldkit` on the now-visible ref internals.

Verified with `pnpm build` (dist declarations regain the members), `pnpm typecheck`, the full `pnpm test` suite, `pnpm lint`, and `pnpm format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUDttKwDtPSbCEx5sgxMvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUDttKwDtPSbCEx5sgxMvp)_