### PR TITLE
Stream-first querying: flatMap, distinct, orderBy

### DIFF
--- a/.changeset/stream-querying-combinators.md
+++ b/.changeset/stream-querying-combinators.md
@@ -6,4 +6,4 @@ Add three combinators to `QueryStream`:
 
 - `QueryStream.flatMap` joins each document to an inner stream (e.g. each author to their messages), concatenating the order keys in the type system so the joined stream stays mergeable and paginable.
 - `QueryStream.distinct` emits the first document of each group of consecutive equal order-key prefixes, reading via a loose index scan (one indexed read per group) rather than scanning every row. The requested prefix must be a prefix of the stream's order key, enforced at the type level.
-- `QueryStream.orderBy` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged. A `flatMap` result cannot be relabeled; relabel its inputs before joining.
+- `QueryStream.orderBy` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged.

--- a/.changeset/stream-querying-combinators.md
+++ b/.changeset/stream-querying-combinators.md
@@ -6,4 +6,4 @@ Add three combinators to `QueryStream`:
 
 - `QueryStream.flatMap` joins each document to an inner stream (e.g. each author to their messages), concatenating the order keys in the type system so the joined stream stays mergeable and paginable.
 - `QueryStream.distinct` emits the first document of each group of consecutive equal order-key prefixes, reading via a loose index scan (one indexed read per group) rather than scanning every row. The requested prefix must be a prefix of the stream's order key, enforced at the type level.
-- `QueryStream.orderBy` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged.
+- `QueryStream.orderBy` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged. A `flatMap` result cannot be relabeled; relabel its inputs before joining.

--- a/.changeset/stream-querying-combinators.md
+++ b/.changeset/stream-querying-combinators.md
@@ -1,0 +1,9 @@
+---
+"@confect/server": minor
+---
+
+Add three combinators to `QueryStream`:
+
+- `QueryStream.flatMap` joins each document to an inner stream (e.g. each author to their messages), concatenating the order keys in the type system so the joined stream stays mergeable and paginable.
+- `QueryStream.distinct` emits the first document of each group of consecutive equal order-key prefixes, reading via a loose index scan (one indexed read per group) rather than scanning every row. The requested prefix must be a prefix of the stream's order key, enforced at the type level.
+- `QueryStream.orderBy` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged.

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -441,6 +441,15 @@ The core of §4 is now implemented as an experimental API:
   type-level constraint (`Key` must extend `readonly [...Fields,
 ...rest]`); narrowing truncates bound keys to the distinct prefix, as in
   `convex-helpers`.
+- **`orderBy`** — re-keying: a position-for-position relabeling of the
+  order key (tuple-length-checked at the type level) that makes streams
+  from different indexes or tables mergeable when their keys align
+  positionally. Because order keys and bounds are pure _values_, the
+  relabeling is transparent to narrowing — bounds pass straight through to
+  the underlying stream, with none of the static-prefix bookkeeping
+  `convex-helpers`' `OrderByStream` needs (its other job, dropping
+  equality-pinned prefix fields, is already the leaf's remaining-field key
+  convention here).
 - **`QueryInitializer.stream(...)`** — `reader.table("notes").stream("by_text",
 (q) => q.eq("text", "a"), "desc")` returns
   `QueryStream<Doc, ["_creationTime"], DocumentDecodeError>`.

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -434,6 +434,13 @@ The core of §4 is now implemented as an experimental API:
   `FlatMapStream.narrow` applies inner bounds to every row's inner stream
   and so drops legitimate elements from non-boundary rows when resuming
   from a mid-row cursor.
+- **`distinct`** — the loose index scan: the first document per distinct
+  value of a _prefix_ of the order key, one index seek per group (each
+  group's first present document narrows the underlying stream past the
+  whole group via a prefix-successor cut). The prefix requirement is a
+  type-level constraint (`Key` must extend `readonly [...Fields,
+...rest]`); narrowing truncates bound keys to the distinct prefix, as in
+  `convex-helpers`.
 - **`QueryInitializer.stream(...)`** — `reader.table("notes").stream("by_text",
 (q) => q.eq("text", "a"), "desc")` returns
   `QueryStream<Doc, ["_creationTime"], DocumentDecodeError>`.
@@ -453,8 +460,8 @@ recommendation:
   improvement over `convex-helpers`' full index keys: equality-pinned values
   never leak into cursors, and merged streams with different pins share a
   cursor space by construction.
-- No `distinct` (loose index scan) or `orderBy` (re-keying) yet; no
-  `maximumBytesRead` accounting; NaN ordering subtleties are skipped.
+- No `orderBy` (re-keying) yet; no `maximumBytesRead` accounting; NaN
+  ordering subtleties are skipped.
 
 ## 8. Open questions
 

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -422,6 +422,18 @@ The core of §4 is now implemented as an experimental API:
   re-apply, and externally constructed streams fall back to in-memory
   filtering. `paginate` composes with this automatically, so resuming from
   a cursor reads only the remaining range.
+- **`flatMap`** — the join: each outer document expands into an inner
+  stream, ordered by (outer key, then inner key), with the concatenated
+  order key tracked _at the type level_ (`readonly [...OuterKey,
+...InnerKey]`) and the `innerKey` argument checked against `f`'s return
+  type. Outer documents that contribute no inner elements (filtered out,
+  or an empty inner stream) emit a `null`-padded filtered element so
+  cursors advance past their cost. Narrowing splits bounds at the
+  outer/inner seam; the inner bound applies only to the _boundary_ outer
+  row — a deliberate correctness deviation from `convex-helpers`, whose
+  `FlatMapStream.narrow` applies inner bounds to every row's inner stream
+  and so drops legitimate elements from non-boundary rows when resuming
+  from a mid-row cursor.
 - **`QueryInitializer.stream(...)`** — `reader.table("notes").stream("by_text",
 (q) => q.eq("text", "a"), "desc")` returns
   `QueryStream<Doc, ["_creationTime"], DocumentDecodeError>`.
@@ -441,8 +453,8 @@ recommendation:
   improvement over `convex-helpers`' full index keys: equality-pinned values
   never leak into cursors, and merged streams with different pins share a
   cursor space by construction.
-- No `flatMap` (join), `distinct` (loose index scan), or `orderBy` (re-keying)
-  yet; no `maximumBytesRead` accounting; NaN ordering subtleties are skipped.
+- No `distinct` (loose index scan) or `orderBy` (re-keying) yet; no
+  `maximumBytesRead` accounting; NaN ordering subtleties are skipped.
 
 ## 8. Open questions
 

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -16,10 +16,7 @@
  *
  * Known limitations (all called out in the design doc):
  *
