### PR TITLE
Stream-first querying: QueryStream core

### DIFF
--- a/.changeset/convex-error-defects.md
+++ b/.changeset/convex-error-defects.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": patch
+---
+
+A `ConvexError` thrown inside a handler's `Effect` (as an exception, rather than placed in the error channel as a typed failure) now reaches the client with its `data` intact, as it does in a plain Convex function. Previously it was delivered as a generic server error.

--- a/.changeset/stream-querying-core.md
+++ b/.changeset/stream-querying-core.md
@@ -2,7 +2,7 @@
 "@confect/server": minor
 ---
 
-Add `QueryStream`, an experimental stream-first querying API. `reader.table(...).stream(index, range?, order?)` returns a genuine Effect `Stream` of documents in index order that stays combinable and paginable: `QueryStream.merge` interleaves streams that share an order key, `QueryStream.filterEffect` and `QueryStream.mapEffect` transform documents without losing pagination support, `QueryStream.unique` expects at most one result, and `QueryStream.paginate` turns any composed stream into a paginated query page.
+Add `QueryStream`, an experimental stream-first querying API. `reader.table(...).stream(index, range?, order?)` returns a genuine Effect `Stream` of documents in index order that stays combinable and paginable: `QueryStream.merge` interleaves streams that share an order key, `QueryStream.filter` and `QueryStream.map` (and their effectful counterparts `filterEffect` and `mapEffect`) transform documents without losing pagination support, `QueryStream.unique` expects at most one result, and `QueryStream.paginate` turns any composed stream into a paginated query page.
 
 The order key is tracked in the type system: fields pinned with `.eq(...)` in the range builder are consumed from the key, and merging streams whose remaining keys differ is a type error.
 
@@ -21,7 +21,7 @@ const inRange = (from: number, to: number) =>
 const page =
   yield *
   QueryStream.merge([inRange(0, 10), inRange(20, 30)]).pipe(
-    QueryStream.filterEffect((event) => Effect.succeed(!event.cancelled)),
+    QueryStream.filter((event) => !event.cancelled),
     QueryStream.paginate(paginationOpts),
   );
 ```

--- a/.changeset/stream-querying-core.md
+++ b/.changeset/stream-querying-core.md
@@ -25,3 +25,7 @@ const page =
     QueryStream.paginate(paginationOpts),
   );
 ```
+
+`QueryStream.paginate` accepts the same `paginationOpts` as the built-in `paginate`. A cursor that is malformed, or that was issued under a different order key (for example after an index change is deployed), fails the query with a `ConvexError` whose data is `{ paginationError: "InvalidCursor" }` — the signal Confect's React hooks treat as "restart pagination". Stream cursors contain the order-key values of the page boundary rather than an opaque token, so don't paginate publicly over a sensitive indexed field without pinning it with `eq`.
+
+Streams passed to `QueryStream.merge` must share an order direction as well as an order key; a direction mismatch fails when the stream runs.

--- a/.changeset/stream-querying-core.md
+++ b/.changeset/stream-querying-core.md
@@ -12,10 +12,16 @@ import { QueryStream } from "@confect/server";
 const inRange = (from: number, to: number) =>
   reader
     .table("events")
-    .stream("from_to", (q) => q.eq("kind", "meeting").gte("start", from).lt("start", to), "desc");
+    .stream(
+      "from_to",
+      (q) => q.eq("kind", "meeting").gte("start", from).lt("start", to),
+      "desc",
+    );
 