- * - `narrow` filters the annotated stream in memory rather than pushing
- *   bounds down into `withIndex` ranges (`splitRange` in `convex-helpers`),
- *   so resuming from a cursor re-reads the range from its start.
- * - No `flatMap` (join) or `distinct` (loose index scan) yet.
+ * - No `distinct` (loose index scan) or `orderBy` (re-keying) yet.
  * - Cursors serialize only the *remaining* (order-key) fields, not the full
  *   index key — equality-pinned values never leak into cursors.
  */
@@ -1087,6 +1084,236 @@ export const mapEffect = dual<
 );
 
 /**
+ * A join: for each outer document, stream the documents of the inner stream
+ * produced by `f`, ordered by (outer key, then inner key) — SQL's `LATERAL`
+ * join shape, `flatMap` on `convex-helpers` streams.
+ *
+ * `options.innerKey` is the order key shared by *every* inner stream —
+ * checked against `f`'s return type, so a mismatched literal is a type
+ * error; each produced stream is also validated at runtime (a defect on
+ * mismatch, like `merge`).
+ *
+ * Cursor accounting: an outer document whose inner stream is empty — or
+ * that was filtered out upstream — still contributes one filtered element
+ * whose inner key components are `null`s, so cursors advance past the cost
+ * of reading it. Narrowing splits bounds at the outer/inner seam: the outer
+ * stream is narrowed by the bounds' outer components, and the inner bound
+ * applies only to the *boundary* outer row (the row whose outer key equals
+ * the bound's outer prefix) — other rows' inner streams run in full. (This
+ * deliberately deviates from `convex-helpers`, which narrows every row's
+ * inner stream and so drops legitimate elements from non-boundary rows.)
+ */
+export const flatMap = dual<
+  <Doc, Doc2, InnerKey extends ReadonlyArray<string>, E2, R2>(
+    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2>,
+    options: { readonly innerKey: NoInfer<InnerKey> },
+  ) => <Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc2, readonly [...Key, ...InnerKey], E | E2, R | R2>,
+  <
+    Doc,
+    Key extends ReadonlyArray<string>,
+    E,
+    R,
+    Doc2,
+    InnerKey extends ReadonlyArray<string>,
+    E2,
+    R2,
+  >(
+    self: QueryStream<Doc, Key, E, R>,
+    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2>,
+    options: { readonly innerKey: NoInfer<InnerKey> },
+  ) => QueryStream<Doc2, readonly [...Key, ...InnerKey], E | E2, R | R2>
+>(3, (self, f, options) =>
+  makeFlatMap(
+    self,
+    f,
+    // Runtime inner key fields follow the same convention as leaves: the
+    // type-level key plus the implicit `_id` tiebreaker.
+    Option.exists(Array.last(options.innerKey), (field) => field === "_id")
+      ? options.innerKey
+      : Array.append(options.innerKey, "_id"),
+    {},
+  ),
+);
+
+/** Inner bounds that apply only to the outer row whose key is `outer`. */
+interface InnerRefinement {
+  readonly outer: OrderKey;
+  readonly inner: KeyBound;
+}
+
+interface InnerRefinements {
+  readonly lower?: InnerRefinement | undefined;
+  readonly upper?: InnerRefinement | undefined;
+}
+
+/** Of two lower refinements, the one at the later boundary row wins. */
+const combineLowerRefinements = (
+  existing: InnerRefinement | undefined,
+  incoming: InnerRefinement | undefined,
+): InnerRefinement | undefined =>
+  existing === undefined
+    ? incoming
+    : incoming === undefined
+      ? existing
+      : Order.isGreaterThan(OrderKeyOrder)(existing.outer, incoming.outer)
+        ? existing
+        : Order.isLessThan(OrderKeyOrder)(existing.outer, incoming.outer)
+          ? incoming
+          : {
+              outer: existing.outer,
+              inner: tightestLower(existing.inner, incoming.inner),
+            };
+
+/** Of two upper refinements, the one at the earlier boundary row wins. */
+const combineUpperRefinements = (
+  existing: InnerRefinement | undefined,
+  incoming: InnerRefinement | undefined,
+): InnerRefinement | undefined =>
+  existing === undefined
+    ? incoming
+    : incoming === undefined
+      ? existing
+      : Order.isLessThan(OrderKeyOrder)(existing.outer, incoming.outer)
+        ? existing
+        : Order.isGreaterThan(OrderKeyOrder)(existing.outer, incoming.outer)
+          ? incoming
+          : {
+              outer: existing.outer,
+              inner: tightestUpper(existing.inner, incoming.inner),
+            };
+
+const makeFlatMap = <
+  Doc,
+  Key extends ReadonlyArray<string>,
+  E,
+  R,
+  Doc2,
+  InnerKey extends ReadonlyArray<string>,
+  E2,
+  R2,
+>(
+  self: QueryStream<Doc, Key, E, R>,
+  f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2>,
+  innerKeyFields: ReadonlyArray<string>,
+  refinements: InnerRefinements,
+): QueryStream<Doc2, readonly [...Key, ...InnerKey], E | E2, R | R2> => {
+  const outerLength = self.keyFields.length;
+  const keyFields = Array.appendAll(self.keyFields, innerKeyFields);
+  // The inner key of an outer document that contributes no inner elements
+  // (filtered out, or an empty inner stream).
+  const nullPadding: OrderKey = Array.makeBy(innerKeyFields.length, () => null);
+
+  const validated = (
+    inner: QueryStream<Doc2, InnerKey, E2, R2>,
+  ): QueryStream<Doc2, InnerKey, E2, R2> => {
+    if (inner.order !== self.order) {
+      throw new Error(
+        `QueryStream.flatMap: inner stream order (${inner.order}) differs from the outer stream's (${self.order})`,
+      );
+    }
+    if (!keyFieldsEquivalence(inner.keyFields, innerKeyFields)) {
+      throw new Error(
+        `QueryStream.flatMap: inner stream order-key fields ([${Array.join(inner.keyFields, ", ")}]) differ from innerKey ([${Array.join(innerKeyFields, ", ")}])`,
+      );
+    }
+    return inner;
+  };
+
+  const innerBoundsFor = (outerKey: OrderKey): KeyBounds => ({
+    lower:
+      refinements.lower !== undefined &&
+      OrderKeyOrder(outerKey, refinements.lower.outer) === 0
+        ? Option.some(refinements.lower.inner)
+        : Option.none(),
+    upper:
+      refinements.upper !== undefined &&
+      OrderKeyOrder(outerKey, refinements.upper.outer) === 0
+        ? Option.some(refinements.upper.inner)
+        : Option.none(),
+  });
+
+  const markerStream = (
+    outerKey: OrderKey,
+    innerBounds: KeyBounds,
+  ): Stream.Stream<Element<Doc2>> =>
+    admittedByLower(innerBounds.lower)(nullPadding) &&
+    admittedByUpper(innerBounds.upper)(nullPadding)
+      ? Stream.succeed([
+          Option.none<Doc2>(),
+          Array.appendAll(outerKey, nullPadding),
+        ] as const)
+      : Stream.empty;
+
+  const annotated: Stream.Stream<
+    Element<Doc2>,
+    E | E2,
+    R | R2
+  > = self.annotated.pipe(
+    Stream.flatMap(([outerDoc, outerKey]) => {
+      const innerBounds = innerBoundsFor(outerKey);
+      return Option.match(outerDoc, {
+        onNone: () => markerStream(outerKey, innerBounds),
+        onSome: (doc) =>
+          narrowByKeyBounds(validated(f(doc)), innerBounds).annotated.pipe(
+            Stream.map(
+              ([innerDoc, innerKey]) =>
+                [innerDoc, Array.appendAll(outerKey, innerKey)] as const,
+            ),
+            Stream.orElseIfEmpty(() => markerStream(outerKey, innerBounds)),
+          ),
+      });
+    }),
+  );
+
+  const split = (
+    bound: Option.Option<KeyBound>,
+  ): {
+    readonly outer: Option.Option<KeyBound>;
+    readonly refinement: InnerRefinement | undefined;
+  } =>
+    Option.match(bound, {
+      onNone: () => ({ outer: Option.none(), refinement: undefined }),
+      onSome: ({ inclusive, key }) =>
+        key.length <= outerLength
+          ? { outer: Option.some({ key, inclusive }), refinement: undefined }
+          : {
+              // The boundary outer row must be included so its inner
+              // stream can be narrowed by the bound's inner components.
+              outer: Option.some({
+                key: Array.take(key, outerLength),
+                inclusive: true,
+              }),
+              refinement: {
+                outer: Array.take(key, outerLength),
+                inner: { key: Array.drop(key, outerLength), inclusive },
+              },
+            },
+    });
+
+  return new QueryStream(
+    self.order,
+    keyFields,
+    annotated,
+    undefined,
+    (bounds) => {
+      const lower = split(bounds.lower);
+      const upper = split(bounds.upper);
+      return makeFlatMap(
+        narrowByKeyBounds(self, { lower: lower.outer, upper: upper.outer }),
+        f,
+        innerKeyFields,
+        {
+          lower: combineLowerRefinements(refinements.lower, lower.refinement),
+          upper: combineUpperRefinements(refinements.upper, upper.refinement),
+        },
+      );
+    },
+  );
+};
+
+/**
  * Restrict a stream to order keys strictly after `after` and at-or-before
  * `until` (in stream order). Bounds are pushed down through the stream's
  * structure via `narrowWith`: leaves rebuild their Convex queries with the
@@ -1146,6 +1373,24 @@ const narrowByKeyBounds = <Doc, Key extends ReadonlyArray<string>, E, R>(
       ? self.narrowWith(bounds)
       : narrowInMemory(self, bounds);
 
+/** Whether a key sits after the lower bound (always, when unbounded). */
+const admittedByLower =
+  (lower: Option.Option<KeyBound>) =>
+  (key: OrderKey): boolean =>
+    Option.match(lower, {
+      onNone: () => true,
+      onSome: (bound) => KeyCutOrder(exactCut(key), lowerCut(bound)) > 0,
+    });
+
+/** Whether a key sits before the upper bound (always, when unbounded). */
+const admittedByUpper =
+  (upper: Option.Option<KeyBound>) =>
+  (key: OrderKey): boolean =>
+    Option.match(upper, {
+      onNone: () => true,
+      onSome: (bound) => KeyCutOrder(exactCut(key), upperCut(bound)) < 0,
+    });
+
 /** The fallback for streams that don't know how to rebuild themselves. */
 const narrowInMemory = <Doc, Key extends ReadonlyArray<string>, E, R>(
   self: QueryStream<Doc, Key, E, R>,
@@ -1155,25 +1400,17 @@ const narrowInMemory = <Doc, Key extends ReadonlyArray<string>, E, R>(
     annotated: Stream.Stream<Element<Doc>, E, R>,
   ) => Stream.Stream<Element<Doc>, E, R>;
 
-  const admittedByLower = (key: OrderKey): boolean =>
-    Option.match(bounds.lower, {
-      onNone: () => true,
-      onSome: (bound) => KeyCutOrder(exactCut(key), lowerCut(bound)) > 0,
-    });
-  const admittedByUpper = (key: OrderKey): boolean =>
-    Option.match(bounds.upper, {
-      onNone: () => true,
-      onSome: (bound) => KeyCutOrder(exactCut(key), upperCut(bound)) < 0,
-    });
+  const aboveLower = admittedByLower(bounds.lower);
+  const belowUpper = admittedByUpper(bounds.upper);
 
   const dropOutOfRange: Narrower =
     self.order === "asc"
-      ? Stream.dropWhile(([, key]) => !admittedByLower(key))
-      : Stream.dropWhile(([, key]) => !admittedByUpper(key));
+      ? Stream.dropWhile(([, key]) => !aboveLower(key))
+      : Stream.dropWhile(([, key]) => !belowUpper(key));
   const takeInRange: Narrower =
     self.order === "asc"
-      ? Stream.takeWhile(([, key]) => admittedByUpper(key))
-      : Stream.takeWhile(([, key]) => admittedByLower(key));
+      ? Stream.takeWhile(([, key]) => belowUpper(key))
+      : Stream.takeWhile(([, key]) => aboveLower(key));
 
   return new QueryStream(
     self.order,

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -16,7 +16,7 @@
  *
  * Known limitations (all called out in the design doc):
  *
- * - No `distinct` (loose index scan) or `orderBy` (re-keying) yet.
+ * - No `orderBy` (re-keying) yet.
  * - Cursors serialize only the *remaining* (order-key) fields, not the full
  *   index key — equality-pinned values never leak into cursors.
  */
@@ -1310,6 +1310,122 @@ const makeFlatMap = <
         },
       );
     },
+  );
+};
+
+/**
+ * Keep the first document for each distinct value of a *prefix* of the
+ * order key — a loose index scan: after a group's first document, the
+ * underlying stream is narrowed past the entire group, so each group costs
+ * one index seek instead of a scan.
+ *
+ * `fields` must be a prefix of the stream's order key — enforced at the
+ * type level (`Key` must extend `readonly [...Fields, ...rest]`) and
+ * validated at runtime.
+ *
+ * Filtered-out elements pass through (still advancing cursors) without
+ * claiming their group, so the first *present* document of each group is
+ * kept. As with `convex-helpers`, prefer applying `filterEffect` *after*
+ * `distinct`: narrowing a distinct stream truncates bounds to the distinct
+ * prefix, so a cursor that lands on a filtered element before its group's
+ * first present document resumes at the next group.
+ */
+export const distinct = dual<
+  <const Fields extends ReadonlyArray<string>>(
+    fields: Fields,
+  ) => <Doc, Key extends readonly [...Fields, ...ReadonlyArray<string>], E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc, Key, E, R>,
+  <
+    const Fields extends ReadonlyArray<string>,
+    Doc,
+    Key extends readonly [...Fields, ...ReadonlyArray<string>],
+    E,
+    R,
+  >(
+    self: QueryStream<Doc, Key, E, R>,
+    fields: Fields,
+  ) => QueryStream<Doc, Key, E, R>
+>(2, (self, fields) => {
+  if (
+    !keyFieldsEquivalence(fields, Array.take(self.keyFields, fields.length))
+  ) {
+    throw new Error(
+      `QueryStream.distinct: fields ([${Array.join(fields, ", ")}]) must be a prefix of the stream's order-key fields ([${Array.join(self.keyFields, ", ")}])`,
+    );
+  }
+  return makeDistinct(self, fields.length);
+});
+
+const makeDistinct = <Doc, Key extends ReadonlyArray<string>, E, R>(
+  self: QueryStream<Doc, Key, E, R>,
+  distinctLength: number,
+): QueryStream<Doc, Key, E, R> => {
+  /** Bounds that skip past the group of the given key, in stream order. */
+  const skipGroupBounds = (key: OrderKey): KeyBounds => {
+    const pastGroup: KeyBound = {
+      key: Array.take(key, distinctLength),
+      inclusive: false,
+    };
+    return self.order === "asc"
+      ? { lower: Option.some(pastGroup), upper: Option.none() }
+      : { lower: Option.none(), upper: Option.some(pastGroup) };
+  };
+
+  // Each step reads one group: everything up to and including the group's
+  // first present document (filtered elements pass through), then the next
+  // step continues from a stream narrowed past the whole group.
+  const annotated: Stream.Stream<Element<Doc>, E, R> = Stream.paginate(
+    self,
+    (current) =>
+      current.annotated.pipe(
+        Stream.takeUntil(([doc, _key]) => Option.isSome(doc)),
+        Stream.runCollect,
+        Effect.map((elements) =>
+          Array.isReadonlyArrayNonEmpty(elements)
+            ? ([
+                elements,
+                pipe(Array.lastNonEmpty(elements), ([doc, key]) =>
+                  Option.isSome(doc)
+                    ? Option.some(
+                        narrowByKeyBounds(current, skipGroupBounds(key)),
+                      )
+                    : // The stream ended on a filtered element: no
+                      // present document remains.
+                      Option.none<QueryStream<Doc, Key, E, R>>(),
+                ),
+              ] as const)
+            : ([
+                Array.empty<Element<Doc>>(),
+                Option.none<QueryStream<Doc, Key, E, R>>(),
+              ] as const),
+        ),
+      ),
+  );
+
+  // Narrowing truncates bound keys to the distinct prefix (as in
+  // `convex-helpers`): a cursor at a group's kept document resumes at the
+  // next group, and an inclusive bound re-reads its whole group so the
+  // group's first present document is re-found.
+  const truncated = (bound: Option.Option<KeyBound>): Option.Option<KeyBound> =>
+    Option.map(bound, ({ inclusive, key }) => ({
+      key: Array.take(key, distinctLength),
+      inclusive,
+    }));
+
+  return new QueryStream(
+    self.order,
+    self.keyFields,
+    annotated,
+    undefined,
+    (bounds) =>
+      makeDistinct(
+        narrowByKeyBounds(self, {
+          lower: truncated(bounds.lower),
+          upper: truncated(bounds.upper),
+        }),
+        distinctLength,
+      ),
   );
 };
 

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -16,7 +16,7 @@
  *
  * Known limitations (all called out in the design doc):
  *