-const page = yield* QueryStream.merge([inRange(0, 10), inRange(20, 30)]).pipe(
-  QueryStream.filterEffect((event) => Effect.succeed(!event.cancelled)),
-  QueryStream.paginate(paginationOpts),
-);
+const page =
+  yield *
+  QueryStream.merge([inRange(0, 10), inRange(20, 30)]).pipe(
+    QueryStream.filterEffect((event) => Effect.succeed(!event.cancelled)),
+    QueryStream.paginate(paginationOpts),
+  );
 ```

--- a/.changeset/stream-querying-core.md
+++ b/.changeset/stream-querying-core.md
@@ -2,7 +2,7 @@
 "@confect/server": minor
 ---
 
-Add `QueryStream`, a stream-first querying prototype. `reader.table(...).stream(index, range?, order?)` returns a genuine Effect `Stream` of documents in index order that stays combinable and paginable: `QueryStream.merge` interleaves streams that share an order key, `QueryStream.filterEffect` and `QueryStream.mapEffect` transform documents without losing pagination support, `QueryStream.unique` expects at most one result, and `QueryStream.paginate` turns any composed stream into a paginated query page.
+Add `QueryStream`, an experimental stream-first querying API. `reader.table(...).stream(index, range?, order?)` returns a genuine Effect `Stream` of documents in index order that stays combinable and paginable: `QueryStream.merge` interleaves streams that share an order key, `QueryStream.filterEffect` and `QueryStream.mapEffect` transform documents without losing pagination support, `QueryStream.unique` expects at most one result, and `QueryStream.paginate` turns any composed stream into a paginated query page.
 
 The order key is tracked in the type system: fields pinned with `.eq(...)` in the range builder are consumed from the key, and merging streams whose remaining keys differ is a type error.
 

--- a/.changeset/stream-querying-core.md
+++ b/.changeset/stream-querying-core.md
@@ -1,0 +1,21 @@
+---
+"@confect/server": minor
+---
+
+Add `QueryStream`, a stream-first querying prototype. `reader.table(...).stream(index, range?, order?)` returns a genuine Effect `Stream` of documents in index order that stays combinable and paginable: `QueryStream.merge` interleaves streams that share an order key, `QueryStream.filterEffect` and `QueryStream.mapEffect` transform documents without losing pagination support, `QueryStream.unique` expects at most one result, and `QueryStream.paginate` turns any composed stream into a paginated query page.
+
+The order key is tracked in the type system: fields pinned with `.eq(...)` in the range builder are consumed from the key, and merging streams whose remaining keys differ is a type error.
+
+```ts
+import { QueryStream } from "@confect/server";
+
+const inRange = (from: number, to: number) =>
+  reader
+    .table("events")
+    .stream("from_to", (q) => q.eq("kind", "meeting").gte("start", from).lt("start", to), "desc");
+
+const page = yield* QueryStream.merge([inRange(0, 10), inRange(20, 30)]).pipe(
+  QueryStream.filterEffect((event) => Effect.succeed(!event.cancelled)),
+  QueryStream.paginate(paginationOpts),
+);
+```

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -401,7 +401,7 @@ The core of §4 is now implemented as an experimental API:
   intact), the typed range builder with type-level
   `eq`-prefix consumption, Convex value ordering, and the combinators/sinks:
   `merge` (k-way ordered, `Key`-invariant so mismatches are type errors),
-  `filterEffect`, `mapEffect`, `narrow`, `unique`, and `paginate` with
+  `filter`/`filterEffect`, `map`/`mapEffect`, `narrow`, `unique`, and `paginate` with
   `cursor`/`endCursor`/`maximumRowsRead` semantics matching `convex-helpers`.
   Leaf streams store a **`Reflection`** — the query recipe (reader handle,
   table, index, recorded range ops, order), the Effect formulation of

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -1,0 +1,428 @@
+# Exploration: a stream-first querying API for Confect
+
+> Status: exploration / pre-RFC.
+> Prompted by the Convex team's direction on streams — see
+> [Merging Streams of Convex data](https://stack.convex.dev/merging-streams-of-convex-data),
+> [Take Control of Pagination](https://stack.convex.dev/pagination), and
+> [Fully Reactive Pagination](https://stack.convex.dev/fully-reactive-pagination).
+
+## TL;DR
+
+Make **`Stream` the query type**, not a terminal method. `reader.table("messages").index("by_creation_time")` would return a `QueryStream<Doc>` — a genuine Effect `Stream` (usable with every `Stream.*` combinator) that additionally remembers its **index ordering** and each element's **index key**. That extra structure is exactly what makes union (`merge`), join (`flatMap`), predicate filtering (`filterEffect`), loose index scans (`distinct`), and — critically — **pagination over arbitrary compositions** possible, which a plain `Stream<Doc>` can never support.
+
+This is the Effect-native formulation of `convex-helpers/server/stream`'s `QueryStream`, and it is a place where Confect can be _better_ than the untyped original: ordering compatibility, merge keys, and distinct-field prefixes can be checked **at the type level** instead of throwing at runtime, and effectful predicates get real error (`E`) and requirements (`R`) channels instead of closed-over `ctx`.
+
+---
+
+## 1. Where we are today
+
+Confect's read path is already stream-shaped underneath — it just doesn't expose it as the primary abstraction:
+
+- `OrderedQuery` (`packages/server/src/OrderedQuery.ts:53-75`) builds one
+  `Stream.fromAsyncIterable` over the Convex `OrderedQuery` async iterator, and derives
+  `first`, `take`, and `collect` from it. `stream()` is offered as _one more terminal_ among
+  five.
+- `paginate` (`OrderedQuery.ts:77-103`) is the odd one out: it bypasses the stream entirely
+  and delegates to Convex's built-in `.paginate()`, with filtering only available as a
+  `paginate`-argument (`filter?: (q: FilterBuilder<…>) => …`), not as a composable
+  combinator.
+- There is no way to combine two queries at all: no union, no join, no interleaving. Every
+  query is one index range over one table.
+- Cursors are untyped `Schema.String` everywhere (`packages/core/src/PaginationResult.ts:12`).
+
+So the question "what would a purely stream-based API look like?" is really: **what has to be
+added to `Stream` so that everything — including `paginate` — can be derived from it?**
+
+## 2. What the Convex articles establish
+
+The three Stack posts, read together, make a precise technical argument:
+
+1. **Pages must be range-defined, not count-defined** ([Fully Reactive Pagination]). A
+   reactive page defined as "next N items after cursor C" grows gaps/overlaps as data
+   changes. The fix is to pin both endpoints: a page is "all items between index key A and
+   index key B", and it grows/shrinks reactively. Convex's built-in `paginate` does this via
+   the internal query journal; anything _not_ built on the built-in `paginate` must do it
+   itself by threading `endCursor`.
+
+2. **`getPage` generalizes pagination to explicit index ranges** ([Take Control of
+   Pagination]). Once a page is "an index range", you can start it anywhere, run it
+   backwards, jump around, and stitch unions/joins — none of which the built-in
+   `paginate`/`usePaginatedQuery` support.
+
+3. **Streams are the composable packaging of that idea** ([Merging Streams]). A
+   `QueryStream` is _an async iterable of documents ordered by indexed fields_. Because each
+   element is annotated with its **index key**, streams can be:
+   - **merged** (`mergedStream([a, b], ["_creationTime"])` — SQL `UNION ALL` with a k-way
+     ordered merge),
+   - **joined** (`flatMap` — each outer doc expands to an inner stream),
+   - **filtered by arbitrary code** (`filterWith` — filtered-out rows still advance the
+     cursor, so the result remains paginable),
+   - **deduplicated** (`distinct` — a loose index scan that _skips_ the index forward), and
+   - **paginated** (`paginate` — narrow the composed stream to `(cursor, endCursor]` bounds
+     and consume; the continue-cursor is just the last index key seen).
+
+The load-bearing insight is the annotation. In `convex-helpers`' internal contract
+(`server/stream.ts`), every stream must implement:
+
+```ts
+abstract iterWithKeys(): AsyncIterable<[T | null, IndexKey, number]>; // doc|filtered, key, bytes
+abstract narrow(indexBounds: IndexBounds): QueryStream<T>;            // push cursor bounds down
+abstract getOrder(): "asc" | "desc";
+abstract getIndexFields(): string[];       // reflection: what am I ordered by?
+abstract getEqualityIndexFilter(): Value[]; // reflection: which key prefix is pinned?
+```
+
+Everything else — `first`, `take`, `collect`, `unique`, `paginate`, `mergedStream`,
+`flatMap`, `distinct` — is derived from these five. `[Symbol.asyncIterator]` just projects
+the doc and drops the keys, i.e. **a plain stream is the forgetful image of a query
+stream.**
+
+## 3. Prior art in typed FP
+
+This shape is well-trodden in the typed FP world, which is reassuring:
+
+- **doobie / fs2 (Scala)**: `sql"select …".query[A].stream` gives a cursor-backed
+  `Stream[ConnectionIO, A]` — lazy, chunked, constant-memory, resource-safe. The "query
+  result is fundamentally a stream; `.to[List]` is just one sink" framing is exactly the
+  inversion proposed here.
+- **fs2 `interleaveOrdered` / ZIO `ZStream` sorted merges / Effect's own
+  `Stream.zipAllSortedByKey*`**: ordered k-way merging of already-sorted streams is a
+  standard combinator family; `mergedStream` is this pattern specialized to index-key order.
+- **Effect `Stream.paginateChunkEffect(s, f)`**: pagination _as unfold_ — state `S` is the
+  cursor, each step effectfully yields a chunk plus `Option<S>`. Convex pagination fits this
+  signature perfectly (`S = continueCursor`), and it's how "give me _all_ pages as one
+  stream" should be spelled on the client/action side.
+- The general lesson from these libraries: **keep the metadata in the type, degrade to the
+  plain stream explicitly**. fs2's `Stream` doesn't know it's sorted; libraries that need
+  sortedness either take it on faith (runtime contract, like `convex-helpers`) or wrap the
+  stream in a witness type. Confect, with a fully typed schema in hand, can do the witness
+  properly.
+
+## 4. The proposed shape
+
+### 4.1 `QueryStream` — a `Stream` that remembers its order
+
+```ts
+// @confect/server/QueryStream (sketch)
+
+interface QueryStream<
+  out Doc,
+  out Key extends ReadonlyArray<string> = ReadonlyArray<string>, // remaining (un-pinned) index fields
+  out E = never,
+  out R = never,
+> extends Stream.Stream<Doc, E, R> {
+  readonly [TypeId]: {
+    readonly _Key: Types.Covariant<Key>;
+  };
+}
+```
+
+- It **is** a `Stream` (implementable via `effect/Streamable.Class`, or a `Pipeable` data
+  type with a `Stream` variance struct): `Stream.take`, `Stream.runCollect`,
+  `Stream.mapEffect`, `Stream.zip` … all just work. Consuming it as a `Stream` yields
+  decoded documents in index order.
+- `Key` is the **type-level ordering witness**: the index fields that still vary, i.e. the
+  index's fields minus the equality-pinned prefix, plus the `_creationTime`/`_id`
+  tiebreakers. It's what `merge`/`distinct`/`flatMap` check against.
+- Internally it carries what the Stream interface can't express (mirroring
+  `convex-helpers`, but in Effect vocabulary):
+
+```ts
+// internal
+readonly annotated: Stream.Stream<readonly [Option.Option<Doc>, IndexKey], E, R>;
+//                                          ^ None = read-but-filtered-out: advances cursors
+readonly order: "asc" | "desc";
+readonly indexFields: ReadonlyArray<string>;
+readonly equalityPrefix: ReadonlyArray<Value>;
+readonly narrow: (bounds: IndexBounds) => QueryStream<Doc, Key, E, R>;
+```
+
+Applying a generic `Stream` combinator degrades a `QueryStream` to a plain `Stream`
+(metadata gone, pagination gone) — which is correct and honest: `Stream.filter` genuinely
+destroys paginate-ability (dropped rows no longer advance cursors), while
+`QueryStream.filterEffect` preserves it. The type system now _explains_ the difference
+instead of the library hiding it.
+
+### 4.2 Constructing: `index()` returns the stream
+
+The `DatabaseReader` surface barely changes — `index()` simply _is_ the query now:
+
+```ts
+const reader = yield * DatabaseReader;
+
+// QueryStream<Doc<"messages">, ["_creationTime", "_id"]>
+const aToB = reader
+  .table("messages")
+  .index("from_to", (q) => q.eq("from", a).eq("to", b));
+
+// consume it like any Stream — no more bespoke terminals
+const first10 = yield * aToB.pipe(Stream.take(10), Stream.runCollect);
+```
+
+Note the `Key`: `from_to` is `["from", "to", "_creationTime", "_id"]`, and both `from` and
+`to` are equality-pinned, so the remaining ordering is `["_creationTime", "_id"]`. Today the
+range callback returns Convex's opaque `IndexRange`, so the pinned prefix is only knowable
+at runtime; a Confect-typed range builder (a thin wrapper over Convex's — which already
+threads the field position through its types) would return `IndexRange<RemainingKey>` and
+make the `Key` inference exact. This is the first concrete win over `convex-helpers`, where
+merge-key compatibility is a runtime `throw`.
+
+`get` stays an `Effect` (a lookup is not a stream), and `search` stays separate (relevance
+order has no index key — see §6.3).
+
+### 4.3 Combining: the `QueryStream.*` combinators
+
+All dual (data-first/data-last), all pipeable, mirroring `Stream`'s own style:
+
+```ts
+// UNION ALL: k-way ordered merge. Type error unless every input's Key matches `by`.
+const conversation: QueryStream<
+  Doc<"messages">,
+  ["_creationTime", "_id"]
+> = QueryStream.merge([aToB, bToA], { by: ["_creationTime"], order: "desc" });
+
+// JOIN: for each friend, stream their messages; result ordered by (outer, inner) keys.
+const feed = friends.pipe(
+  QueryStream.flatMap(
+    (friend) =>
+      reader
+        .table("messages")
+        .index("from_to", (q) => q.eq("from", friend.friendId)),
+    { key: ["to", "_creationTime", "_id"] }, // inferable from the inner stream's type
+  ),
+);
+
+// WHERE with arbitrary Effect code — E and R flow into the stream's channels.
+const visible = conversation.pipe(
+  QueryStream.filterEffect((message) =>
+    reader
+      .table("users")
+      .get(message.from)
+      .pipe(Effect.map((author) => !author.banned)),
+  ),
+);
+// : QueryStream<Doc<"messages">, ["_creationTime", "_id"], DocumentDecodeError | GetByIdFailure>
+
+// SELECT: map preserves index keys, so the result is still paginable.
+const projected = visible.pipe(QueryStream.mapEffect((m) => decorate(m)));
+
+// DISTINCT / loose index scan: fields must be a prefix of Key — checked in types.
+const recipients = reader
+  .table("messages")
+  .index("from_to", (q) => q.eq("from", me))
+  .pipe(QueryStream.distinct(["to"]));
+```
+
+Compare `filterEffect` with the `convex-helpers` original, where the predicate is
+`(doc) => Promise<boolean>` closing over `ctx`: here the predicate is an `Effect`, so it can
+use the `DatabaseReader` (or any service), its failures are typed and surface in the
+stream's `E`, it's interruptible, and it's testable with the same Layer machinery as
+everything else in Confect.
+
+### 4.4 Consuming: `Stream` sinks, plus two query-specific ones
+
+```ts
+// Plain Stream consumption (order preserved, cursors irrelevant):
+yield * Stream.runCollect(conversation);
+yield * Stream.runHead(conversation); // ≈ first()
+yield * conversation.pipe(Stream.take(5), Stream.runCollect);
+
+// Query-specific terminals that need the annotations:
+yield * QueryStream.unique(aToB); // Effect<Option<Doc>, … | NotUniqueError>
+yield * QueryStream.paginate(conversation, paginationOpts);
+// : Effect<PaginationResult<Doc>, DocumentDecodeError | E, R>
+```
+
+`first`/`take`/`collect` stop being bespoke methods — they were already implemented as
+Stream sinks internally (`OrderedQuery.ts:63-75`); the API finally admits it. Whether to
+keep them as convenience re-exports on `QueryStream` is a bikeshed; the important part is
+they're derived, not primitive.
+
+### 4.5 Pagination as a stream sink
+
+`QueryStream.paginate` is the port of `convex-helpers`' `QueryStream.paginate`
+(`stream.ts:349-450`), now expressible because the stream kept its annotations:
+
+1. deserialize `cursor`/`endCursor` into `IndexKey`s,
+2. `narrow` the composed stream to those bounds (each layer pushes bounds down —
+   `MergedStream.narrow` narrows every branch, `FlatMapStream` narrows outer+inner, the leaf
+   turns bounds into real `withIndex` ranges via split-range reflection),
+3. consume the annotated stream, counting _read_ rows (including filtered-out `None`s)
+   against `maximumRowsRead`/`maximumBytesRead`,
+4. the continue-cursor is the serialized last index key; `pageStatus`/`splitCursor` fall out
+   of the same accounting.
+
+Two pieces of existing Confect infrastructure line up almost eerily well:
+
+- `PaginationOptions` (`packages/core/src/PaginationOptions.ts`) already declares
+  `endCursor`, `maximumRowsRead`, and `maximumBytesRead` — the exact protocol fields
+  stream-pagination needs. Nothing changes on the wire, and `FunctionSpec.publicPaginatedQuery`
+  handlers keep their shape:
+
+```ts
+FunctionSpec.publicPaginatedQuery({
+  args: () => Schema.Struct({ otherUser: Ref.Id("users") }),
+  item: () => Message,
+});
+
+// impl
+({ otherUser, paginationOpts }) =>
+  Effect.gen(function* () {
+    const reader = yield* DatabaseReader;
+    const me = yield* currentUserId;
+    const sent = reader
+      .table("messages")
+      .index("from_to", (q) => q.eq("from", me).eq("to", otherUser), "desc");
+    const received = reader
+      .table("messages")
+      .index("from_to", (q) => q.eq("from", otherUser).eq("to", me), "desc");
+    return yield* QueryStream.paginate(
+      QueryStream.merge([sent, received], { by: ["_creationTime"] }),
+      paginationOpts,
+    );
+  });
+```
+
+- The one thing that must change alongside: **`@confect/react`'s `usePaginatedQuery`**.
+  Today it rides `convex/react`'s internal hook, whose gap-free reactivity depends on the
+  query journal that only the built-in `db.paginate` writes. Stream pagination doesn't
+  touch the journal, so the client must pin pages itself by echoing each page's
+  `continueCursor` back as the next request's `endCursor` — precisely what
+  `convex-helpers/react`'s `usePaginatedQuery` does. Since Confect already owns its hook
+  wrapper and already decodes/encodes the protocol fields, adopting the endCursor-pinning
+  strategy is contained in `@confect/react` (likely by vendoring/adapting the helper hook
+  rather than reaching into more `convex/react` internals). Same trick, one layer down: the
+  _hook_ re-issues range-pinned queries; the semantics the articles demand are preserved.
+
+### 4.6 Client-side streams, for completeness
+
+A purely stream-based story doesn't stop at the function boundary:
+
+- `@confect/js`'s `WebSocketClient.reactiveQuery` already returns
+  `Stream<Returns, …>` — the subscription side is done.
+- A natural addition: `Stream.paginateChunkEffect` over a paginated query ref, giving
+  clients/actions "all pages as one `Stream<Item>`" with the cursor as internal unfold
+  state:
+
+```ts
+const allMessages: Stream.Stream<Message, …> = client.paginatedQueryStream(
+  api.messages.list,
+  { otherUser },
+  { pageSize: 100 },
+);
+```
+
+(One-shot, non-reactive — the reactive UI path remains `usePaginatedQuery`.)
+
+## 5. Why this is better in Effect than in vanilla TS
+
+| Concern                                | `convex-helpers/server/stream`                 | Effect-native `QueryStream`                                                                                                |
+| -------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Merge-key compatibility                | runtime `throw` ("Consider using .orderBy")    | type error at `merge` call site                                                                                            |
+| `distinct`/`flatMap` field constraints | runtime validation                             | type-level prefix/key checks against the schema's index tuples                                                             |
+| Filter predicates                      | `(doc) => Promise<boolean>` closing over `ctx` | `(doc) => Effect<boolean, E2, R2>` — typed errors, DI via `R`, interruptible                                               |
+| Error handling                         | thrown exceptions                              | `E` channel: `DocumentDecodeError \| NotUniqueError \| user errors`, matchable                                             |
+| Document validation                    | none (raw docs)                                | per-element `Schema` decode, exactly as today                                                                              |
+| Early termination                      | `break` in a `for await`                       | `Stream.take`/interruption, resource-safe by construction                                                                  |
+| Ecosystem                              | bespoke methods                                | the whole `Stream` toolbox (`throttle`, `zip`, `grouped`, `changes`, …) for free once you (explicitly) leave paginate-land |
+| Cursors                                | `string`                                       | branded `Cursor` (still a string on the wire), decoded/validated at the edge                                               |
+
+And one thing to keep from `convex-helpers` verbatim: the cursor accounting trick of
+streaming `[Option<Doc>, IndexKey]` rather than `Doc` — it's the difference between "a
+stream you can look at" and "a stream you can resume".
+
+## 6. Design questions worth settling early
+
+### 6.1 Subtype of `Stream`, or separate type with `.stream`?
+
+Recommendation: **subtype** (that's what "purely stream-based" means). The cost is that
+generic `Stream` combinators silently degrade the type from `QueryStream` to `Stream` —
+but that degradation is semantically real (see §4.1), and TypeScript handles it gracefully:
+you keep a `Stream<Doc, E, R>`, you've lost `QueryStream.paginate`. The alternative (a
+builder with a `.stream()` escape hatch) is what we have today, and it's exactly the
+"stream as afterthought" shape being replaced.
+
+### 6.2 Wrap `convex-helpers`, or port it?
+
+- **Wrapping** gets battle-tested `narrow`/split-range/merge logic for free and tracks
+  upstream fixes, but impedance-mismatches on every combinator that takes user code: their
+  `filterWith`/`flatMap` take `Promise`-returning functions, so every Effect predicate needs
+  a `Runtime` capture to run inside their iterator, and `R` threading gets awkward.
+- **Porting** (the annotated-stream core, `ReflectIndexRange`, `splitRange`, k-way merge,
+  distinct-skip) is a bounded amount of code (~the interesting half of a 2k-line file, with
+  the reflection machinery mostly mechanical), keeps `E`/`R` first-class, and lets the merge
+  be a proper `Channel`-level ordered merge.
+
+Recommendation: **port the core, steal the tests**. Keep cursor _wire format_
+compatibility a non-goal (Confect cursors never met `convex-helpers` cursors), but keep the
+same serialization approach (JSON of `convexToJson`'d index keys), and inherit their
+documented caveats (index keys — including filtered-out rows' keys — are visible in
+cursors; treat cursors as sensitive if index fields are).
+
+### 6.3 What about `search()` and vector search?
+
+Search results are relevance-ordered: there is no index key, hence no `narrow`, no merge,
+no stream pagination. `search()` should return a plain `Stream<Doc, DocumentDecodeError>`
+(possibly with Convex-native `paginate` kept as an `Effect`-returning sibling), and the
+types will correctly refuse to `merge` it with index streams. Vector search stays as-is.
+
+### 6.4 Laziness and reuse
+
+Today `streamEncoded` is built once per `OrderedQuery.make` and re-consuming it relies on
+Convex's iterable semantics. A `QueryStream` should be a _description_ (like every Stream):
+each run re-executes the underlying Convex query. That also matters for `paginate`, which
+runs the stream through `narrow` — i.e. never consumes the un-narrowed iterator at all.
+
+### 6.5 Migration and versioning
+
+This is a breaking change to the read API (terminals move off the query object), so it's
+naturally a major — and the Effect v4 line (`v10` branch) is the obvious vehicle, since the
+read API is being touched there anyway. A staging option that keeps `main` shippable:
+
+1. Additive: introduce `QueryStream` + combinators; `index()` keeps returning
+   `OrderedQuery`, which gains `asQueryStream()` (or `QueryStream.fromOrderedQuery`).
+2. v10: `index()` returns `QueryStream` directly; `first`/`take`/`collect`/`paginate`
+   terminals are removed in favor of `Stream` sinks + `QueryStream.paginate`;
+   `paginate`'s `filter` argument is removed in favor of `QueryStream.filterEffect`;
+   `@confect/react`'s `usePaginatedQuery` switches to endCursor-pinned pages.
+
+Docs impact is contained: `apps/docs/server/database/reading.mdx` becomes a streams page
+(the current "Methods" section becomes "Consuming a stream"), plus a new "Combining
+queries" page for merge/flatMap/filter/distinct — which is a genuinely new capability
+Confect simply doesn't have a page for today, because it doesn't have the feature.
+
+## 7. Open questions
+
+1. **Key inference ergonomics** — how far to push the typed range builder. Full inference
+   of the eq-pinned prefix (so `Key` is exact) vs. a simpler declared-`by` at merge sites
+   with runtime validation as backstop. Prototype the former; it's the marquee type-safety
+   win, and Convex's own `IndexRangeBuilder` types already thread field positions.
+2. **`orderBy` re-keying** — `convex-helpers` lets you re-designate index fields
+   (`.orderBy(...)`) to make heterogeneous streams mergeable (e.g. two tables that both end
+   in `["_creationTime", "_id"]` but with different-named prefixes). Same-named fields
+   across tables is a real restriction in practice; decide whether `merge`'s `by` matches
+   _positions_ (suffix of the key) rather than _names_ to sidestep it.
+3. **Reactivity guarantees** — document precisely which client patterns are gap-free
+   (endCursor-pinned `usePaginatedQuery`) vs. eventually-consistent-ish (manual
+   `loadMore` without pinning), mirroring the caveats in the Merging Streams article.
+4. **Bandwidth accounting** — whether to surface `maximumBytesRead`-style limits on
+   non-paginate sinks too (e.g. a `QueryStream.collectWithBudget`), since `filterEffect`
+   makes it easy to read a lot while emitting a little.
+5. **`Chunk`ing** — Convex iterators yield one doc at a time; whether to re-chunk
+   internally (and batch-decode via `Stream.mapChunksEffect`) for constant-factor wins.
+
+## Appendix: the annotated-element trick, in one picture
+
+```
+QueryStream<Doc, Key, E, R>
+│
+│  annotated: Stream<[Option<Doc>, IndexKey], E, R>   ← resumable: every element knows where it is
+│  order, indexFields, equalityPrefix                 ← mergeable: compatibility is checkable
+│  narrow(bounds)                                     ← paginable: cursors become index ranges
+│
+└─ forget the annotations ────────────────► Stream<Doc, E, R>   ← consumable: the whole Stream toolbox
+```
+
+`merge` / `flatMap` / `filterEffect` / `distinct` / `mapEffect` operate on the annotated
+level and return `QueryStream`; `paginate` / `unique` are sinks on the annotated level;
+everything else is ordinary `Stream` code.

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -454,6 +454,13 @@ recommendation but deferring the heaviest piece:
    makes it easy to read a lot while emitting a little.
 5. **`Chunk`ing** — Convex iterators yield one doc at a time; whether to re-chunk
    internally (and batch-decode via `Stream.mapChunksEffect`) for constant-factor wins.
+6. **Cursor opacity** — stream cursors serialize the remaining order-key _values_ as
+   plain JSON, so page boundaries expose those values to clients (fine for
+   `_creationTime`/`_id`, not for a sensitive indexed field), and clients can craft
+   cursors targeting chosen keys within the stream's range. Built-in Convex cursors are
+   opaque tokens; decide whether to encrypt/sign stream cursors (requires key material
+   on the deployment) or document the exposure as a constraint on which indexes should
+   back public paginated streams.
 
 ## Appendix: the annotated-element trick, in one picture
 

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -391,9 +391,9 @@ Docs impact is contained: `apps/docs/server/database/reading.mdx` becomes a stre
 queries" page for merge/flatMap/filter/distinct — which is a genuinely new capability
 Confect simply doesn't have a page for today, because it doesn't have the feature.
 
-## 7. Prototype (implemented on this branch)
+## 7. Experimental implementation (on this branch)
 
-The core of §4 is now implemented as a working prototype:
+The core of §4 is now implemented as an experimental API:
 
 - **`packages/server/src/QueryStream.ts`** — the `QueryStream` class (a genuine
   `Stream`, implementing the `Stream` protocol — variance marker, `pipe`, and
@@ -417,7 +417,7 @@ The core of §4 is now implemented as a working prototype:
   (order-key inference, merge mismatch rejection, range-builder misuse, `E`/`R`
   channel propagation).
 
-Deliberate prototype simplifications, in line with §6.2's "port the core"
+Deliberate simplifications, in line with §6.2's "port the core"
 recommendation but deferring the heaviest piece:
 
 - `narrow` filters the annotated stream **in memory** (`dropWhile`/`takeWhile`

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -117,8 +117,8 @@ interface QueryStream<
 }
 ```
 
-- It **is** a `Stream` (implementable via `effect/Streamable.Class`, or a `Pipeable` data
-  type with a `Stream` variance struct): `Stream.take`, `Stream.runCollect`,
+- It **is** a `Stream` (a `Pipeable` data type carrying the `Stream` variance
+  marker and channel): `Stream.take`, `Stream.runCollect`,
   `Stream.mapEffect`, `Stream.zip` … all just work. Consuming it as a `Stream` yields
   decoded documents in index order.
 - `Key` is the **type-level ordering witness**: the index fields that still vary, i.e. the
@@ -391,7 +391,51 @@ Docs impact is contained: `apps/docs/server/database/reading.mdx` becomes a stre
 queries" page for merge/flatMap/filter/distinct — which is a genuinely new capability
 Confect simply doesn't have a page for today, because it doesn't have the feature.
 
-## 7. Open questions
+## 7. Prototype (implemented on this branch)
+
+The core of §4 is now implemented as a working prototype:
+
+- **`packages/server/src/QueryStream.ts`** — the `QueryStream` class (a genuine
+  `Stream`, implementing the `Stream` protocol — variance marker, `pipe`, and
+  `channel` — directly on the class so `Stream.*` type inference stays
+  intact), the typed range builder with type-level
+  `eq`-prefix consumption, Convex value ordering, and the combinators/sinks:
+  `merge` (k-way ordered, `Key`-invariant so mismatches are type errors),
+  `filterEffect`, `mapEffect`, `narrow`, `unique`, and `paginate` with
+  `cursor`/`endCursor`/`maximumRowsRead` semantics matching `convex-helpers`.
+  Leaf streams store a **`Reflection`** — the query recipe (reader handle,
+  table, index, recorded range ops, order), the Effect formulation of
+  `convex-helpers`' `reflect()` — and rebuild the (one-shot) Convex query
+  from it on every run, so a `QueryStream` value is a reusable description.
+- **`QueryInitializer.stream(...)`** — `reader.table("notes").stream("by_text",
+(q) => q.eq("text", "a"), "desc")` returns
+  `QueryStream<Doc, ["_creationTime"], DocumentDecodeError>`.
+- **`packages/server/test/mock-backend/queryStream.test.ts`** — runtime tests
+  (ordering, plain `Stream` consumption, range bounds, merge interleaving,
+  effectful filtering, cursor-chained pagination over a merged+filtered
+  stream, endCursor pinning, `SplitRequired`, `unique`) and type-level tests
+  (order-key inference, merge mismatch rejection, range-builder misuse, `E`/`R`
+  channel propagation).
+
+Deliberate prototype simplifications, in line with §6.2's "port the core"
+recommendation but deferring the heaviest piece:
+
+- `narrow` filters the annotated stream **in memory** (`dropWhile`/`takeWhile`
+  on order keys) instead of pushing bounds into `withIndex` ranges, so
+  resuming from a cursor re-reads the range from its start. The leaf
+  `Reflection` now carries everything the `splitRange` decomposition needs to
+  rebuild a leaf with tighter bounds; what remains is the decomposition
+  itself, plus making `narrow` recurse through composed streams (merge
+  narrows every branch, a filter narrows the stream beneath it) as
+  `convex-helpers` does.
+- Cursors serialize only the _remaining_ (order-key) fields — a deliberate
+  improvement over `convex-helpers`' full index keys: equality-pinned values
+  never leak into cursors, and merged streams with different pins share a
+  cursor space by construction.
+- No `flatMap` (join), `distinct` (loose index scan), or `orderBy` (re-keying)
+  yet; no `maximumBytesRead` accounting; NaN ordering subtleties are skipped.
+
+## 8. Open questions
 
 1. **Key inference ergonomics** — how far to push the typed range builder. Full inference
    of the eq-pinned prefix (so `Key` is exact) vs. a simpler declared-`by` at merge sites

--- a/packages/server/src/QueryInitializer.ts
+++ b/packages/server/src/QueryInitializer.ts
@@ -344,7 +344,15 @@ export const make = <
                   table.indexes as ReadonlyRecord<string, ReadonlyArray<string>>
                 )[indexName],
               ),
-              Option.getOrElse(() => Array.empty<string>()),
+              // An unknown index name is a defect, not an empty field list:
+              // silently empty fields would make key extraction and range
+              // splitting target the wrong fields.
+              Option.getOrThrowWith(
+                () =>
+                  new Error(
+                    `QueryInitializer.stream: table "${tableName}" has no index named "${indexName}"`,
+                  ),
+              ),
               Array.append("_creationTime"),
             );
 

--- a/packages/server/src/QueryInitializer.ts
+++ b/packages/server/src/QueryInitializer.ts
@@ -104,7 +104,7 @@ export interface QueryInitializer<
     ) => SearchFilter,
   ) => OrderedQuery.OrderedQuery<TableInfoFor<DataModel_, TableName>, Doc>;
   /**
-   * PROTOTYPE — stream-first querying (see `notes/stream-based-querying.md`).
+   * EXPERIMENTAL — stream-first querying (see `notes/stream-based-querying.md`).
    *
    * Like `index`, but returns a {@link QueryStream.QueryStream}: a genuine
    * Effect `Stream` of documents in index order that stays mergeable and

--- a/packages/server/src/QueryInitializer.ts
+++ b/packages/server/src/QueryInitializer.ts
@@ -18,6 +18,9 @@ import type { GenericId } from "convex/values";
 import { pipe } from "effect/Function";
 import * as Array from "effect/Array";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
+import type { ReadonlyRecord } from "effect/Record";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import type {
@@ -27,6 +30,7 @@ import type {
 import type * as DataModel from "./DataModel";
 import * as Document from "./Document";
 import * as OrderedQuery from "./OrderedQuery";
+import * as QueryStream from "./QueryStream";
 import type * as Table from "./Table";
 import type * as TableInfo from "./TableInfo";
 
@@ -99,6 +103,50 @@ export interface QueryInitializer<
       >,
     ) => SearchFilter,
   ) => OrderedQuery.OrderedQuery<TableInfoFor<DataModel_, TableName>, Doc>;
+  /**
+   * PROTOTYPE — stream-first querying (see `notes/stream-based-querying.md`).
+   *
+   * Like `index`, but returns a {@link QueryStream.QueryStream}: a genuine
+   * Effect `Stream` of documents in index order that stays mergeable and
+   * paginable. The typed range builder consumes `eq`-pinned fields from the
+   * index's field tuple at the type level, so the stream's order-key type is
+   * exactly the fields that still vary.
+   */
+  readonly stream: {
+    <
+      IndexName extends keyof Indexes<
+        ConvexTableInfoFor<DataModel_, TableName>
+      > &
+        string,
+      Spec extends QueryStream.AnyIndexRangeSpec,
+    >(
+      indexName: IndexName,
+      indexRange: (
+        q: QueryStream.RangeBuilder<
+          TableInfoFor<DataModel_, TableName>["convexDocument"],
+          NamedIndex<ConvexTableInfoFor<DataModel_, TableName>, IndexName>
+        >,
+      ) => Spec,
+      order?: "asc" | "desc",
+    ): QueryStream.QueryStream<
+      Doc,
+      QueryStream.Remaining<Spec>,
+      Document.DocumentDecodeError
+    >;
+    <
+      IndexName extends keyof Indexes<
+        ConvexTableInfoFor<DataModel_, TableName>
+      > &
+        string,
+    >(
+      indexName: IndexName,
+      order?: "asc" | "desc",
+    ): QueryStream.QueryStream<
+      Doc,
+      NamedIndex<ConvexTableInfoFor<DataModel_, TableName>, IndexName>,
+      Document.DocumentDecodeError
+    >;
+  };
 }
 
 export const make = <
@@ -262,6 +310,55 @@ export const make = <
     );
   };
 