- * - No `orderBy` (re-keying) yet.
+ * - No `maximumBytesRead` accounting; NaN ordering subtleties are skipped.
  * - Cursors serialize only the *remaining* (order-key) fields, not the full
  *   index key — equality-pinned values never leak into cursors.
  */
@@ -1356,6 +1356,81 @@ export const distinct = dual<
   }
   return makeDistinct(self, fields.length);
 });
+
+/**
+ * Re-key a stream: declare that its order key should be regarded as `key`,
+ * a position-for-position relabeling of the order-key fields (the trailing
+ * `_id` tiebreaker keeps its name). Order keys are *values*, so relabeling
+ * changes only the names used for compatibility validation — the element
+ * order is untouched, and narrowing passes bounds through to the
+ * underlying stream unchanged. Use it to make streams from different
+ * indexes or tables mergeable when their keys align positionally; the
+ * caller asserts the *semantic* alignment of the relabeled fields.
+ *
+ * (This is `convex-helpers`' `.orderBy()`. There it may also drop
+ * equality-pinned prefix fields from the key — Confect's remaining-field
+ * order keys already drop those at the leaf.)
+ *
+ * `key` must have as many fields as the stream's order key, enforced at
+ * the type level via tuple length. One caveat: a `flatMap` result's
+ * runtime key carries interior `_id` tiebreakers that its type-level key
+ * omits, so relabeling one is rejected by the runtime length validation.
+ */
+export const orderBy = dual<
+  <const NewKey extends ReadonlyArray<string>>(
+    key: NewKey,
+  ) => <
+    Doc,
+    Key extends ReadonlyArray<string> & {
+      readonly length: NewKey["length"];
+    },
+    E,
+    R,
+  >(
+    self: QueryStream<Doc, Key, E, R>,
+  ) => QueryStream<Doc, Types.Mutable<NewKey>, E, R>,
+  <
+    const NewKey extends ReadonlyArray<string>,
+    Doc,
+    Key extends ReadonlyArray<string> & {
+      readonly length: NewKey["length"];
+    },
+    E,
+    R,
+  >(
+    self: QueryStream<Doc, Key, E, R>,
+    key: NewKey,
+  ) => QueryStream<Doc, Types.Mutable<NewKey>, E, R>
+>(2, (self, key) => orderByImpl(self, key));
+
+const orderByImpl = <
+  Doc,
+  Key extends ReadonlyArray<string>,
+  E,
+  R,
+  NewKey extends ReadonlyArray<string>,
+>(
+  self: QueryStream<Doc, Key, E, R>,
+  key: NewKey,
+): QueryStream<Doc, Types.Mutable<NewKey>, E, R> => {
+  const keyFields = Option.exists(Array.last(key), (field) => field === "_id")
+    ? key
+    : Array.append(key, "_id");
+  if (keyFields.length !== self.keyFields.length) {
+    throw new Error(
+      `QueryStream.orderBy: key ([${Array.join(key, ", ")}]) must have as many fields as the stream's order key ([${Array.join(self.keyFields, ", ")}])`,
+    );
+  }
+  return new QueryStream(
+    self.order,
+    keyFields,
+    self.annotated,
+    undefined,
+    // Bounds are positional values, so they apply to the underlying
+    // stream as-is.
+    (bounds) => orderByImpl(narrowByKeyBounds(self, bounds), key),
+  );
+};
 
 const makeDistinct = <Doc, Key extends ReadonlyArray<string>, E, R>(
   self: QueryStream<Doc, Key, E, R>,

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -1130,9 +1130,7 @@ export const flatMap = dual<
     f,
     // Runtime inner key fields follow the same convention as leaves: the
     // type-level key plus the implicit `_id` tiebreaker.
-    Option.exists(Array.last(options.innerKey), (field) => field === "_id")
-      ? options.innerKey
-      : Array.append(options.innerKey, "_id"),
+    withIdTiebreaker(options.innerKey),
     {},
   ),
 );
@@ -1413,9 +1411,7 @@ const orderByImpl = <
   self: QueryStream<Doc, Key, E, R>,
   key: NewKey,
 ): QueryStream<Doc, Types.Mutable<NewKey>, E, R> => {
-  const keyFields = Option.exists(Array.last(key), (field) => field === "_id")
-    ? key
-    : Array.append(key, "_id");
+  const keyFields = withIdTiebreaker(key);
   if (keyFields.length !== self.keyFields.length) {
     throw new Error(
       `QueryStream.orderBy: key ([${Array.join(key, ", ")}]) must have as many fields as the stream's order key ([${Array.join(self.keyFields, ", ")}])`,

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -222,6 +222,55 @@ const withIdTiebreaker = (
     ? fields
     : Array.append(fields, "_id");
 
+/**
+ * The position of the `_id` tiebreaker that {@link withIdTiebreaker} added
+ * to `fields` (none when the fields already ended with `_id`, as `by_id`'s
+ * do — that `_id` is part of the type-level key).
+ */
+const appendedTiebreaker = (
+  fields: ReadonlyArray<string>,
+  withTiebreaker: ReadonlyArray<string>,
+): ReadonlyArray<number> =>
+  withTiebreaker.length === fields.length ? [] : [withTiebreaker.length - 1];
+
+/** The order-key fields the type-level key names: all but the tiebreakers. */
+const visibleKeyFields = (self: {
+  readonly keyFields: ReadonlyArray<string>;
+  readonly tiebreakers: ReadonlyArray<number>;
+}): ReadonlyArray<string> =>
+  Array.filter(
+    self.keyFields,
+    (_field, index) => !Array.contains(self.tiebreakers, index),
+  );
+
+/**
+ * The runtime length of the order-key prefix that covers the first
+ * `visibleLength` type-visible fields — including any tiebreakers that
+ * sit between them.
+ */
+const runtimePrefixLength = (
+  self: {
+    readonly keyFields: ReadonlyArray<string>;
+    readonly tiebreakers: ReadonlyArray<number>;
+  },
+  visibleLength: number,
+): number =>
+  visibleLength === 0
+    ? 0
+    : Option.getOrThrowWith(
+        Array.get(
+          Array.filter(
+            Array.makeBy(self.keyFields.length, identity),
+            (index) => !Array.contains(self.tiebreakers, index),
+          ),
+          visibleLength - 1,
+        ),
+        () =>
+          new Error(
+            `QueryStream: prefix length ${visibleLength} exceeds the order key ([${Array.join(self.keyFields, ", ")}])`,
+          ),
+      ) + 1;
+
 // -----------------------------------------------------------------------------
 // Convex value ordering
 // -----------------------------------------------------------------------------
@@ -546,6 +595,17 @@ export class QueryStream<
      * falls back to filtering the annotated stream in memory.
      */
     readonly narrowWith?: (bounds: KeyBounds) => QueryStream<Doc, Key, E, R>,
+    /**
+     * Positions in `keyFields` of the implicit `_id` tiebreakers the
+     * type-level `Key` omits: normally the trailing one, plus — on a
+     * `flatMap` result — the outer key's interior one. Combinators that
+     * relate the type-level key to the runtime key (`orderBy`, `distinct`)
+     * skip over them. Defaults to the trailing `_id`, if any.
+     */
+    readonly tiebreakers: ReadonlyArray<number> = appendedTiebreaker(
+      Array.dropRight(keyFields, 1),
+      keyFields,
+    ),
   ) {}
 
   toStream(): Stream.Stream<Doc, E, R> {
@@ -717,6 +777,15 @@ const makeLeaf = <Doc>(
   // fully pinned `by_id` stream has an *empty* order key, not a re-appended
   // `_id`.
   const keyFields = Array.drop(fullIndexFields, reflection.spec.eqCount);
+  // The appended `_id` (if any) is the key's one type-invisible position —
+  // unless pinning consumed the whole key.
+  const tiebreakers = Array.map(
+    Array.filter(
+      appendedTiebreaker(reflection.indexFields, fullIndexFields),
+      (position) => position >= reflection.spec.eqCount,
+    ),
+    (position) => position - reflection.spec.eqCount,
+  );
   const keyPaths = Array.map(keyFields, (field) => String.split(field, "."));
   // `eq`-pinned values form a shared prefix of both bound keys.
   const eqValues = Array.take(bounds.lower.key, reflection.spec.eqCount);
@@ -771,6 +840,7 @@ const makeLeaf = <Doc>(
           onSome: (bound) => tightestUpper(bounds.upper, toFullKeySpace(bound)),
         }),
       }),
+    tiebreakers,
   );
 };
 
@@ -950,6 +1020,7 @@ export const merge = <Doc, Key extends ReadonlyArray<string>, E, R>(
           narrowByKeyBounds(stream, keyBounds),
         ),
       ]),
+    head.tiebreakers,
   );
 };
 
@@ -973,6 +1044,7 @@ const transform = <Doc, Key extends ReadonlyArray<string>, E, R, Doc2>(
     ),
     undefined,
     (keyBounds) => transform(narrowByKeyBounds(self, keyBounds), f),
+    self.tiebreakers,
   );
 
 /** The effectful {@link transform}. */
@@ -1000,6 +1072,7 @@ const transformEffect = <
     ),
     undefined,
     (keyBounds) => transformEffect(narrowByKeyBounds(self, keyBounds), f),