+  const stream: QueryInitializerFunction<"stream"> = ((
+    indexName: string,
+    indexRangeOrOrder?:
+      | ((
+          q: QueryStream.RangeBuilder<any, any>,
+        ) => QueryStream.AnyIndexRangeSpec)
+      | "asc"
+      | "desc",
+    maybeOrder?: "asc" | "desc",
+  ) => {
+    const order = Predicate.isString(indexRangeOrOrder)
+      ? indexRangeOrOrder
+      : (maybeOrder ?? "asc");
+
+    // With no range callback, the leaf gets an empty spec (no ops, no
+    // pinned fields).
+    const spec = Predicate.isFunction(indexRangeOrOrder)
+      ? indexRangeOrOrder(QueryStream.rangeBuilder())
+      : QueryStream.rangeBuilder();
+
+    // The type-level field tuple appends the `_creationTime` tiebreaker, but
+    // the runtime `table.indexes` record stores only the declared fields —
+    // append it here.
+    const indexFields: ReadonlyArray<string> =
+      indexName === "by_id"
+        ? ["_id"]
+        : indexName === "by_creation_time"
+          ? ["_creationTime"]
+          : pipe(
+              Option.fromUndefinedOr(
+                (
+                  table.indexes as ReadonlyRecord<string, ReadonlyArray<string>>
+                )[indexName],
+              ),
+              Option.getOrElse(() => Array.empty<string>()),
+              Array.append("_creationTime"),
+            );
+
+    return QueryStream.fromReflection({
+      reader: convexDatabaseReader as QueryStream.ReflectionReader,
+      tableName,
+      tableSchema: table.Fields,
+      indexName,
+      indexFields,
+      spec,
+      order,
+    });
+  }) as QueryInitializerFunction<"stream">;
+
   const search: QueryInitializerFunction<"search"> = (
     indexName,
     searchFilter,
@@ -283,6 +380,7 @@ export const make = <
     get,
     index,
     search,
+    stream,
   };
 };
 

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -668,6 +668,64 @@ export const mapEffect = dual<
 );
 
 /**
+ * Filter with a pure predicate — `Stream.filter` that keeps the stream
+ * paginable: filtered-out elements still advance cursors. Use
+ * `filterEffect` when the predicate needs to read the database or another
+ * service.
+ */
+export const filter = dual<
+  <Doc>(
+    predicate: (doc: Doc) => boolean,
+  ) => <Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc, Key, E, R>,
+  <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+    predicate: (doc: Doc) => boolean,
+  ) => QueryStream<Doc, Key, E, R>
+>(
+  2,
+  (self, predicate) =>
+    new QueryStream(
+      self.order,
+      self.keyFields,
+      Stream.map(
+        self.annotated,
+        ([doc, key]) => [Option.filter(doc, predicate), key] as const,
+      ),
+    ),
+);
+
+/**
+ * Transform elements with a pure function while preserving order keys —
+ * `Stream.map` that keeps the stream mergeable and paginable. The mapper
+ * must not change the ordering semantics. Use `mapEffect` when the mapper
+ * needs to read the database or another service.
+ */
+export const map = dual<
+  <Doc, Doc2>(
+    f: (doc: Doc) => Doc2,
+  ) => <Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc2, Key, E, R>,
+  <Doc, Key extends ReadonlyArray<string>, E, R, Doc2>(
+    self: QueryStream<Doc, Key, E, R>,
+    f: (doc: Doc) => Doc2,
+  ) => QueryStream<Doc2, Key, E, R>
+>(
+  2,
+  (self, f) =>
+    new QueryStream(
+      self.order,
+      self.keyFields,
+      Stream.map(
+        self.annotated,
+        ([doc, key]) => [Option.map(doc, f), key] as const,
+      ),
+    ),
+);
+
+/**
  * Restrict a stream to order keys strictly after `after` and at-or-before
  * `until` (in stream order). Prototype: filters in memory. Production would
  * push these bounds down into `withIndex` ranges: a leaf's `reflection`

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -1,5 +1,5 @@
 /**
- * PROTOTYPE — a stream-first querying API for Confect.
+ * EXPERIMENTAL — a stream-first querying API for Confect.
  *
  * A `QueryStream` is a genuine Effect `Stream` of decoded documents, ordered
  * by indexed fields, that additionally remembers:
@@ -14,7 +14,7 @@
  * This is the Effect-native formulation of `convex-helpers/server/stream`'s
  * `QueryStream`; see `notes/stream-based-querying.md` for the design.
  *
- * Prototype limitations (all called out in the design doc):
+ * Known limitations (all called out in the design doc):
  *
  * - `narrow` filters the annotated stream in memory rather than pushing
  *   bounds down into `withIndex` ranges (`splitRange` in `convex-helpers`),

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -1,0 +1,1002 @@
+/**
+ * PROTOTYPE — a stream-first querying API for Confect.
+ *
+ * A `QueryStream` is a genuine Effect `Stream` of decoded documents, ordered
+ * by indexed fields, that additionally remembers:
+ *
+ * - its **order key** at the type level (the index fields that still vary
+ *   after equality pinning), so that `merge` can reject incompatible streams
+ *   at compile time, and
+ * - each element's **order key values** at runtime (including read-but-
+ *   filtered-out elements), so that `paginate` works over arbitrary
+ *   compositions of `merge`/`filterEffect`/`mapEffect`.
+ *
+ * This is the Effect-native formulation of `convex-helpers/server/stream`'s
+ * `QueryStream`; see `notes/stream-based-querying.md` for the design.
+ *
+ * Prototype limitations (all called out in the design doc):
+ *
+ * - `narrow` filters the annotated stream in memory rather than pushing
+ *   bounds down into `withIndex` ranges (`splitRange` in `convex-helpers`),
+ *   so resuming from a cursor re-reads the range from its start.
+ * - No `flatMap` (join) or `distinct` (loose index scan) yet.
+ * - Cursors serialize only the *remaining* (order-key) fields, not the full
+ *   index key — equality-pinned values never leak into cursors.
+ */
+import type { GenericDocument, FieldTypeFromFieldPath } from "convex/server";
+import { convexToJson, jsonToConvex, type Value } from "convex/values";
+import { identity, dual, pipe } from "effect/Function";
+import { pipeArguments, type Pipeable } from "effect/Pipeable";
+import * as Array from "effect/Array";
+import type * as Channel from "effect/Channel";
+import * as Chunk from "effect/Chunk";
+import * as Effect from "effect/Effect";
+import * as Equivalence from "effect/Equivalence";
+import * as Filter from "effect/Filter";
+import * as Match from "effect/Match";
+import * as Option from "effect/Option";
+import * as Order from "effect/Order";
+import * as Predicate from "effect/Predicate";
+import * as Pull from "effect/Pull";
+import * as Record from "effect/Record";
+import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import * as String from "effect/String";
+import type * as Types from "effect/Types";
+import * as Document from "./Document";
+
+export const TypeId = "@confect/server/QueryStream";
+export type TypeId = typeof TypeId;
+
+// -----------------------------------------------------------------------------
+// Order keys
+// -----------------------------------------------------------------------------
+
+/**
+ * The values of a document's order-key fields: the index fields that still
+ * vary after equality pinning, plus the trailing `_id` tiebreaker. `undefined`
+ * appears for optional fields that are absent.
+ */
+export type OrderKey = ReadonlyArray<Value | undefined>;
+
+/**
+ * An element of the annotated stream: the decoded document (`None` when the
+ * element was read but filtered out — it still advances cursors) paired with
+ * its order key.
+ */
+export type Element<Doc> = readonly [Option.Option<Doc>, OrderKey];
+
+// -----------------------------------------------------------------------------
+// Typed index ranges
+// -----------------------------------------------------------------------------
+//
+// The range builder mirrors Convex's `IndexRangeBuilder`, but *consumes* the
+// index-field tuple at the type level as `eq` pins fields. The remaining
+// tuple becomes the resulting stream's order key, which is what `merge`
+// checks for compatibility.
+
+export const RangeSpecTypeId = "@confect/server/QueryStream/IndexRangeSpec";
+export type RangeSpecTypeId = typeof RangeSpecTypeId;
+
+export type RangeOp = {
+  readonly _tag: "eq" | "gt" | "gte" | "lt" | "lte";
+  readonly field: string;
+  readonly value: Value | undefined;
+};
+
+/**
+ * The result of applying a range callback: the recorded operations, plus a
+ * phantom `Remaining` — the index fields not consumed by `eq` pinning.
+ */
+export interface IndexRangeSpec<out Fields extends ReadonlyArray<string>> {
+  readonly [RangeSpecTypeId]: {
+    readonly _Remaining: Types.Covariant<Fields>;
+  };
+  readonly eqCount: number;
+  readonly ops: ReadonlyArray<RangeOp>;
+}
+
+export type AnyIndexRangeSpec = IndexRangeSpec<ReadonlyArray<string>>;
+
+export type Remaining<Spec> = Spec extends IndexRangeSpec<infer R> ? R : never;
+
+type Head<Fields extends ReadonlyArray<string>> = Fields extends readonly [
+  infer H extends string,
+  ...ReadonlyArray<string>,
+]
+  ? H
+  : never;
+
+type Tail<Fields extends ReadonlyArray<string>> = Fields extends readonly [
+  string,
+  ...infer Rest extends ReadonlyArray<string>,
+]
+  ? Rest
+  : ReadonlyArray<string>;
+
+/**
+ * A typed index-range builder. `eq` must target the next unpinned index
+ * field, and consumes it; `gt`/`gte`/`lt`/`lte` bound the next field without
+ * consuming it (bounded fields still vary within the range).
+ */
+export interface RangeBuilder<
+  ConvexDoc extends GenericDocument,
+  Fields extends ReadonlyArray<string>,
+> extends IndexRangeSpec<Fields> {
+  readonly eq: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => RangeBuilder<ConvexDoc, Tail<Fields>>;
+  readonly gt: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => LowerBoundedRange<ConvexDoc, Fields>;
+  readonly gte: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => LowerBoundedRange<ConvexDoc, Fields>;
+  readonly lt: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => IndexRangeSpec<Fields>;
+  readonly lte: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => IndexRangeSpec<Fields>;
+}
+
+/** After `gt`/`gte`, only an upper bound on the same field may follow. */
+export interface LowerBoundedRange<
+  ConvexDoc extends GenericDocument,
+  Fields extends ReadonlyArray<string>,
+> extends IndexRangeSpec<Fields> {
+  readonly lt: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => IndexRangeSpec<Fields>;
+  readonly lte: (
+    field: Head<Fields>,
+    value: FieldTypeFromFieldPath<ConvexDoc, Head<Fields>>,
+  ) => IndexRangeSpec<Fields>;
+}
+
+const makeRangeBuilder = (
+  eqCount: number,
+  ops: ReadonlyArray<RangeOp>,
+): RangeBuilder<GenericDocument, ReadonlyArray<string>> => {
+  const push =
+    (tag: RangeOp["_tag"], nextEqCount: number) =>
+    (field: string, value: Value | undefined) =>
+      makeRangeBuilder(
+        nextEqCount,
+        Array.append(ops, { _tag: tag, field, value }),
+      );
+
+  return {
+    [RangeSpecTypeId]: {
+      _Remaining: identity as Types.Covariant<ReadonlyArray<string>>,
+    },
+    eqCount,
+    ops,
+    eq: push("eq", eqCount + 1),
+    gt: push("gt", eqCount),
+    gte: push("gte", eqCount),
+    lt: push("lt", eqCount),
+    lte: push("lte", eqCount),
+  };
+};
+
+/** The initial builder handed to a range callback. */
+export const rangeBuilder = <
+  ConvexDoc extends GenericDocument,
+  Fields extends ReadonlyArray<string>,
+>(): RangeBuilder<ConvexDoc, Fields> =>
+  makeRangeBuilder(0, []) as unknown as RangeBuilder<ConvexDoc, Fields>;
+
+/** Replay a recorded range spec onto Convex's real `IndexRangeBuilder`. */
+export const applyRange = (spec: AnyIndexRangeSpec, q: any): any =>
+  Array.reduce(spec.ops, q, (builder, op) =>
+    builder[op._tag](op.field, op.value),
+  );
+
+// -----------------------------------------------------------------------------
+// Convex value ordering
+// -----------------------------------------------------------------------------
+//
+// Convex orders values first by type, then within the type:
+// undefined < null < bigint < number < boolean < string < bytes < array
+// < object. (NaN subtleties are simplified in this prototype.)
+
+type ValueType =
+  | "undefined"
+  | "null"
+  | "bigint"
+  | "number"
+  | "boolean"
+  | "string"
+  | "bytes"
+  | "array"
+  | "object";
+
+const valueType = (value: Value | undefined): ValueType =>
+  value === undefined
+    ? "undefined"
+    : value === null
+      ? "null"
+      : Predicate.isBigInt(value)
+        ? "bigint"
+        : Predicate.isNumber(value)
+          ? "number"
+          : Predicate.isBoolean(value)
+            ? "boolean"
+            : Predicate.isString(value)
+              ? "string"
+              : value instanceof ArrayBuffer
+                ? "bytes"
+                : Array.isArray(value)
+                  ? "array"
+                  : "object";
+
+const valueTypeRank: Record.ReadonlyRecord<ValueType, number> = {
+  undefined: 0,
+  null: 1,
+  bigint: 2,
+  number: 3,
+  boolean: 4,
+  string: 5,
+  bytes: 6,
+  array: 7,
+  object: 8,
+};
+
+const ByValueType: Order.Order<Value | undefined> = Order.mapInput(
+  Order.Number,
+  (value: Value | undefined) => valueTypeRank[valueType(value)],
+);
+
+const WithinValueType: Order.Order<Value | undefined> = Order.make(
+  (self, that) =>
+    // Only consulted when `ByValueType` ties, so `self` and `that` have the
+    // same `ValueType` and the per-branch casts of `that` are safe.
+    Match.value(valueType(self)).pipe(
+      Match.whenOr("undefined", "null", () => 0 as const),
+      Match.when("bigint", () => Order.BigInt(self as bigint, that as bigint)),
+      Match.when("number", () => Order.Number(self as number, that as number)),
+      Match.when("boolean", () =>
+        Order.Boolean(self as boolean, that as boolean),
+      ),
+      Match.when("string", () => Order.String(self as string, that as string)),
+      Match.when("bytes", () =>
+        BytesOrder(self as ArrayBuffer, that as ArrayBuffer),
+      ),
+      Match.when("array", () =>
+        OrderKeyOrder(
+          self as ReadonlyArray<Value>,
+          that as ReadonlyArray<Value>,
+        ),
+      ),
+      Match.when("object", () =>
+        ObjectOrder(
+          self as Record.ReadonlyRecord<string, Value>,
+          that as Record.ReadonlyRecord<string, Value>,
+        ),
+      ),
+      Match.exhaustive,
+    ),
+);
+
+/** `Order` over Convex values, matching Convex's index ordering. */
+export const ValueOrder: Order.Order<Value | undefined> = Order.combine(
+  ByValueType,
+  WithinValueType,
+);
+
+/**
+ * `Order` over order keys: lexicographic by `ValueOrder`, then by length —
+ * also the ordering of Convex array values.
+ */
+export const OrderKeyOrder: Order.Order<OrderKey> = Order.Array(ValueOrder);
+
+const BytesOrder: Order.Order<ArrayBuffer> = Order.mapInput(
+  Order.Array(Order.Number),
+  (bytes: ArrayBuffer) => Array.fromIterable(new Uint8Array(bytes)),
+);
+
+const ObjectEntryOrder = Order.Tuple([Order.String, ValueOrder]);
+
+const ObjectOrder: Order.Order<Record.ReadonlyRecord<string, Value>> =
+  Order.mapInput(Order.Array(ObjectEntryOrder), (record) =>
+    pipe(
+      Record.toEntries(record),
+      Array.sortBy(Order.mapInput(Order.String, (entry) => entry[0])),
+    ),
+  );
+
+/** Order of positions in stream order: for `desc`, later keys are smaller. */
+const PositionOrder = (order: "asc" | "desc"): Order.Order<OrderKey> =>
+  order === "asc" ? OrderKeyOrder : Order.flip(OrderKeyOrder);
+
+// -----------------------------------------------------------------------------
+// QueryStream
+// -----------------------------------------------------------------------------
+
+/**
+ * An Effect `Stream` of decoded documents in index order, carrying the order
+ * key of each element so compositions stay mergeable and paginable.
+ *
+ * `Key` is the type-level order-key witness: the index fields that still
+ * vary. Streams with different `Key`s cannot be merged (a type error), and
+ * applying a generic `Stream` combinator degrades a `QueryStream` to a plain
+ * `Stream` — which is honest: generic combinators can't maintain cursor
+ * accounting, so the result is consumable but no longer paginable.
+ */
+export class QueryStream<
+  out Doc,
+  Key extends ReadonlyArray<string> = ReadonlyArray<string>,
+  out E = never,
+  out R = never,
+> implements Stream.Stream<Doc, E, R> {
+  declare readonly _Key: (_: Key) => Key;
+
+  // The `Stream` protocol (the variance marker, `pipe`, and the `channel`
+  // the Stream runtime consumes) is implemented directly: the members are
+  // `declare`d with their real types here and wired up on the prototype
+  // below, so type-parameter inference over `QueryStream` values stays
+  // intact for every `Stream.*` combinator.
+  declare readonly [Stream.TypeId]: Stream.VarianceStruct<Doc, E, R>;
+  declare readonly pipe: Pipeable["pipe"];
+  declare readonly channel: Channel.Channel<
+    Array.NonEmptyReadonlyArray<Doc>,
+    E,
+    void,
+    unknown,
+    unknown,
+    unknown,
+    R
+  >;
+
+  constructor(
+    readonly order: "asc" | "desc",
+    /** Names of the order-key fields (runtime; ends with `_id`). */
+    readonly keyFields: ReadonlyArray<string>,
+    /** The annotated elements; `None` = read but filtered out. */
+    readonly annotated: Stream.Stream<Element<Doc>, E, R>,
+    /**
+     * Present on leaf streams only: the recipe this stream's underlying
+     * Convex query is (re)built from on every run. Derived streams
+     * (`merge`, `filterEffect`, …) don't carry one — rebuilding them would
+     * also require replaying their combinator, which is the recursive
+     * `narrow` architecture of `convex-helpers`, not yet ported.
+     */
+    readonly reflection?: Reflection,
+  ) {}
+
+  toStream(): Stream.Stream<Doc, E, R> {
+    return Stream.filterMap(
+      this.annotated,
+      Filter.fromPredicateOption(([doc, _key]) => doc),
+    );
+  }
+}
+
+const streamVariance = {
+  _R: identity,
+  _E: identity,
+  _A: identity,
+};
+
+// Runtime wiring for the `declare`d members above. This is deliberately
+// non-FP: implementing the `Streamable` protocol requires prototype-level
+// JS (an `arguments`-based `pipe`, an internal `channel` getter the Stream
+// runtime unwraps). (`prototype` is widened so the Effect language service
+// doesn't flag the `defineProperties` return value — an Effect-able — as
+// floating.)
+const queryStreamPrototype: object = QueryStream.prototype;
+
+Object.defineProperties(queryStreamPrototype, {
+  [Stream.TypeId]: { value: streamVariance },
+  pipe: {
+    value: function (this: unknown) {
+      return pipeArguments(this, arguments);
+    },
+  },
+  channel: {
+    get(this: QueryStream<unknown>) {
+      return Stream.toChannel(this.toStream());
+    },
+  },
+});
+
+export type Any = QueryStream<any, ReadonlyArray<string>, any, any>;
+
+// -----------------------------------------------------------------------------
+// Constructors
+// -----------------------------------------------------------------------------
+
+/**
+ * The subset of a Convex database reader a leaf stream needs to (re)build
+ * its query. (Method syntax keeps the parameter types bivariant, so the
+ * strongly-typed readers Confect holds assign to it structurally.)
+ */
+export interface ReflectionReader {
+  query(tableName: string): {
+    withIndex(
+      indexName: string,
+      indexRange?: (q: any) => any,
+    ): {
+      order(order: "asc" | "desc"): AsyncIterable<unknown>;
+    };
+  };
+}
+
+/**
+ * What a leaf stream stores instead of a constructed query: everything
+ * needed to rebuild `db.query(table).withIndex(index, range).order(order)`.
+ * A Convex query object is one-shot (its first iteration consumes it), so a
+ * leaf holds this *recipe* and re-executes it on every run of the stream —
+ * the Effect formulation of `convex-helpers`' `reflect()`. It is also the
+ * data a future `splitRange`-style `narrow` needs in order to rebuild the
+ * leaf with tighter index bounds instead of filtering in memory.
+ */
+export interface Reflection {
+  readonly reader: ReflectionReader;
+  readonly tableName: string;
+  readonly tableSchema: Schema.Codec<any, any>;
+  readonly indexName: string;
+  /**
+   * All of the index's fields in order, including the `_creationTime`
+   * tiebreaker (for `by_id`, just `["_id"]`).
+   */
+  readonly indexFields: ReadonlyArray<string>;
+  /** The recorded range: `eq` pins the first `spec.eqCount` index fields. */
+  readonly spec: AnyIndexRangeSpec;
+  readonly order: "asc" | "desc";
+}
+
+/** Rebuild the Convex ordered query a reflection describes. */
+const buildQuery = (reflection: Reflection): AsyncIterable<unknown> =>
+  (Array.isReadonlyArrayEmpty(reflection.spec.ops)
+    ? reflection.reader
+        .query(reflection.tableName)
+        .withIndex(reflection.indexName)
+    : reflection.reader
+        .query(reflection.tableName)
+        .withIndex(reflection.indexName, (q) => applyRange(reflection.spec, q))
+  ).order(reflection.order);
+
+/**
+ * Build a leaf `QueryStream` from reflection data. Each run of the stream
+ * rebuilds the Convex query from the reflection; order keys are extracted
+ * from the *encoded* document before schema decoding.
+ */
+export const fromReflection = <Doc>(
+  reflection: Reflection,
+): QueryStream<Doc, ReadonlyArray<string>, Document.DocumentDecodeError> => {
+  // The order key is the index fields that still vary — everything after
+  // the eq-pinned prefix — plus the implicit `_id` tiebreaker that makes
+  // order keys strictly ordered.
+  const remainingFields = Array.drop(
+    reflection.indexFields,
+    reflection.spec.eqCount,
+  );
+  const keyFields = Option.exists(
+    Array.last(remainingFields),
+    (field) => field === "_id",
+  )
+    ? remainingFields
+    : Array.append(remainingFields, "_id");
+
+  const annotated = Stream.suspend(() =>
+    Stream.fromAsyncIterable(buildQuery(reflection), identity),
+  ).pipe(
+    Stream.orDie,
+    Stream.mapEffect((encoded) =>
+      Effect.map(
+        Document.decode(reflection.tableName, reflection.tableSchema)(encoded),
+        (doc) =>
+          [
+            Option.some(doc as Doc),
+            extractOrderKey(
+              encoded as Record.ReadonlyRecord<string, unknown>,
+              keyFields,
+            ),
+          ] as const,
+      ),
+    ),
+  );
+
+  return new QueryStream(reflection.order, keyFields, annotated, reflection);
+};
+
+const extractOrderKey = (
+  encoded: Record.ReadonlyRecord<string, unknown>,
+  keyFields: ReadonlyArray<string>,
+): OrderKey =>
+  Array.map(keyFields, (fieldPath) =>
+    Array.reduce(
+      String.split(fieldPath, "."),
+      encoded as unknown,
+      (value, segment) =>
+        (value as Record.ReadonlyRecord<string, unknown> | undefined)?.[
+          segment
+        ],
+    ),
+  ) as OrderKey;
+
+// -----------------------------------------------------------------------------
+// Combinators
+// -----------------------------------------------------------------------------
+
+const keyFieldsEquivalence = Array.makeEquivalence(Equivalence.String);
+
+/**
+ * One input to a k-way merge: its pull effect, the elements pulled so far,
+ * and whether the underlying stream is exhausted.
+ */
+interface MergeSource<Doc, E> {
+  readonly pull: Pull.Pull<Array.NonEmptyReadonlyArray<Element<Doc>>, E>;
+  readonly buffer: ReadonlyArray<Element<Doc>>;
+  readonly done: boolean;
+}
+
+const makeMergeSource = <Doc, E>(
+  pull: MergeSource<Doc, E>["pull"],
+  buffer: ReadonlyArray<Element<Doc>>,
+  done: boolean,
+): MergeSource<Doc, E> => ({ pull, buffer, done });
+
+/**
+ * Refill an empty source from its pull, translating the pull's
+ * end-of-stream signal (a `Done` failure) into `done`.
+ */
+const fillMergeSource = <Doc, E>(
+  source: MergeSource<Doc, E>,
+): Effect.Effect<MergeSource<Doc, E>, E> =>
+  source.done || Array.isReadonlyArrayNonEmpty(source.buffer)
+    ? Effect.succeed(source)
+    : source.pull.pipe(
+        Effect.map((elements) => makeMergeSource(source.pull, elements, false)),
+        Pull.catchDone(() =>
+          Effect.succeed(makeMergeSource(source.pull, source.buffer, true)),
+        ),
+      );
+
+/**
+ * One step of the k-way merge as a pure unfold: fill every source, emit the
+ * earliest head (ties go to the earliest source, keeping the merge stable),
+ * and return the sources with that head consumed. `undefined` when every
+ * source is exhausted.
+ */
+const mergeStep =
+  <Doc, E>(position: Order.Order<OrderKey>) =>
+  (
+    sources: ReadonlyArray<MergeSource<Doc, E>>,
+  ): Effect.Effect<
+    readonly [Element<Doc>, ReadonlyArray<MergeSource<Doc, E>>] | undefined,
+    E
+  > =>
+    Effect.map(Effect.forEach(sources, fillMergeSource), (filled) => {
+      const isEarlier = Order.isLessThan(position);
+
+      const earliest = Array.reduce(
+        filled,
+        Option.none<readonly [number, Element<Doc>]>(),
+        (best, source, index) =>
+          Option.match(Array.head(source.buffer), {
+            onNone: () => best,
+            onSome: (head) =>
+              Option.match(best, {
+                onNone: () => Option.some([index, head] as const),
+                onSome: ([, bestElement]) =>
+                  isEarlier(head[1], bestElement[1])
+                    ? Option.some([index, head] as const)
+                    : best,
+              }),
+          }),
+      );
+
+      return Option.getOrUndefined(
+        Option.map(
+          earliest,
+          ([index, element]) =>
+            [
+              element,
+              Array.map(filled, (source, sourceIndex) =>
+                sourceIndex === index
+                  ? makeMergeSource(
+                      source.pull,
+                      Array.drop(source.buffer, 1),
+                      source.done,
+                    )
+                  : source,
+              ),
+            ] as const,
+        ),
+      );
+    });
+
+/**
+ * Merge streams ordered by the same key into one ordered stream — SQL's
+ * `UNION ALL` as a k-way ordered merge. Streams with different order keys or
+ * directions are a **type error** (`Key` is invariant); the runtime check
+ * below only guards untyped call sites.
+ */
+export const merge = <Doc, Key extends ReadonlyArray<string>, E, R>(
+  streams: readonly [
+    QueryStream<Doc, Key, E, R>,
+    ...ReadonlyArray<QueryStream<Doc, Key, E, R>>,
+  ],
+): QueryStream<Doc, Key, E, R> => {
+  const head = Array.headNonEmpty(streams);
+  const incompatible = Array.findFirst(
+    Array.tailNonEmpty(streams),
+    (stream) =>
+      stream.order !== head.order ||
+      !keyFieldsEquivalence(stream.keyFields, head.keyFields),
+  );
+  if (Option.isSome(incompatible)) {
+    throw new Error(
+      `QueryStream.merge: all streams must share an order and order-key fields (got ${head.order} [${Array.join(head.keyFields, ", ")}] and ${incompatible.value.order} [${Array.join(incompatible.value.keyFields, ", ")}])`,
+    );
+  }
+
+  const annotated: Stream.Stream<Element<Doc>, E, R> = Stream.unwrap(
+    Effect.map(
+      Effect.forEach(streams, (stream) => Stream.toPull(stream.annotated)),
+      (pulls) =>
+        Stream.unfold(
+          Array.map(pulls, (pull) =>
+            makeMergeSource<Doc, E>(pull, Array.empty(), false),
+          ),
+          mergeStep<Doc, E>(PositionOrder(head.order)),
+        ),
+    ),
+  );
+
+  return new QueryStream(head.order, head.keyFields, annotated);
+};
+
+/**
+ * Filter with an effectful predicate. Unlike `Stream.filter`, filtered-out
+ * elements still advance cursors, so the result remains paginable. The
+ * predicate's `E2`/`R2` flow into the stream's channels.
+ */
+export const filterEffect = dual<
+  <Doc, E2, R2>(
+    predicate: (doc: Doc) => Effect.Effect<boolean, E2, R2>,
+  ) => <Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc, Key, E | E2, R | R2>,
+  <Doc, Key extends ReadonlyArray<string>, E, R, E2, R2>(
+    self: QueryStream<Doc, Key, E, R>,
+    predicate: (doc: Doc) => Effect.Effect<boolean, E2, R2>,
+  ) => QueryStream<Doc, Key, E | E2, R | R2>
+>(
+  2,
+  (self, predicate) =>
+    new QueryStream(
+      self.order,
+      self.keyFields,
+      Stream.mapEffect(self.annotated, ([doc, key]) =>
+        Option.match(doc, {
+          onNone: () => Effect.succeed([Option.none<never>(), key] as const),
+          onSome: (value) =>
+            Effect.map(
+              predicate(value),
+              (keep) =>
+                [keep ? Option.some(value) : Option.none(), key] as const,
+            ),
+        }),
+      ),
+    ),
+);
+
+/**
+ * Transform elements while preserving order keys, so the result remains
+ * mergeable and paginable (unlike `Stream.mapEffect`, which degrades to a
+ * plain `Stream`). The mapper must not change the ordering semantics.
+ */
+export const mapEffect = dual<
+  <Doc, Doc2, E2, R2>(
+    f: (doc: Doc) => Effect.Effect<Doc2, E2, R2>,
+  ) => <Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc2, Key, E | E2, R | R2>,
+  <Doc, Key extends ReadonlyArray<string>, E, R, Doc2, E2, R2>(
+    self: QueryStream<Doc, Key, E, R>,
+    f: (doc: Doc) => Effect.Effect<Doc2, E2, R2>,
+  ) => QueryStream<Doc2, Key, E | E2, R | R2>
+>(
+  2,
+  (self, f) =>
+    new QueryStream(
+      self.order,
+      self.keyFields,
+      Stream.mapEffect(self.annotated, ([doc, key]) =>
+        Option.match(doc, {
+          onNone: () => Effect.succeed([Option.none<never>(), key] as const),
+          onSome: (value) =>
+            Effect.map(
+              f(value),
+              (mapped) => [Option.some(mapped), key] as const,
+            ),
+        }),
+      ),
+    ),
+);
+
+/**
+ * Restrict a stream to order keys strictly after `after` and at-or-before
+ * `until` (in stream order). Prototype: filters in memory. Production would
+ * push these bounds down into `withIndex` ranges: a leaf's `reflection`
+ * carries everything needed to rebuild it with tighter bounds
+ * (`splitRange`-style decomposition of a composite-key bound into a concat
+ * of Convex-expressible ranges); composed streams then narrow recursively,
+ * as in `convex-helpers`.
+ */
+export const narrow = dual<
+  (bounds: {
+    readonly after?: OrderKey | undefined;
+    readonly until?: OrderKey | undefined;
+  }) => <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc, Key, E, R>,
+  <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+    bounds: {
+      readonly after?: OrderKey | undefined;
+      readonly until?: OrderKey | undefined;
+    },
+  ) => QueryStream<Doc, Key, E, R>
+>(
+  2,
+  <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+    bounds: {
+      readonly after?: OrderKey | undefined;
+      readonly until?: OrderKey | undefined;
+    },
+  ) => {
+    type Narrower = (
+      annotated: Stream.Stream<Element<Doc>, E, R>,
+    ) => Stream.Stream<Element<Doc>, E, R>;
+
+    const notPast = Order.isLessThanOrEqualTo(PositionOrder(self.order));
+    const after = bounds.after;
+    const until = bounds.until;
+
+    const dropUpToAfter: Narrower =
+      after === undefined
+        ? identity
+        : Stream.dropWhile(([, key]) => notPast(key, after));
+    const takeUpToUntil: Narrower =
+      until === undefined
+        ? identity
+        : Stream.takeWhile(([, key]) => notPast(key, until));
+
+    return new QueryStream(
+      self.order,
+      self.keyFields,
+      pipe(self.annotated, dropUpToAfter, takeUpToUntil),
+    );
+  },
+);
+
+// -----------------------------------------------------------------------------
+// Sinks
+// -----------------------------------------------------------------------------
+
+export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
+  "NotUniqueError",
+  {},
+) {
+  override get message(): string {
+    return "Expected the query stream to contain at most one document";
+  }
+}
+
+/** Expect zero or one element; fail with `NotUniqueError` on two or more. */
+export const unique = <Doc, Key extends ReadonlyArray<string>, E, R>(
+  self: QueryStream<Doc, Key, E, R>,
+): Effect.Effect<Option.Option<Doc>, E | NotUniqueError, R> =>
+  self.pipe(
+    Stream.take(2),
+    Stream.runCollect,
+    Effect.flatMap((docs) =>
+      docs.length >= 2
+        ? Effect.fail(new NotUniqueError())
+        : Effect.succeed(Array.head(docs)),
+    ),
+  );
+
+// -----------------------------------------------------------------------------
+// Pagination
+// -----------------------------------------------------------------------------
+
+const UNDEFINED_SENTINEL = { $undefined: true } as const;
+
+export const serializeCursor = (key: OrderKey): string =>
+  JSON.stringify(
+    Array.map(key, (value) =>
+      value === undefined ? UNDEFINED_SENTINEL : convexToJson(value),
+    ),
+  );
+
+export const deserializeCursor = (cursor: string): OrderKey =>
+  Array.map(JSON.parse(cursor) as ReadonlyArray<unknown>, (value) =>
+    Predicate.hasProperty(value, "$undefined")
+      ? undefined
+      : jsonToConvex(value as Parameters<typeof jsonToConvex>[0]),
+  );
+
+/** The cursor denoting the end of the stream. */
+export const END_CURSOR = "[]";
+
+export interface PaginateOptions {
+  readonly numItems: number;
+  readonly cursor: string | null;
+  readonly endCursor?: string | null | undefined;
+  readonly id?: number | undefined;
+  readonly maximumRowsRead?: number | undefined;
+  readonly maximumBytesRead?: number | undefined;
+}
+
+/**
+ * `page` stays a *mutable array type* (its property is still `readonly`):
+ * paginated query handlers return this value where the Convex pagination
+ * protocol's result type is expected — `PaginationResult` from
+ * `convex/server` and the `@confect/core` `PaginationResult` schema type
+ * (`Schema.mutable(Schema.Array(...))`) both declare `page` mutable, and a
+ * `ReadonlyArray` is not assignable to a mutable array. Readonly
+ * *properties* assign to mutable ones, so everything else is `readonly`.
+ */
+export interface PaginationResult<Doc> {
+  readonly page: Doc[];
+  readonly isDone: boolean;
+  readonly continueCursor: string;
+  readonly splitCursor?: string;
+  readonly pageStatus?: "SplitRecommended" | "SplitRequired";
+}
+
+interface PaginateState<Doc> {
+  readonly page: Chunk.Chunk<Doc>;
+  readonly readKeys: Chunk.Chunk<OrderKey>;
+  readonly stopped: boolean;
+  readonly hitLimit: boolean;
+}
+
+const initialPaginateState = <Doc>(): PaginateState<Doc> => ({
+  page: Chunk.empty(),
+  readKeys: Chunk.empty(),
+  stopped: false,
+  hitLimit: false,
+});
+
+/**
+ * Consume one page of a stream. Semantics follow
+ * `convex-helpers/server/stream`:
+ *
+ * - `cursor` is exclusive, `endCursor` inclusive; when `endCursor` is set,
+ *   `numItems` is ignored and the page runs to the end cursor — the
+ *   reactive-adjacency guarantee that keeps concurrent pages gap-free.
+ * - Filtered-out elements count as read (for `maximumRowsRead`) and advance
+ *   the continue cursor.
+ */
+export const paginate = dual<
+  (
+    options: PaginateOptions,
+  ) => <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => Effect.Effect<PaginationResult<Doc>, E, R>,
+  <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+    options: PaginateOptions,
+  ) => Effect.Effect<PaginationResult<Doc>, E, R>
+>(
+  2,
+  <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+    options: PaginateOptions,
+  ) =>
+    Effect.suspend(() => {
+      if (options.numItems === 0) {
+        if (options.cursor === null) {
+          return Effect.die(
+            new Error(
+              "QueryStream.paginate: numItems of 0 with a null cursor is not supported",
+            ),
+          );
+        }
+        return Effect.succeed<PaginationResult<Doc>>({
+          page: [],
+          isDone: false,
+          continueCursor: options.cursor,
+        });
+      }
+
+      const after = Option.map(
+        Option.fromNullOr(options.cursor),
+        deserializeCursor,
+      );
+      const endCursor = Option.fromNullishOr(options.endCursor);
+      // An end cursor of `END_CURSOR` pins the page to the end of the
+      // stream rather than to a key.
+      const pinnedEnd = Option.filter(
+        endCursor,
+        (cursor) => cursor !== END_CURSOR,
+      );
+      const until = Option.map(pinnedEnd, deserializeCursor);
+      const narrowed = narrow(self, {
+        after: Option.getOrUndefined(after),
+        until: Option.getOrUndefined(until),
+      });
+      // With an endCursor the page runs to it, however many items that is.
+      const maxRows = Option.isSome(endCursor) ? undefined : options.numItems;
+      const maximumRowsRead = options.maximumRowsRead;
+
+      return Stream.run(
+        narrowed.annotated,
+        Sink.fold(
+          initialPaginateState<Doc>,
+          (state) => !state.stopped,
+          (state, [doc, key]: Element<Doc>) => {
+            const readKeys = Chunk.append(state.readKeys, key);
+            const page = Option.match(doc, {
+              onNone: () => state.page,
+              onSome: (value) => Chunk.append(state.page, value),
+            });
+            const hitLimit =
+              maximumRowsRead !== undefined &&
+              Chunk.size(readKeys) >= maximumRowsRead;
+            return Effect.succeed<PaginateState<Doc>>({
+              page,
+              readKeys,
+              hitLimit,
+              stopped:
+                hitLimit ||
+                (maxRows !== undefined && Chunk.size(page) >= maxRows),
+            });
+          },
+        ),
+      ).pipe(
+        Effect.map((state): PaginationResult<Doc> => {
+          const page = Chunk.toArray(state.page);
+          // `stopped` implies at least one element was read, so the last
+          // read key exists exactly when the fold stopped early.
+          const stoppedAt = state.stopped
+            ? Chunk.last(state.readKeys)
+            : Option.none<OrderKey>();
+          return Option.match(stoppedAt, {
+            onSome: (lastKey) =>
+              state.hitLimit
+                ? {
+                    page,
+                    isDone: false,
+                    continueCursor: serializeCursor(lastKey),
+                    pageStatus: "SplitRequired" as const,
+                    splitCursor: serializeCursor(
+                      Chunk.getUnsafe(
+                        state.readKeys,
+                        Math.floor((Chunk.size(state.readKeys) - 1) / 2),
+                      ),
+                    ),
+                  }
+                : {
+                    page,
+                    isDone: false,
+                    continueCursor: serializeCursor(lastKey),
+                  },
+            // The narrowed stream was exhausted: either we reached the
+            // pinned end cursor (more may follow it) or the true end of
+            // the stream.
+            onNone: () => ({
+              page,
+              isDone: Option.isNone(pinnedEnd),
+              continueCursor: Option.getOrElse(pinnedEnd, () => END_CURSOR),
+            }),
+          });
+        }),
+      );
+    }),
+);

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -23,8 +23,19 @@
  * - Cursors serialize only the *remaining* (order-key) fields, not the full
  *   index key — equality-pinned values never leak into cursors.
  */