+    self.tiebreakers,
   );
 
 /**
@@ -1124,16 +1197,18 @@ export const flatMap = dual<
     f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2>,
     options: { readonly innerKey: NoInfer<InnerKey> },
   ) => QueryStream<Doc2, readonly [...Key, ...InnerKey], E | E2, R | R2>
->(3, (self, f, options) =>
-  makeFlatMap(
+>(3, (self, f, options) => {
+  // Runtime inner key fields follow the same convention as leaves: the
+  // type-level key plus the implicit `_id` tiebreaker.
+  const innerKeyFields = withIdTiebreaker(options.innerKey);
+  return makeFlatMap(
     self,
     f,
-    // Runtime inner key fields follow the same convention as leaves: the
-    // type-level key plus the implicit `_id` tiebreaker.
-    withIdTiebreaker(options.innerKey),
+    innerKeyFields,
+    appendedTiebreaker(options.innerKey, innerKeyFields),
     {},
-  ),
-);
+  );
+});
 
 /** Inner bounds that apply only to the outer row whose key is `outer`. */
 interface InnerRefinement {
@@ -1195,10 +1270,18 @@ const makeFlatMap = <
   self: QueryStream<Doc, Key, E, R>,
   f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2>,
   innerKeyFields: ReadonlyArray<string>,
+  innerTiebreakers: ReadonlyArray<number>,
   refinements: InnerRefinements,
 ): QueryStream<Doc2, readonly [...Key, ...InnerKey], E | E2, R | R2> => {
   const outerLength = self.keyFields.length;
   const keyFields = Array.appendAll(self.keyFields, innerKeyFields);
+  // The joined key keeps the outer key's tiebreaker *inside* it: the
+  // type-level key `[...Key, ...InnerKey]` omits it, so it's recorded as a
+  // tiebreaker position for `orderBy`/`distinct` to skip.
+  const tiebreakers = Array.appendAll(
+    self.tiebreakers,
+    Array.map(innerTiebreakers, (position) => position + outerLength),
+  );
   // The inner key of an outer document that contributes no inner elements
   // (filtered out, or an empty inner stream).
   const nullPadding: OrderKey = Array.makeBy(innerKeyFields.length, () => null);
@@ -1302,12 +1385,14 @@ const makeFlatMap = <
         narrowByKeyBounds(self, { lower: lower.outer, upper: upper.outer }),
         f,
         innerKeyFields,
+        innerTiebreakers,
         {
           lower: combineLowerRefinements(refinements.lower, lower.refinement),
           upper: combineUpperRefinements(refinements.upper, upper.refinement),
         },
       );
     },
+    tiebreakers,
   );
 };
 
@@ -1345,14 +1430,15 @@ export const distinct = dual<
     fields: Fields,
   ) => QueryStream<Doc, Key, E, R>
 >(2, (self, fields) => {
-  if (
-    !keyFieldsEquivalence(fields, Array.take(self.keyFields, fields.length))
-  ) {
+  const visible = visibleKeyFields(self);
+  if (!keyFieldsEquivalence(fields, Array.take(visible, fields.length))) {
     throw new Error(
-      `QueryStream.distinct: fields ([${Array.join(fields, ", ")}]) must be a prefix of the stream's order-key fields ([${Array.join(self.keyFields, ", ")}])`,
+      `QueryStream.distinct: fields ([${Array.join(fields, ", ")}]) must be a prefix of the stream's order-key fields ([${Array.join(visible, ", ")}])`,
     );
   }
-  return makeDistinct(self, fields.length);
+  // Groups are runs of equal *runtime* prefixes, so a prefix that reaches
+  // past a tiebreaker (into a `flatMap` result's inner key) includes it.
+  return makeDistinct(self, runtimePrefixLength(self, fields.length));
 });
 
 /**
@@ -1370,9 +1456,9 @@ export const distinct = dual<
  * order keys already drop those at the leaf.)
  *
  * `key` must have as many fields as the stream's order key, enforced at
- * the type level via tuple length. One caveat: a `flatMap` result's
- * runtime key carries interior `_id` tiebreakers that its type-level key
- * omits, so relabeling one is rejected by the runtime length validation.
+ * the type level via tuple length. The implicit `_id` tiebreakers the
+ * type-level key omits — the trailing one, and a `flatMap` result's
+ * interior one — keep their names and positions.
  */
 export const orderBy = dual<
   <const NewKey extends ReadonlyArray<string>>(
@@ -1411,12 +1497,27 @@ const orderByImpl = <
   self: QueryStream<Doc, Key, E, R>,
   key: NewKey,
 ): QueryStream<Doc, Types.Mutable<NewKey>, E, R> => {
-  const keyFields = withIdTiebreaker(key);
-  if (keyFields.length !== self.keyFields.length) {
+  const visible = visibleKeyFields(self);
+  if (key.length !== visible.length) {
     throw new Error(
-      `QueryStream.orderBy: key ([${Array.join(key, ", ")}]) must have as many fields as the stream's order key ([${Array.join(self.keyFields, ", ")}])`,
+      `QueryStream.orderBy: key ([${Array.join(key, ", ")}]) must have as many fields as the stream's order key ([${Array.join(visible, ", ")}])`,
     );
   }
+  // Relabel the type-visible positions in order; tiebreakers keep their
+  // names.
+  const keyFields = Array.map(self.keyFields, (field, index) =>
+    Array.contains(self.tiebreakers, index)
+      ? field
+      : Option.getOrThrowWith(
+          Array.get(
+            key,
+            index -
+              Array.filter(self.tiebreakers, (position) => position < index)
+                .length,
+          ),
+          () => new Error("QueryStream.orderBy: key/order-key length mismatch"),
+        ),
+  );
   return new QueryStream(
     self.order,
     keyFields,
@@ -1425,6 +1526,7 @@ const orderByImpl = <
     // Bounds are positional values, so they apply to the underlying
     // stream as-is.
     (bounds) => orderByImpl(narrowByKeyBounds(self, bounds), key),
+    self.tiebreakers,
   );
 };
 
@@ -1497,6 +1599,7 @@ const makeDistinct = <Doc, Key extends ReadonlyArray<string>, E, R>(
         }),
         distinctLength,
       ),
+    self.tiebreakers,
   );
 };
 
@@ -1603,6 +1706,9 @@ const narrowInMemory = <Doc, Key extends ReadonlyArray<string>, E, R>(
     self.order,
     self.keyFields,
     pipe(self.annotated, dropOutOfRange, takeInRange),
+    undefined,
+    undefined,
+    self.tiebreakers,
   );
 };
 

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -718,6 +718,65 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
+  it.effect("orderBy relabels order keys so foreign streams merge", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          yield* writer.table("notes").insert({ text: "a", tag: "ta1" });
+          yield* writer.table("notes").insert({
+            author: { name: "A", role: "admin" },
+            tag: "tr1",
+            text: "x1",
+          });
+          yield* writer.table("notes").insert({ text: "m", tag: "ta2" });
+          yield* writer.table("notes").insert({
+            author: { name: "U", role: "user" },
+            tag: "tr2",
+            text: "x2",
+          });
+
+          // Two different indexes over the same table: the range bounds
+          // keep their document sets disjoint.
+          const byText = reader
+            .table("notes")
+            .stream("by_text", (q) => q.lt("text", "x"));
+          const byRole = reader
+            .table("notes")
+            .stream("by_role", (q) => q.gte("author.role", "admin"));
+
+          // `by_role`'s key is ["author.role", "_creationTime"]; relabel
+          // it to merge positionally with `by_text`. Convex's string order
+          // interleaves the values: "a" < "admin" < "m" < "user".
+          const merged = QueryStream.merge([
+            byText,
+            byRole.pipe(QueryStream.orderBy(["text", "_creationTime"])),
+          ]);
+
+          const tags = yield* Stream.runCollect(merged).pipe(
+            Effect.map((docs) => docs.map((doc) => doc.tag)),
+          );
+          expect(tags).toEqual(["ta1", "tr1", "ta2", "tr2"]);
+
+          // Pagination narrows through the relabeling into both leaves:
+          // bounds are positional values, so the relabeled branch's leaf
+          // receives them against its own fields.
+          const pages = yield* paginateAll(merged, 1);
+          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+            ["ta1"],
+            ["tr1"],
+            ["ta2"],
+            ["tr2"],
+          ]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
   it.effect("resumes a fully eq-pinned by_id stream from its cursor", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
@@ -1031,6 +1090,16 @@ describe("QueryStream types", () => {
       // @ts-expect-error — "text" is pinned away on this stream's key.
       const distinctPinnedAway = QueryStream.distinct(pinned, ["text"]);
       void distinctPinnedAway;
+
+      // orderBy relabels the order key position-for-position.
+      const relabeled = QueryStream.orderBy(full, ["renamed", "_creationTime"]);
+      expectTypeOf<KeyOf<typeof relabeled>>().toEqualTypeOf<
+        ["renamed", "_creationTime"]
+      >();
+
+      // @ts-expect-error — the new key must have as many fields as the old.
+      const relabeledTooShort = QueryStream.orderBy(full, ["_creationTime"]);
+      void relabeledTooShort;
     });
     void _typeChecks;
   });

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -624,6 +624,100 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
+  it.effect("distinct keeps the first document per group", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          for (const [text, tag] of [
+            ["a", "a1"],
+            ["a", "a2"],
+            ["b", "b1"],
+            ["b", "b2"],
+            ["c", "c1"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const tagsOf = <E, R>(
+            stream: Stream.Stream<{ tag?: string }, E, R>,
+          ): Effect.Effect<ReadonlyArray<string | undefined>, E, R> =>
+            Stream.runCollect(stream).pipe(
+              Effect.map((docs) => docs.map((doc) => doc.tag)),
+            );
+
+          const firstPerText = yield* tagsOf(
+            reader
+              .table("notes")
+              .stream("by_text")
+              .pipe(QueryStream.distinct(["text"])),
+          );
+          expect(firstPerText).toEqual(["a1", "b1", "c1"]);
+
+          // In descending order, the first document of each group is the
+          // group's last in ascending order.
+          const firstPerTextDesc = yield* tagsOf(
+            reader
+              .table("notes")
+              .stream("by_text", "desc")
+              .pipe(QueryStream.distinct(["text"])),
+          );
+          expect(firstPerTextDesc).toEqual(["c1", "b2", "a2"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("distinct paginates group by group", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          for (const [text, tag] of [
+            ["a", "a1"],
+            ["a", "a2"],
+            ["b", "b1"],
+            ["b", "b2"],
+            ["c", "c1"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const distinctTexts = reader
+            .table("notes")
+            .stream("by_text")
+            .pipe(QueryStream.distinct(["text"]));
+
+          const pages = yield* paginateAll(distinctTexts, 1);
+          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+            ["a1"],
+            ["b1"],
+            ["c1"],
+          ]);
+
+          // Filtering *after* distinct filters the kept documents.
+          const filtered = distinctTexts.pipe(
+            QueryStream.filterEffect((note) =>
+              Effect.succeed(note.tag !== "b1"),
+            ),
+          );
+          const filteredPages = yield* paginateAll(filtered, 1);
+          expect(
+            filteredPages.map((page) => page.map((doc) => doc.tag)),
+          ).toEqual([["a1"], ["c1"]]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
   it.effect("resumes a fully eq-pinned by_id stream from its cursor", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
@@ -923,6 +1017,20 @@ describe("QueryStream types", () => {
         innerKey: ["text", "_creationTime"],
       });
       void joinedMismatched;
+
+      // distinct preserves the order key and requires a prefix of it.
+      const distinctTexts = QueryStream.distinct(full, ["text"]);
+      expectTypeOf<KeyOf<typeof distinctTexts>>().toEqualTypeOf<
+        ["text", "_creationTime"]
+      >();
+
+      // @ts-expect-error — fields must be a prefix of the order key.
+      const distinctNonPrefix = QueryStream.distinct(full, ["_creationTime"]);
+      void distinctNonPrefix;
+
+      // @ts-expect-error — "text" is pinned away on this stream's key.
+      const distinctPinnedAway = QueryStream.distinct(pinned, ["text"]);
+      void distinctPinnedAway;
     });
     void _typeChecks;
   });

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -513,6 +513,117 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
+  it.effect("flatMap joins each outer document to an inner stream", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          // Inner rows, keyed by text; outer rows reference them via `tag`.
+          for (const [text, tag] of [
+            ["a", "a1"],
+            ["a", "a2"],
+            ["b", "b1"],
+            ["x1", "a"],
+            ["x2", "b"],
+            ["x3", "none"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const outer = reader
+            .table("notes")
+            .stream("by_text", (q) => q.gte("text", "x"));
+          const joined = outer.pipe(
+            QueryStream.flatMap(
+              (note) =>
+                reader
+                  .table("notes")
+                  .stream("by_text", (q) => q.eq("text", note.tag ?? "")),
+              { innerKey: ["_creationTime"] },
+            ),
+          );
+
+          const tags = yield* Stream.runCollect(joined).pipe(
+            Effect.map((docs) => docs.map((doc) => doc.tag)),
+          );
+          // x1 → the "a" rows in creation order, x2 → the "b" row, and
+          // x3's empty inner stream contributes nothing visible.
+          expect(tags).toEqual(["a1", "a2", "b1"]);
+
+          // Filtered-out outer documents contribute nothing visible either.
+          const filteredJoin = outer.pipe(
+            QueryStream.filterEffect((note) =>
+              Effect.succeed(note.text !== "x2"),
+            ),
+            QueryStream.flatMap(
+              (note) =>
+                reader
+                  .table("notes")
+                  .stream("by_text", (q) => q.eq("text", note.tag ?? "")),
+              { innerKey: ["_creationTime"] },
+            ),
+          );
+          const filteredTags = yield* Stream.runCollect(filteredJoin).pipe(
+            Effect.map((docs) => docs.map((doc) => doc.tag)),
+          );
+          expect(filteredTags).toEqual(["a1", "a2"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("flatMap paginates across inner-stream boundaries", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          // The "b" row is inserted *first*, so its creation time is the
+          // smallest: if resuming wrongly applied the boundary row's inner
+          // bound to every row (as `convex-helpers` does), the "b" row
+          // would be skipped on the page after a mid-"a" cursor.
+          for (const [text, tag] of [
+            ["b", "b1"],
+            ["a", "a1"],
+            ["a", "a2"],
+            ["x0", "none"],
+            ["x1", "a"],
+            ["x2", "b"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const joined = reader
+            .table("notes")
+            .stream("by_text", (q) => q.gte("text", "x"))
+            .pipe(
+              QueryStream.flatMap(
+                (note) =>
+                  reader
+                    .table("notes")
+                    .stream("by_text", (q) => q.eq("text", note.tag ?? "")),
+                { innerKey: ["_creationTime"] },
+              ),
+            );
+
+          const pages = yield* paginateAll(joined, 1);
+          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+            ["a1"],
+            ["a2"],
+            ["b1"],
+          ]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
   it.effect("resumes a fully eq-pinned by_id stream from its cursor", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
@@ -798,6 +909,20 @@ describe("QueryStream types", () => {
           ? R
           : never
       >().toEqualTypeOf<SomeService>();
+
+      // flatMap concatenates order keys at the type level.
+      const joined = QueryStream.flatMap(bounded, (_note) => pinned, {
+        innerKey: ["_creationTime"],
+      });
+      expectTypeOf<KeyOf<typeof joined>>().toEqualTypeOf<
+        readonly ["text", "_creationTime", "_creationTime"]
+      >();
+
+      const joinedMismatched = QueryStream.flatMap(bounded, (_note) => pinned, {
+        // @ts-expect-error — innerKey must match the inner stream's order key.
+        innerKey: ["text", "_creationTime"],
+      });
+      void joinedMismatched;
     });
     void _typeChecks;
   });

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -777,6 +777,96 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
+  it.effect("orderBy and distinct see through flatMap tiebreakers", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          for (const [text, tag] of [
+            ["b", "b1"],
+            ["a", "a1"],
+            ["a", "a2"],
+            ["x0", "none"],
+            ["x1", "a"],
+            ["x2", "b"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const tagsOf = <E, R>(
+            stream: Stream.Stream<{ tag?: string }, E, R>,
+          ): Effect.Effect<ReadonlyArray<string | undefined>, E, R> =>
+            Stream.runCollect(stream).pipe(
+              Effect.map((docs) => docs.map((doc) => doc.tag)),
+            );
+
+          // Type-level key ["text", "_creationTime", "_creationTime"]; the
+          // runtime key also carries the outer row's `_id` in the middle.
+          const joined = reader
+            .table("notes")
+            .stream("by_text", (q) => q.gte("text", "x"))
+            .pipe(
+              QueryStream.flatMap(
+                (note) =>
+                  reader
+                    .table("notes")
+                    .stream("by_text", (q) => q.eq("text", note.tag ?? "")),
+                { innerKey: ["_creationTime"] },
+              ),
+            );
+          expect(joined.keyFields).toEqual([
+            "text",
+            "_creationTime",
+            "_id",
+            "_creationTime",
+            "_id",
+          ]);
+
+          // Relabeling names only the type-visible positions.
+          const relabeled = joined.pipe(
+            QueryStream.orderBy(["outerText", "outerCreated", "innerCreated"]),
+          );
+          expect(relabeled.keyFields).toEqual([
+            "outerText",
+            "outerCreated",
+            "_id",
+            "innerCreated",
+            "_id",
+          ]);
+          const pages = yield* paginateAll(relabeled, 1);
+          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+            ["a1"],
+            ["a2"],
+            ["b1"],
+          ]);
+
+          // Distinct over the outer key keeps each outer row's first inner
+          // document; the "x0" row has none.
+          expect(
+            yield* tagsOf(joined.pipe(QueryStream.distinct(["text"]))),
+          ).toEqual(["a1", "b1"]);
+
+          // A prefix reaching into the inner key spans the outer `_id`.
+          expect(
+            yield* tagsOf(
+              joined.pipe(
+                QueryStream.distinct([
+                  "text",
+                  "_creationTime",
+                  "_creationTime",
+                ]),
+              ),
+            ),
+          ).toEqual(["a1", "a2", "b1"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
   it.effect("resumes a fully eq-pinned by_id stream from its cursor", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
@@ -1100,6 +1190,12 @@ describe("QueryStream types", () => {
       // @ts-expect-error — the new key must have as many fields as the old.
       const relabeledTooShort = QueryStream.orderBy(full, ["_creationTime"]);
       void relabeledTooShort;
+
+      // A flatMap result relabels by its type-level (tiebreaker-free) key.
+      const relabeledJoin = QueryStream.orderBy(joined, ["a", "b", "c"]);
+      expectTypeOf<KeyOf<typeof relabeledJoin>>().toEqualTypeOf<
+        ["a", "b", "c"]
+      >();
     });
     void _typeChecks;
   });


### PR DESCRIPTION
**Stack 3/8** — [1: QueryStream core (#597)] · [2: push-down narrow (#598)] ← **combinators** · [4: useStreamPaginatedQuery (#600)] · [5: example feed (#601)] · [6: maximumBytesRead (#636)] · [7: Foldkit pinning (#637)] · [8: docs (#634)]

Builds on #598. Adds the three remaining structural combinators from the convex-helpers stream vocabulary, each with type-level order-key tracking and push-down narrow support.

## What's in this layer

- **`flatMap`** — the join: maps each outer document to an inner stream; the result's order key is the type-level concatenation `readonly [...Key, ...InnerKey]`. Filtered/empty outer rows emit null-padded marker elements so cursors still advance. Narrowing splits bounds at the outer/inner seam, applying the inner refinement **only to the boundary outer row** — a deliberate deviation from convex-helpers, whose `FlatMapStream.narrow` applies inner bounds to every outer row (a correctness bug there; a regression test here covers the exact case).
- **`distinct`** — loose index scan: emits the first document per group of equal order-key prefix values, issuing one narrowed index read per group instead of scanning all rows. The prefix requirement is enforced at the type level (`Key extends readonly [...Fields, ...]`).
- **`orderBy`** — positional order-key relabel (values unchanged), so streams over different indexes/tables with compatible value order can be merged; length mismatch is a compile error.
- **Tiebreaker positions**: each stream records where its runtime key carries the implicit `_id` tiebreakers its type-level key omits (the trailing one, plus a `flatMap` result's interior one). `orderBy` relabels only the type-visible positions and `distinct` translates its prefix into the runtime prefix covering those fields, so both work on `flatMap` results instead of being rejected by a raw length/prefix comparison.
- The layer's code-review commit routes `flatMap` and `orderBy` through the shared `_id`-tiebreaker helper.

## Verification

- Join + filtered-outer tests, the flatMap boundary-pagination regression test, distinct groups asc/desc, distinct pagination + filter-after, orderBy relabel/merge, orderBy + distinct on a `flatMap` result (relabeled runtime key, pagination, distinct over the outer key and over a prefix reaching into the inner key), plus type-level tests for key concatenation, innerKey mismatch, distinct prefix errors, orderBy length mismatch, and relabeling a join.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m