-import type { GenericDocument, FieldTypeFromFieldPath } from "convex/server";
-import { convexToJson, jsonToConvex, type Value } from "convex/values";
+import type {
+  GenericDocument,
+  FieldTypeFromFieldPath,
+  PaginationOptions as ConvexPaginationOptions,
+  PaginationResult as ConvexPaginationResult,
+} from "convex/server";
+import {
+  compareValues,
+  ConvexError,
+  convexToJson,
+  jsonToConvex,
+  type Value,
+} from "convex/values";
 import { identity, dual, pipe } from "effect/Function";
 import { pipeArguments, type Pipeable } from "effect/Pipeable";
 import * as Array from "effect/Array";
@@ -33,12 +44,11 @@ import * as Chunk from "effect/Chunk";
 import * as Effect from "effect/Effect";
 import * as Equivalence from "effect/Equivalence";
 import * as Filter from "effect/Filter";
-import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
 import * as Predicate from "effect/Predicate";
 import * as Pull from "effect/Pull";
-import * as Record from "effect/Record";
+import type * as Record from "effect/Record";
 import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -200,96 +210,30 @@ export const applyRange = (spec: AnyIndexRangeSpec, q: any): any =>
     builder[op._tag](op.field, op.value),
   );
 
+/**
+ * Append the implicit `_id` tiebreaker unless the field list already ends
+ * with it — the single runtime convention for order-key and index-key
+ * field lists.
+ */
+const withIdTiebreaker = (
+  fields: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+  Option.exists(Array.last(fields), (field) => field === "_id")
+    ? fields
+    : Array.append(fields, "_id");
+
 // -----------------------------------------------------------------------------
 // Convex value ordering
 // -----------------------------------------------------------------------------
-//
-// Convex orders values first by type, then within the type:
-// undefined < null < bigint < number < boolean < string < bytes < array
-// < object. (NaN subtleties are simplified in this prototype.)
 
-type ValueType =
-  | "undefined"
-  | "null"
-  | "bigint"
-  | "number"
-  | "boolean"
-  | "string"
-  | "bytes"
-  | "array"
-  | "object";
-
-const valueType = (value: Value | undefined): ValueType =>
-  value === undefined
-    ? "undefined"
-    : value === null
-      ? "null"
-      : Predicate.isBigInt(value)
-        ? "bigint"
-        : Predicate.isNumber(value)
-          ? "number"
-          : Predicate.isBoolean(value)
-            ? "boolean"
-            : Predicate.isString(value)
-              ? "string"
-              : value instanceof ArrayBuffer
-                ? "bytes"
-                : Array.isArray(value)
-                  ? "array"
-                  : "object";
-
-const valueTypeRank: Record.ReadonlyRecord<ValueType, number> = {
-  undefined: 0,
-  null: 1,
-  bigint: 2,
-  number: 3,
-  boolean: 4,
-  string: 5,
-  bytes: 6,
-  array: 7,
-  object: 8,
-};
-
-const ByValueType: Order.Order<Value | undefined> = Order.mapInput(
-  Order.Number,
-  (value: Value | undefined) => valueTypeRank[valueType(value)],
-);
-
-const WithinValueType: Order.Order<Value | undefined> = Order.make(
-  (self, that) =>
-    // Only consulted when `ByValueType` ties, so `self` and `that` have the
-    // same `ValueType` and the per-branch casts of `that` are safe.
-    Match.value(valueType(self)).pipe(
-      Match.whenOr("undefined", "null", () => 0 as const),
-      Match.when("bigint", () => Order.BigInt(self as bigint, that as bigint)),
-      Match.when("number", () => Order.Number(self as number, that as number)),
-      Match.when("boolean", () =>
-        Order.Boolean(self as boolean, that as boolean),
-      ),
-      Match.when("string", () => Order.String(self as string, that as string)),
-      Match.when("bytes", () =>
-        BytesOrder(self as ArrayBuffer, that as ArrayBuffer),
-      ),
-      Match.when("array", () =>
-        OrderKeyOrder(
-          self as ReadonlyArray<Value>,
-          that as ReadonlyArray<Value>,
-        ),
-      ),
-      Match.when("object", () =>
-        ObjectOrder(
-          self as Record.ReadonlyRecord<string, Value>,
-          that as Record.ReadonlyRecord<string, Value>,
-        ),
-      ),
-      Match.exhaustive,
-    ),
-);
-
-/** `Order` over Convex values, matching Convex's index ordering. */
-export const ValueOrder: Order.Order<Value | undefined> = Order.combine(
-  ByValueType,
-  WithinValueType,
+/**
+ * `Order` over Convex values, matching Convex's index ordering — a wrapper
+ * around the canonical `compareValues` from `convex/values` (type rank
+ * first, then within the type, including UTF-8 string order and NaN
+ * bit-level ordering).
+ */
+export const ValueOrder: Order.Order<Value | undefined> = Order.make(
+  (self, that) => Math.sign(compareValues(self, that)) as -1 | 0 | 1,
 );
 
 /**
@@ -297,21 +241,6 @@ export const ValueOrder: Order.Order<Value | undefined> = Order.combine(
  * also the ordering of Convex array values.
  */
 export const OrderKeyOrder: Order.Order<OrderKey> = Order.Array(ValueOrder);
-
-const BytesOrder: Order.Order<ArrayBuffer> = Order.mapInput(
-  Order.Array(Order.Number),
-  (bytes: ArrayBuffer) => Array.fromIterable(new Uint8Array(bytes)),
-);
-
-const ObjectEntryOrder = Order.Tuple([Order.String, ValueOrder]);
-
-const ObjectOrder: Order.Order<Record.ReadonlyRecord<string, Value>> =
-  Order.mapInput(Order.Array(ObjectEntryOrder), (record) =>
-    pipe(
-      Record.toEntries(record),
-      Array.sortBy(Order.mapInput(Order.String, (entry) => entry[0])),
-    ),
-  );
 
 /** Order of positions in stream order: for `desc`, later keys are smaller. */
 const PositionOrder = (order: "asc" | "desc"): Order.Order<OrderKey> =>
@@ -473,19 +402,15 @@ const buildQuery = (reflection: Reflection): AsyncIterable<unknown> =>
 export const fromReflection = <Doc>(
   reflection: Reflection,
 ): QueryStream<Doc, ReadonlyArray<string>, Document.DocumentDecodeError> => {
-  // The order key is the index fields that still vary — everything after
-  // the eq-pinned prefix — plus the implicit `_id` tiebreaker that makes
-  // order keys strictly ordered.
-  const remainingFields = Array.drop(
-    reflection.indexFields,
+  // The order key is the index fields that still vary: everything after
+  // the eq-pinned prefix of the full index key (the index's fields plus
+  // the implicit `_id` tiebreaker, already explicit for `by_id`) — so a
+  // fully pinned `by_id` stream has an *empty* order key.
+  const keyFields = Array.drop(
+    withIdTiebreaker(reflection.indexFields),
     reflection.spec.eqCount,
   );
-  const keyFields = Option.exists(
-    Array.last(remainingFields),
-    (field) => field === "_id",
-  )
-    ? remainingFields
-    : Array.append(remainingFields, "_id");
+  const keyPaths = Array.map(keyFields, (field) => String.split(field, "."));
 
   const annotated = Stream.suspend(() =>
     Stream.fromAsyncIterable(buildQuery(reflection), identity),
@@ -499,7 +424,7 @@ export const fromReflection = <Doc>(
             Option.some(doc as Doc),
             extractOrderKey(
               encoded as Record.ReadonlyRecord<string, unknown>,
-              keyFields,
+              keyPaths,
             ),
           ] as const,
       ),
@@ -511,11 +436,11 @@ export const fromReflection = <Doc>(
 
 const extractOrderKey = (
   encoded: Record.ReadonlyRecord<string, unknown>,
-  keyFields: ReadonlyArray<string>,
+  keyPaths: ReadonlyArray<ReadonlyArray<string>>,
 ): OrderKey =>
-  Array.map(keyFields, (fieldPath) =>
+  Array.map(keyPaths, (path) =>
     Array.reduce(
-      String.split(fieldPath, "."),
+      path,
       encoded as unknown,
       (value, segment) =>
         (value as Record.ReadonlyRecord<string, unknown> | undefined)?.[
@@ -531,34 +456,45 @@ const extractOrderKey = (
 const keyFieldsEquivalence = Array.makeEquivalence(Equivalence.String);
 
 /**
- * One input to a k-way merge: its pull effect, the elements pulled so far,
- * and whether the underlying stream is exhausted.
+ * One input to a k-way merge: its pull effect, the last pulled chunk with a
+ * read index into it (an index rather than re-slicing keeps consuming a
+ * chunk linear), and whether the underlying stream is exhausted.
  */
 interface MergeSource<Doc, E> {
   readonly pull: Pull.Pull<Array.NonEmptyReadonlyArray<Element<Doc>>, E>;
   readonly buffer: ReadonlyArray<Element<Doc>>;
+  readonly index: number;
   readonly done: boolean;
 }
 
 const makeMergeSource = <Doc, E>(
   pull: MergeSource<Doc, E>["pull"],
   buffer: ReadonlyArray<Element<Doc>>,
+  index: number,
   done: boolean,
-): MergeSource<Doc, E> => ({ pull, buffer, done });
+): MergeSource<Doc, E> => ({ pull, buffer, index, done });
+
+const mergeSourceHead = <Doc, E>(
+  source: MergeSource<Doc, E>,
+): Option.Option<Element<Doc>> => Array.get(source.buffer, source.index);
 
 /**
- * Refill an empty source from its pull, translating the pull's
+ * Refill an exhausted-buffer source from its pull, translating the pull's
  * end-of-stream signal (a `Done` failure) into `done`.
  */
 const fillMergeSource = <Doc, E>(
   source: MergeSource<Doc, E>,
 ): Effect.Effect<MergeSource<Doc, E>, E> =>
-  source.done || Array.isReadonlyArrayNonEmpty(source.buffer)
+  source.done || source.index < source.buffer.length
     ? Effect.succeed(source)
     : source.pull.pipe(
-        Effect.map((elements) => makeMergeSource(source.pull, elements, false)),
+        Effect.map((elements) =>
+          makeMergeSource(source.pull, elements, 0, false),
+        ),
         Pull.catchDone(() =>
-          Effect.succeed(makeMergeSource(source.pull, source.buffer, true)),
+          Effect.succeed(
+            makeMergeSource(source.pull, source.buffer, source.index, true),
+          ),
         ),
       );
 
@@ -576,51 +512,56 @@ const mergeStep =
     readonly [Element<Doc>, ReadonlyArray<MergeSource<Doc, E>>] | undefined,
     E
   > =>
-    Effect.map(Effect.forEach(sources, fillMergeSource), (filled) => {
-      const isEarlier = Order.isLessThan(position);
+    Effect.map(
+      Effect.forEach(sources, fillMergeSource, { concurrency: "unbounded" }),
+      (filled) => {
+        const isEarlier = Order.isLessThan(position);
 
-      const earliest = Array.reduce(
-        filled,
-        Option.none<readonly [number, Element<Doc>]>(),
-        (best, source, index) =>
-          Option.match(Array.head(source.buffer), {
-            onNone: () => best,
-            onSome: (head) =>
-              Option.match(best, {
-                onNone: () => Option.some([index, head] as const),
-                onSome: ([, bestElement]) =>
-                  isEarlier(head[1], bestElement[1])
-                    ? Option.some([index, head] as const)
-                    : best,
-              }),
-          }),
-      );
+        const earliest = Array.reduce(
+          filled,
+          Option.none<readonly [number, Element<Doc>]>(),
+          (best, source, index) =>
+            Option.match(mergeSourceHead(source), {
+              onNone: () => best,
+              onSome: (head) =>
+                Option.match(best, {
+                  onNone: () => Option.some([index, head] as const),
+                  onSome: ([, bestElement]) =>
+                    isEarlier(head[1], bestElement[1])
+                      ? Option.some([index, head] as const)
+                      : best,
+                }),
+            }),
+        );
 
-      return Option.getOrUndefined(
-        Option.map(
-          earliest,
-          ([index, element]) =>
-            [
-              element,
-              Array.map(filled, (source, sourceIndex) =>
-                sourceIndex === index
-                  ? makeMergeSource(
-                      source.pull,
-                      Array.drop(source.buffer, 1),
-                      source.done,
-                    )
-                  : source,
-              ),
-            ] as const,
-        ),
-      );
-    });
+        return Option.getOrUndefined(
+          Option.map(
+            earliest,
+            ([index, element]) =>
+              [
+                element,
+                Array.map(filled, (source, sourceIndex) =>
+                  sourceIndex === index
+                    ? makeMergeSource(
+                        source.pull,
+                        source.buffer,
+                        source.index + 1,
+                        source.done,
+                      )
+                    : source,
+                ),
+              ] as const,
+          ),
+        );
+      },
+    );
 
 /**
  * Merge streams ordered by the same key into one ordered stream — SQL's
- * `UNION ALL` as a k-way ordered merge. Streams with different order keys or
- * directions are a **type error** (`Key` is invariant); the runtime check
- * below only guards untyped call sites.
+ * `UNION ALL` as a k-way ordered merge. Streams with different order keys
+ * are a **type error** (`Key` is invariant); the order *direction* is not
+ * part of the type, so a direction mismatch — like a key mismatch from an
+ * untyped call site — is caught by the runtime check below.
  */
 export const merge = <Doc, Key extends ReadonlyArray<string>, E, R>(
   streams: readonly [
@@ -647,7 +588,7 @@ export const merge = <Doc, Key extends ReadonlyArray<string>, E, R>(
       (pulls) =>
         Stream.unfold(
           Array.map(pulls, (pull) =>
-            makeMergeSource<Doc, E>(pull, Array.empty(), false),
+            makeMergeSource<Doc, E>(pull, Array.empty(), 0, false),
           ),
           mergeStep<Doc, E>(PositionOrder(head.order)),
         ),
@@ -816,6 +757,14 @@ export const unique = <Doc, Key extends ReadonlyArray<string>, E, R>(
 
 const UNDEFINED_SENTINEL = { $undefined: true } as const;
 
+/**
+ * Serialize an order key as a cursor. Unlike the built-in Convex pagination
+ * cursors (opaque tokens), these carry the raw order-key *values* — they are
+ * delivered to clients in `continueCursor`/`splitCursor`, so a stream whose
+ * remaining order key includes a sensitive indexed field exposes that
+ * field's values at page boundaries. Pin such fields with `eq`, or don't
+ * paginate over them publicly, until cursors are made opaque.
+ */
 export const serializeCursor = (key: OrderKey): string =>
   JSON.stringify(
     Array.map(key, (value) =>
@@ -830,34 +779,63 @@ export const deserializeCursor = (cursor: string): OrderKey =>
       : jsonToConvex(value as Parameters<typeof jsonToConvex>[0]),
   );
 
+/**
+ * The error a stream-paginated query fails with when a client-supplied
+ * cursor is malformed or no longer matches the stream's order-key shape —
+ * the `paginationError: "InvalidCursor"` form `convex/react` (and
+ * `useStreamPaginatedQuery`) recognize as "reset pagination" rather than an
+ * application failure.
+ */
+const invalidCursorError = () =>
+  new ConvexError({ paginationError: "InvalidCursor" });
+
+/**
+ * Parse and validate a client-supplied cursor against the stream's
+ * order-key arity, throwing the `InvalidCursor` `ConvexError` on any
+ * mismatch (malformed JSON, a non-array, or a stale cursor serialized under
+ * a different stream shape).
+ */
+const deserializeCursorChecked = (
+  cursor: string,
+  keyFieldCount: number,
+): OrderKey => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cursor);
+  } catch {
+    throw invalidCursorError();
+  }
+  if (!globalThis.Array.isArray(parsed) || parsed.length !== keyFieldCount) {
+    throw invalidCursorError();
+  }
+  try {
+    return Array.map(parsed as ReadonlyArray<unknown>, (value) =>
+      Predicate.hasProperty(value, "$undefined")
+        ? undefined
+        : jsonToConvex(value as Parameters<typeof jsonToConvex>[0]),
+    );
+  } catch {
+    throw invalidCursorError();
+  }
+};
+
 /** The cursor denoting the end of the stream. */
 export const END_CURSOR = "[]";
 
-export interface PaginateOptions {
-  readonly numItems: number;
-  readonly cursor: string | null;
-  readonly endCursor?: string | null | undefined;
-  readonly id?: number | undefined;
-  readonly maximumRowsRead?: number | undefined;
-  readonly maximumBytesRead?: number | undefined;
-}
+/**
+ * The pagination protocol's request options — `PaginationOptions` from
+ * `convex/server`, aliased so the wire protocol has a single source of
+ * truth (`@confect/core`'s `PaginationOptions` schema encodes the same
+ * shape).
+ */
+export type PaginateOptions = ConvexPaginationOptions;
 
 /**
- * `page` stays a *mutable array type* (its property is still `readonly`):
- * paginated query handlers return this value where the Convex pagination
- * protocol's result type is expected — `PaginationResult` from
- * `convex/server` and the `@confect/core` `PaginationResult` schema type
- * (`Schema.mutable(Schema.Array(...))`) both declare `page` mutable, and a
- * `ReadonlyArray` is not assignable to a mutable array. Readonly
- * *properties* assign to mutable ones, so everything else is `readonly`.
+ * The pagination protocol's result — `PaginationResult` from
+ * `convex/server` (whose `page` is a mutable array type, which is why
+ * handlers can return this value where Convex expects its result shape).
  */
-export interface PaginationResult<Doc> {
-  readonly page: Doc[];
-  readonly isDone: boolean;
-  readonly continueCursor: string;
-  readonly splitCursor?: string;
-  readonly pageStatus?: "SplitRecommended" | "SplitRequired";
-}
+export type PaginationResult<Doc> = ConvexPaginationResult<Doc>;
 
 interface PaginateState<Doc> {
   readonly page: Chunk.Chunk<Doc>;
@@ -872,6 +850,12 @@ const initialPaginateState = <Doc>(): PaginateState<Doc> => ({
   stopped: false,
   hitLimit: false,
 });
+
+/** Where a split page divides: the midpoint of the keys read so far. */
+const midpointCursor = (readKeys: Chunk.Chunk<OrderKey>): string =>
+  serializeCursor(
+    Chunk.getUnsafe(readKeys, Math.floor((Chunk.size(readKeys) - 1) / 2)),
+  );
 
 /**
  * Consume one page of a stream. Semantics follow
@@ -915,9 +899,8 @@ export const paginate = dual<
         });
       }
 
-      const after = Option.map(
-        Option.fromNullOr(options.cursor),
-        deserializeCursor,
+      const after = Option.map(Option.fromNullOr(options.cursor), (cursor) =>
+        deserializeCursorChecked(cursor, self.keyFields.length),
       );
       const endCursor = Option.fromNullishOr(options.endCursor);
       // An end cursor of `END_CURSOR` pins the page to the end of the
@@ -926,7 +909,9 @@ export const paginate = dual<
         endCursor,
         (cursor) => cursor !== END_CURSOR,
       );
-      const until = Option.map(pinnedEnd, deserializeCursor);
+      const until = Option.map(pinnedEnd, (cursor) =>
+        deserializeCursorChecked(cursor, self.keyFields.length),
+      );
       const narrowed = narrow(self, {
         after: Option.getOrUndefined(after),
         until: Option.getOrUndefined(until),
@@ -975,12 +960,7 @@ export const paginate = dual<
                     isDone: false,
                     continueCursor: serializeCursor(lastKey),
                     pageStatus: "SplitRequired" as const,
-                    splitCursor: serializeCursor(
-                      Chunk.getUnsafe(
-                        state.readKeys,
-                        Math.floor((Chunk.size(state.readKeys) - 1) / 2),
-                      ),
-                    ),
+                    splitCursor: midpointCursor(state.readKeys),
                   }
                 : {
                     page,

--- a/packages/server/src/RegisteredFunction.ts
+++ b/packages/server/src/RegisteredFunction.ts
@@ -187,6 +187,12 @@ export const combineErrorSchemas = (
  * error channel—reaches the client as a `ConvexError`. The fiber dies and
  * `runPromise` rejects with a generic failure.
  *
+ * Either way, a `ConvexError` *defect* — thrown imperatively rather than
+ * placed in the error channel, e.g. the pagination protocol's
+ * `InvalidCursor` signal from `QueryStream.paginate` — is rethrown bare so
+ * it retains its identity and Convex serializes its `data` to the client,
+ * matching how a thrown `ConvexError` behaves in a plain Convex handler.
+ *
  * A `scheduler` in `runOptions` must be passed here as a run option rather
  * than provided via `Effect.provideService` inside `effect`: the run option
  * lands in the fiber's root context, while a service provided within `effect`
@@ -202,21 +208,33 @@ export const runHandlerPromise =
     },
   ) =>
   <A, E>(effect: Effect.Effect<A, E>): Promise<A> => {
-    if (errorSchema === undefined) {
-      return Effect.runPromise(Effect.orDie(effect), runOptions);
-    }
-    const withConvexError = effect.pipe(
-      Effect.catch((typedError) =>
-        pipe(
-          Schema.encodeEffect(errorSchema)(typedError),
-          Effect.orDie,
-          Effect.andThen((encodedError) =>
-            Effect.fail(new ConvexError(encodedError)),
-          ),
-        ),
-      ),
+    // A `ConvexError` defect escapes into the (escaped) failure channel so
+    // the `throw` below rethrows it with its identity intact.
+    const rethrowConvexErrorDefects = Effect.catchDefect(
+      (defect: unknown): Effect.Effect<never, ConvexError<any>> =>
+        defect instanceof ConvexError
+          ? Effect.fail(defect)
+          : Effect.die(defect),
     );
-    return Effect.runPromise(Effect.result(withConvexError), runOptions).then(
+
+    const withConvexError =
+      errorSchema === undefined
+        ? Effect.orDie(effect)
+        : effect.pipe(
+            Effect.catch((typedError) =>
+              pipe(
+                Schema.encodeEffect(errorSchema)(typedError),
+                Effect.orDie,
+                Effect.andThen((encodedError) =>
+                  Effect.fail(new ConvexError(encodedError)),
+                ),
+              ),
+            ),
+          );
+    return Effect.runPromise(
+      Effect.result(rethrowConvexErrorDefects(withConvexError)),
+      runOptions,
+    ).then(
       Result.match({
         onFailure: (error) => {
           throw error;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -25,6 +25,7 @@ export * as OrderedQuery from "./OrderedQuery";
 export * as QueryCtx from "./QueryCtx";
 export * as QueryInitializer from "./QueryInitializer";
 export * as QueryRunner from "./QueryRunner";
+export * as QueryStream from "./QueryStream";
 export * as RegisteredConvexFunction from "./RegisteredConvexFunction";
 export * as RegisteredFunction from "./RegisteredFunction";
 export * as RegisteredFunctions from "./RegisteredFunctions";

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -1,0 +1,487 @@
+import { type Document, QueryStream } from "@confect/server";
+import { describe, expect, expectTypeOf, it } from "@effect/vitest";
+import { assertEquals } from "@effect/vitest/utils";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import * as Stream from "effect/Stream";
+import {
+  DatabaseReader,
+  DatabaseWriter,
+} from "./fixtures/confect/_generated/services";
+import * as TestConfect from "./TestConfect";
+
+const collectTexts = <E, R>(
+  stream: Stream.Stream<{ text: string }, E, R>,
+): Effect.Effect<ReadonlyArray<string>, E, R> =>
+  Stream.runCollect(stream).pipe(
+    Effect.map((docs) => docs.map((doc) => doc.text)),
+  );
+
+const insertNotes = (texts: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const writer = yield* DatabaseWriter;
+
+    yield* Effect.forEach(texts, (text) =>
+      writer.table("notes").insert({ text }),
+    );
+  });
+
+describe("QueryStream", () => {
+  it.effect("emits documents in index order", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["banana", "apple", "cherry"]);
+
+          const reader = yield* DatabaseReader;
+
+          const ascending = yield* collectTexts(
+            reader.table("notes").stream("by_text"),
+          );
+          expect(ascending).toEqual(["apple", "banana", "cherry"]);
+
+          const descending = yield* collectTexts(
+            reader.table("notes").stream("by_text", "desc"),
+          );
+          expect(descending).toEqual(["cherry", "banana", "apple"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("is a reusable description backed by leaf reflection", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["banana", "apple"]);
+
+          const reader = yield* DatabaseReader;
+
+          const stream = reader
+            .table("notes")
+            .stream("by_text", (q) => q.gte("text", "a"));
+
+          // The leaf stores the query recipe, not a (one-shot) Convex
+          // query object…
+          expect(stream.reflection?.tableName).toBe("notes");
+          expect(stream.reflection?.indexName).toBe("by_text");
+          expect(stream.reflection?.indexFields).toEqual([
+            "text",
+            "_creationTime",
+          ]);
+          expect(stream.reflection?.spec.eqCount).toBe(0);
+          expect(stream.reflection?.spec.ops).toEqual([
+            { _tag: "gte", field: "text", value: "a" },
+          ]);
+
+          // …so one stream value can be run any number of times.
+          const first = yield* collectTexts(stream);
+          const second = yield* collectTexts(stream);
+          expect(first).toEqual(["apple", "banana"]);
+          expect(second).toEqual(first);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("supports plain Stream combinators", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["banana", "apple", "cherry"]);
+
+          const reader = yield* DatabaseReader;
+
+          const firstTwo = yield* reader
+            .table("notes")
+            .stream("by_text")
+            .pipe(
+              Stream.map((note) => note.text),
+              Stream.take(2),
+              Stream.runCollect,
+            );
+          expect(firstTwo).toEqual(["apple", "banana"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("applies typed index range bounds", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["banana", "apple", "cherry"]);
+
+          const reader = yield* DatabaseReader;
+
+          const fromB = yield* collectTexts(
+            reader.table("notes").stream("by_text", (q) => q.gte("text", "b")),
+          );
+          expect(fromB).toEqual(["banana", "cherry"]);
+
+          const bOnly = yield* collectTexts(
+            reader
+              .table("notes")
+              .stream("by_text", (q) => q.gte("text", "b").lt("text", "c")),
+          );
+          expect(bOnly).toEqual(["banana"]);
+
+          const exactly = yield* collectTexts(
+            reader
+              .table("notes")
+              .stream("by_text", (q) => q.eq("text", "apple")),
+          );
+          expect(exactly).toEqual(["apple"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("merge interleaves streams in order-key order", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          // Insertion order fixes `_creationTime` order (convex-test bumps
+          // the clock on collisions), so the merged sequence is exactly the
+          // alternating insertion order.
+          for (const [text, tag] of [
+            ["a", "1"],
+            ["b", "2"],
+            ["a", "3"],
+            ["b", "4"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const streamFor = (text: string, order: "asc" | "desc") =>
+            reader
+              .table("notes")
+              .stream("by_text", (q) => q.eq("text", text), order);
+
+          const merged = QueryStream.merge([
+            streamFor("a", "asc"),
+            streamFor("b", "asc"),
+          ]);
+          const tags = yield* Stream.runCollect(merged).pipe(
+            Effect.map((docs) => docs.map((doc) => doc.tag)),
+          );
+          expect(tags).toEqual(["1", "2", "3", "4"]);
+
+          const mergedDesc = QueryStream.merge([
+            streamFor("a", "desc"),
+            streamFor("b", "desc"),
+          ]);
+          const tagsDesc = yield* Stream.runCollect(mergedDesc).pipe(
+            Effect.map((docs) => docs.map((doc) => doc.tag)),
+          );
+          expect(tagsDesc).toEqual(["4", "3", "2", "1"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("filterEffect filters with an effectful predicate", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["banana", "apple", "cherry"]);
+
+          const reader = yield* DatabaseReader;
+
+          const filtered = yield* collectTexts(
+            reader
+              .table("notes")
+              .stream("by_text")
+              .pipe(
+                QueryStream.filterEffect((note) =>
+                  Effect.succeed(note.text !== "banana"),
+                ),
+              ),
+          );
+          expect(filtered).toEqual(["apple", "cherry"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("paginates a merged, filtered stream with cursors", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          for (const [text, tag] of [
+            ["a", "1"],
+            ["b", "2"],
+            ["a", "3"],
+            ["b", "4"],
+            ["a", "5"],
+            ["b", "6"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          // One stream value serves every page: a QueryStream is a
+          // description, and leaves rebuild their (one-shot) Convex query
+          // from stored reflection data on each run.
+          const composed = QueryStream.merge([
+            reader.table("notes").stream("by_text", (q) => q.eq("text", "a")),
+            reader.table("notes").stream("by_text", (q) => q.eq("text", "b")),
+          ]).pipe(
+            QueryStream.filterEffect((note) =>
+              Effect.succeed(note.tag !== "3"),
+            ),
+          );
+
+          const tagsOf = (page: ReadonlyArray<{ tag?: string }>) =>
+            page.map((doc) => doc.tag);
+
+          const page1 = yield* QueryStream.paginate(composed, {
+            numItems: 2,
+            cursor: null,
+          });
+          expect(tagsOf(page1.page)).toEqual(["1", "2"]);
+          assertEquals(page1.isDone, false);
+
+          // The second page starts after the first page's cursor and skips
+          // the filtered-out element (which still advanced the cursor).
+          const page2 = yield* QueryStream.paginate(composed, {
+            numItems: 2,
+            cursor: page1.continueCursor,
+          });
+          expect(tagsOf(page2.page)).toEqual(["4", "5"]);
+          assertEquals(page2.isDone, false);
+
+          const page3 = yield* QueryStream.paginate(composed, {
+            numItems: 2,
+            cursor: page2.continueCursor,
+          });
+          expect(tagsOf(page3.page)).toEqual(["6"]);
+          assertEquals(page3.isDone, true);
+          assertEquals(page3.continueCursor, QueryStream.END_CURSOR);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("paginate honors endCursor for gap-free adjacent pages", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["a", "b", "c", "d"]);
+
+          const reader = yield* DatabaseReader;
+          const stream = reader.table("notes").stream("by_text");
+
+          const page1 = yield* QueryStream.paginate(stream, {
+            numItems: 2,
+            cursor: null,
+          });
+          expect(page1.page.map((doc) => doc.text)).toEqual(["a", "b"]);
+
+          // Re-request the same page pinned to its end cursor: `numItems`
+          // is ignored and the page runs exactly to the pinned endpoint —
+          // the range-defined page the reactive pagination articles call
+          // for.
+          const pinned = yield* QueryStream.paginate(stream, {
+            numItems: 1,
+            cursor: null,
+            endCursor: page1.continueCursor,
+          });
+          expect(pinned.page.map((doc) => doc.text)).toEqual(["a", "b"]);
+          assertEquals(pinned.isDone, false);
+          assertEquals(pinned.continueCursor, page1.continueCursor);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("paginate reports SplitRequired when maximumRowsRead is hit", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["a", "b", "c", "d"]);
+
+          const reader = yield* DatabaseReader;
+
+          const result = yield* QueryStream.paginate(
+            reader
+              .table("notes")
+              .stream("by_text")
+              .pipe(QueryStream.filterEffect(() => Effect.succeed(false))),
+            { numItems: 3, cursor: null, maximumRowsRead: 2 },
+          );
+
+          assertEquals(result.page.length, 0);
+          assertEquals(result.isDone, false);
+          assertEquals(result.pageStatus, "SplitRequired");
+          expect(result.splitCursor).toBeDefined();
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("unique succeeds on zero or one and fails on two", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["apple", "banana", "banana"]);
+
+          const reader = yield* DatabaseReader;
+          const byText = (text: string) =>
+            reader.table("notes").stream("by_text", (q) => q.eq("text", text));
+
+          const none = yield* QueryStream.unique(byText("missing"));
+          assertEquals(Option.isNone(none), true);
+
+          const one = yield* QueryStream.unique(byText("apple"));
+          assertEquals(
+            Option.map(one, (doc) => doc.text),
+            Option.some("apple"),
+          );
+
+          const two = yield* Effect.result(
+            QueryStream.unique(byText("banana")),
+          );
+          assertEquals(
+            Result.match(two, {
+              onFailure: (error) => error._tag,
+              onSuccess: () => "unexpected success",
+            }),
+            "NotUniqueError",
+          );
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+});
+
+describe("QueryStream types", () => {
+  type KeyOf<S> =
+    S extends QueryStream.QueryStream<
+      any,
+      infer K extends ReadonlyArray<string>,
+      any,
+      any
+    >
+      ? K
+      : never;
+
+  class SomeService extends Context.Service<
+    SomeService,
+    { readonly check: (text: string) => Effect.Effect<boolean> }
+  >()("@confect/server/test/mock-backend/queryStream.test/SomeService") {}
+
+  it("infers the remaining order key from eq pinning", () => {
+    const _typeChecks = Effect.gen(function* () {
+      const reader = yield* DatabaseReader;
+
+      const full = reader.table("notes").stream("by_text");
+      expectTypeOf<KeyOf<typeof full>>().toEqualTypeOf<
+        ["text", "_creationTime"]
+      >();
+
+      const pinned = reader
+        .table("notes")
+        .stream("by_text", (q) => q.eq("text", "x"));
+      expectTypeOf<KeyOf<typeof pinned>>().toEqualTypeOf<["_creationTime"]>();
+
+      // Bounded fields still vary, so they are not consumed.
+      const bounded = reader
+        .table("notes")
+        .stream("by_text", (q) => q.gte("text", "a"));
+      expectTypeOf<KeyOf<typeof bounded>>().toEqualTypeOf<
+        ["text", "_creationTime"]
+      >();
+
+      const byCreationTime = reader.table("notes").stream("by_creation_time");
+      expectTypeOf<KeyOf<typeof byCreationTime>>().toEqualTypeOf<
+        ["_creationTime"]
+      >();
+
+      // A QueryStream is a genuine Stream…
+      const asStream: Stream.Stream<
+        { text: string },
+        Document.DocumentDecodeError
+      > = pinned;
+      void asStream;
+
+      // …and generic Stream combinators degrade it to a plain Stream.
+      const degraded = Stream.map(pinned, (note) => note.text);
+      expectTypeOf<typeof degraded>().toEqualTypeOf<
+        Stream.Stream<string, Document.DocumentDecodeError>
+      >();
+
+      // Streams pinned the same way merge; the pinned values may differ.
+      const mergedPinned = QueryStream.merge([pinned, pinned]);
+      void mergedPinned;
+      // Streams over the same index remain mergeable with
+      // `by_creation_time` streams: both are ordered by the same remaining
+      // key.
+      const mergedAcrossIndexes = QueryStream.merge([pinned, byCreationTime]);
+      void mergedAcrossIndexes;
+
+      // @ts-expect-error — order keys differ: ["text", "_creationTime"]
+      const mergedMismatched = QueryStream.merge([pinned, full]);
+      void mergedMismatched;
+
+      const wrongField = reader
+        .table("notes")
+        // @ts-expect-error — `eq` must target the next index field.
+        .stream("by_text", (q) => q.eq("tag", "x"));
+      void wrongField;
+
+      const wrongValue = reader
+        .table("notes")
+        // @ts-expect-error — the value must match the field's type.
+        .stream("by_text", (q) => q.eq("text", 42));
+      void wrongValue;
+
+      const afterBound = reader.table("notes").stream("by_text", (q) => {
+        const lowerBounded = q.gte("text", "a");
+        // @ts-expect-error — after a lower bound, `eq` is gone.
+        void lowerBounded.eq;
+        return lowerBounded;
+      });
+      void afterBound;
+
+      // The predicate's error and requirement channels surface in the
+      // stream's channels.
+      const filtered = QueryStream.filterEffect(pinned, (note) =>
+        Effect.flatMap(SomeService, (service) => service.check(note.text)),
+      );
+      expectTypeOf<
+        typeof filtered extends QueryStream.QueryStream<any, any, any, infer R>
+          ? R
+          : never
+      >().toEqualTypeOf<SomeService>();
+    });
+    void _typeChecks;
+  });
+});

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -1,9 +1,10 @@
 import { type Document, QueryStream } from "@confect/server";
-import { describe, expect, expectTypeOf, it } from "@effect/vitest";
+import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { assertEquals } from "@effect/vitest/utils";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
 import * as Result from "effect/Result";
 import * as Stream from "effect/Stream";
 import {
@@ -340,6 +341,37 @@ describe("QueryStream", () => {
           assertEquals(result.isDone, false);
           assertEquals(result.pageStatus, "SplitRequired");
           expect(result.splitCursor).toBeDefined();
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("fails with the InvalidCursor signal on a malformed cursor", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["a"]);
+
+          const reader = yield* DatabaseReader;
+          const stream = reader.table("notes").stream("by_text");
+
+          const fromCursor = (cursor: string) =>
+            QueryStream.paginate(stream, { numItems: 1, cursor }).pipe(
+              Effect.catchDefect((defect) => Effect.succeed(defect)),
+            );
+
+          // Malformed JSON, and a stale cursor with the wrong key arity
+          // (`by_text` keys have three components: text, _creationTime,
+          // _id).
+          for (const cursor of ["_notjson", "[1, 2]"]) {
+            const defect = yield* fromCursor(cursor);
+            assert(Predicate.hasProperty(defect, "data"));
+            expect(
+              (defect.data as { paginationError?: string }).paginationError,
+            ).toBe("InvalidCursor");
+          }
         }),
       );
     }).pipe(Effect.provide(TestConfect.layer)),

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -377,6 +377,42 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
+  it.effect("filter and map keep the stream paginable", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["a", "b", "c", "d"]);
+
+          const reader = yield* DatabaseReader;
+
+          const shouted = reader
+            .table("notes")
+            .stream("by_text")
+            .pipe(
+              QueryStream.filter((note) => note.text !== "b"),
+              QueryStream.map((note) => note.text.toUpperCase()),
+            );
+
+          const page1 = yield* QueryStream.paginate(shouted, {
+            numItems: 2,
+            cursor: null,
+          });
+          expect(page1.page).toEqual(["A", "C"]);
+
+          // The filtered-out "b" still advanced the cursor.
+          const page2 = yield* QueryStream.paginate(shouted, {
+            numItems: 2,
+            cursor: page1.continueCursor,
+          });
+          expect(page2.page).toEqual(["D"]);
+          assertEquals(page2.isDone, true);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
   it.effect("unique succeeds on zero or one and fails on two", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
@@ -502,6 +538,23 @@ describe("QueryStream types", () => {
         return lowerBounded;
       });
       void afterBound;
+
+      // Pure `filter`/`map` keep the order key and leave E/R untouched.
+      const pureFiltered = QueryStream.filter(
+        pinned,
+        (note) => note.text !== "",
+      );
+      expectTypeOf<KeyOf<typeof pureFiltered>>().toEqualTypeOf<
+        ["_creationTime"]
+      >();
+      const pureMapped = QueryStream.map(pinned, (note) => note.text);
+      expectTypeOf<typeof pureMapped>().toEqualTypeOf<
+        QueryStream.QueryStream<
+          string,
+          ["_creationTime"],
+          Document.DocumentDecodeError
+        >
+      >();
 
       // The predicate's error and requirement channels surface in the
       // stream's channels.


### PR DESCRIPTION
**Stack 1/8** — **QueryStream core** · [2: push-down narrow (#598)] · [3: flatMap/distinct/orderBy (#599)] · [4: useStreamPaginatedQuery (#600)] · [5: example feed (#601)] · [6: maximumBytesRead (#636)] · [7: Foldkit pinning (#637)] · [8: docs (#634)]

> **Now based on `v10` (Effect v4).** The stack was rebuilt on the `v10` prerelease branch and ported to `effect@4.0.0-rc.112`: the class implements the v4 `Stream` protocol (variance marker, `pipe`, `channel`) directly, the k-way merge consumes v4 pulls (end-of-stream via `Cause.Done`), pagination folds through `Sink.fold`, and value ordering uses the renamed `Order` instances. The original exploration's incremental history (thunk leaves → reflection → Effect-native internals) is squashed into one commit here, since porting each intermediate state to v4 would have added noise without review value.

Introduces `QueryStream`, an experimental stream-first querying API for `@confect/server`, plus the design doc (`notes/stream-based-querying.md`) that motivates it and records the design decisions and open questions.

## What's in this layer

- `reader.table(...).stream(index, range?, order?)` on `QueryInitializer` — returns a `QueryStream` that is a genuine Effect `Stream` (all `Stream.*` combinators work on it) while carrying the metadata needed for pagination.
- **Type-level order keys**: `Key` is the tuple of index fields remaining after `.eq(...)` pinning in the typed range builder. `QueryStream.merge` requires all inputs to share a `Key`, so merging incompatible streams is a compile error.
- Combinators that preserve paginability: `merge` (k-way ordered interleave), `filter` / `map` and their effectful forms `filterEffect` / `mapEffect` (for predicates and mappers that read the database or use a service), `unique`, and `paginate` — which speaks the Convex pagination protocol (cursors, `endCursor` pinning for gap-free reactive pages, `maximumRowsRead` → `SplitRequired`).
- Leaves are built from **reflection data** (reader + table + index + range spec + order) rather than a captured query thunk, so downstream layers can rebuild leaf queries with tightened bounds.
- Value ordering (`ValueOrder`) wraps `compareValues` from `convex/values`, so it matches Convex's index ordering exactly.
- The layer's code-review commit adds cursor validation with the `InvalidCursor` `ConvexError` (and handlers rethrowing `ConvexError` defects bare — its own patch changeset, since it affects every handler), concurrent index-based merge refills, `convex/server` protocol type aliases, and loud failure on unknown index names.

## Verification

- Mock-backend integration tests for this layer: ordering, merge asc/desc, filtering (pure and effectful), cursor-chained pagination, endCursor pinning, `SplitRequired`, invalid-cursor signalling, plus type-level tests (merge key mismatch, range-builder misuse, E/R propagation, pure `filter`/`map` leaving E/R untouched).
- Full `pnpm check` and all suites green at this commit on `v10`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m