### PR TITLE
Migrate Claude Code configuration to Codex

### DIFF
--- a/.agents/skills/create-changeset/SKILL.md
+++ b/.agents/skills/create-changeset/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: create-changeset
+description: >-
+  Write a Changesets changeset file for the current branch. Use when the user
+  asks to add a changeset, write a changeset, or prepare changes for release,
+  and before opening a PR that changes published @confect/* code.
+---
+
+A changeset is a `.changeset/<name>.md` file: YAML frontmatter listing affected packages with semver bump types, then a changelog entry.
+
+```md
+---
+"@confect/react": minor
+---
+
+Description of the change for the changelog.
+```
+
+The entry is **release-note prose for consumers reading `CHANGELOG.md`** — people who use the published packages through the documented API and have never read Confect's source. The one rule everything below serves: **describe the change to the package's public surface as a consumer experiences it; never summarize the diff.**
+
+You will usually have just made the change yourself. Write from your knowledge of the intent and the user-facing outcome. Use the diff only to confirm which published packages changed and to catch surface changes you forgot — not as source material for prose.
+
+> **Do not imitate existing changesets or CHANGELOG entries.** Many past entries over-describe implementation and name internal symbols; they are precedent for file format only, not for style or level of detail. Read `.changeset/` only to avoid filename collisions.
+
+## 1. List the user-visible delta
+
+Before writing any prose, list what changed on the public surface. Only four kinds of things belong on this list:
+
+1. **Exports consumers call** — functions, hooks, services, classes, types they write in their own code (`useQuery`, `FunctionSpec.publicQuery`, `TestConfect.layer`).
+2. **Observable behavior** — results, type errors at consumer call sites, runtime errors and their messages, what `confect codegen` / `confect dev` print and their exit codes.
+3. **Authored artifacts** — file layouts the user writes (`confect/notes.spec.ts`), generated names they reference (`refs.notes.list`).
+4. **Dependency and peer range changes** on published packages.
+
+Diff hunks that change nothing on this list — internal helpers, type plumbing, codegen pipeline steps, test files — do not appear in the changeset at all, not even as an aside.
+
+- **Empty list, no published package behavior touched** → no changeset (internal refactors, tests, tooling, comments).
+- **Empty list, but published code changed in a way that could conceivably surface** → one-sentence `patch` stating the observable risk area, without naming internals.
+
+## 2. The public-surface test
+
+Confect's public API is what the documentation and example app teach. Every identifier you intend to name in the entry must pass one of:
+
+- **Documented**: appears in `apps/docs/**/*.mdx`
+- **Demonstrated**: used via a `@confect/*` import in `apps/example/`
+- **New in this branch**: added by this change, exported from the package's public entry point, and something a consumer will type in their own code
+
+Names that are consumer-observable by nature also pass without a grep hit: npm package names in dependency/peer range changes, web-platform globals, and fields of the published `package.json` (e.g. `sideEffects`, `exports`).
+
+Verify — don't assume:
+
+```bash
+grep -rn "TheName" apps/docs --include="*.mdx"
+grep -rn "TheName" apps/example/src apps/example/confect
+```
+
+A name that fails the test doesn't get prose about it — it gets **replaced by the consumer-facing wrapper it serves**, or the sentence is cut. If you cannot state the change without naming an internal symbol, that's strong evidence the change isn't user-facing; drop to a one-line `patch` or no changeset.
+
+The same test applies to _mechanics_, not just identifiers: a sentence narrating how the fix works internally (what now decodes what, which step of the pipeline changed, what was renamed) is implementation-facing even if every noun is public. Frame every sentence around what the consumer authors, calls, gets back, or sees in their terminal.
+
+## 3. Frontmatter and bump
+
+Read `.changeset/config.json` for `baseBranch` and the fixed group. All `@confect/*` packages version together, so the frontmatter's job is accuracy, not storytelling: list each published package whose _own surface or behavior_ changed. Don't add a package just because it contains supporting plumbing for another package's feature.
+
+- **`major`** — removed/renamed exports or behavior changes that break existing consumer code. One major bumps the whole fixed group; reserve for genuine breaks.
+- **`minor`** — new consumer-facing exports, new optional parameters, new capabilities, backward-compatible observable refinements, raised peer-dependency floors (consumers must upgrade the peer alongside).
+- **`patch`** — bug fixes, typing fixes that don't change call-site shape, performance, dependency bumps requiring no consumer action, docs/JSDoc fixes.
+
+When in doubt: minor for new things, patch for fixes; major only when consumers must change their code.
+
+Name the file with a short kebab-case slug describing the change (`add-use-paginated-query`, `fix-pagination-cursor`).
+
+## 4. Write the entry
+
+**Default shape: one sentence** naming the affected API and what changed. Add a short second paragraph only when the symptom or new behavior isn't obvious from the summary. Reserve multi-paragraph entries with code blocks for new APIs worth a usage sample and for breaking changes.
+
+- Imperative, present-tense summary: "Add", "Fix", "Remove" — not "Added", "Fixed".
+- "Now …" / "Previously …" for behavior explanation. Plain technical prose; no marketing, no emojis.
+- Backtick every symbol, flag, path, and command a reader might search for; module-qualify names (`Schema.decode`, `Cron.prev`).
+- For runtime errors, quote (or closely paraphrase) the message the user sees — never the internal error class name.
+- New API worth adopting → a short fenced usage example, with the `import` line if non-obvious.
+- Consumers must rewrite call sites → adjacent **Before:** / **After:** fenced blocks.
+- Non-trivial breaking change → one-line summary, a `### Breaking Changes` bullet list of removed/renamed/retyped surfaces, and a short "To migrate, …" paragraph usable without reading the diff.
+- One body across all listed packages — the frontmatter already says which packages moved. If server and client consumers need substantively different guidance, write two changesets.
+
+Omit: PR/commit links and `Thanks @…` (automation adds them); "this PR"/"this commit" phrasing; motivation backstory; vague summaries ("Improve performance", "Update types"); history of prior workarounds — describe where the consumer lands, not the journey.
+
+### Example
+
+A real PR added a `usePaginatedQuery` hook to `@confect/react`, supported by new decoding helpers and ref types in `@confect/core`.
+
+**Bad — narrates the supporting plumbing, shows no usage:**
+
+```md
+Add typed paginated query support to `@confect/react` with `usePaginatedQuery`, including typed paginated args, result items, and pagination options. Add supporting pagination page decoding and public paginated query reference types to `@confect/core`.
+```
+
+The second sentence fails the public-surface test: consumers never import the decoding helper or the reference types; they exist to make the hook work. "Typed paginated args, result items, and pagination options" describes the types' existence instead of what anyone writes.
+
+**Good — the hook as the consumer uses it:**
+
+````md
+Add `usePaginatedQuery` to `@confect/react` — a typed wrapper around Convex's paginated queries that accepts a Confect query ref and decodes each page of results through the query's returns schema.
+
+```ts
+import { usePaginatedQuery } from "@confect/react";
+
+const { results, status, loadMore } = usePaginatedQuery(
+  refs.public.notes.list,
+  { author },
+  { initialNumItems: 10 },
+);
+```
+````
+
+## 5. Final check
+
+Reread the entry as a consumer who knows the docs but has never seen Confect's source, and confirm:
+
+1. Every backticked identifier passes the public-surface test of section 2.
+2. No sentence explains how the change was implemented — only what the consumer authors, calls, receives, or sees.
+3. The frontmatter lists only packages whose own surface or behavior changed.
+4. The summary alone tells a reader whether the release affects them.
+
+If any check fails, fix the entry before saving — don't ship it with a caveat.

--- a/.agents/skills/managing-prereleases/SKILL.md
+++ b/.agents/skills/managing-prereleases/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: managing-prereleases
+description: >-
+  How to optionally ship a major version of `@confect/*` as iterative Changesets
+  prereleases on a dedicated `vN` release branch before graduating to stable —
+  one possible release path for a major, not the only one. Use whenever the user
+  wants to cut a beta/next/prerelease, set up a `vN` branch, run `pnpm changeset
+  pre enter`/`pre exit`, publish `X.0.0-next.N` versions under the npm `next`
+  dist-tag, or merge a prerelease line back into `main`.
+---
+
+# Managing prereleases
+
+A major version of `@confect/*` can be shipped as iterative prereleases on a dedicated `vN` branch under the npm `next` dist-tag, then graduated to stable when `vN` merges into `main`. This is one release path for a major, not a requirement — a major can also go straight out as a stable release from `main` like any other version. Reach for this workflow only when a major warrants a prerelease cycle (e.g. to let consumers try it under `@next` before it lands on `latest`).
+
+For Changesets-specific behavior and caveats, see the upstream [Changesets prereleases docs](https://github.com/changesets/changesets/blob/main/docs/prereleases.md). Read them in full before your first prerelease cycle — the docs themselves open with: "Prereleases are very complicated! Using them requires a thorough understanding of all parts of npm publishes. Mistakes can lead to repository and publish states that are very hard to fix."
+
+## Conventions
+
+- All `@confect/*` packages version together via the `fixed` group in `.changeset/config.json`, so a single `pnpm changeset` covers every package being bumped for the major.
+- The release branch is named after the target major (`v9`, `v10`, …). `main` continues to receive patch releases of the current stable line while `vN` is in flight.
+- Prereleases publish through the existing [`.github/workflows/release.yml`](.github/workflows/release.yml), extended to trigger on `vN` alongside `main`. Do **not** add a separate `release-vN.yml` — npm trusted publishing (OIDC) is configured for `release.yml`, and a differently named workflow fails publish with a misleading `E404`.
+- The Changesets `pre` tag is `next`, which also becomes the npm dist-tag. Consumers opt in with `pnpm add @confect/server@next`; `latest` continues to resolve to the current stable line.
+- `pnpm release` (defined in the root `package.json`) is `pnpm build && changeset publish`. It works the same in pre mode and stable mode — the difference is purely in what `.changeset/pre.json` / the changesets folder contain at publish time.
+
+## Never run prereleases on `main`
+
+The upstream docs are explicit on this:
+
+> If you decide to do prereleases from the default branch of your repository, without having a branch for your last stable release without the prerelease changes, you will block other changes until you are ready to exit prerelease mode. We thoroughly recommend only running prereleases from a branch other than the default branch.
+
+Always use a dedicated `vN` branch so `main` can keep cutting patch releases of the current stable line.
+
+## Caveats to keep in mind
+
+These are from the Changesets docs but are easy to miss:
+
+- **Prerelease versions bump dependents more aggressively than stable releases.** Most semver ranges do not satisfy prerelease versions (e.g. `^5.0.0` is not satisfied by `5.1.0-next.0`), so `changeset version` will bump packages depending on a prereleased package even when the dependent itself has no changeset. With the `@confect/*` fixed group this is mostly invisible, but expect every package in the group to move in lockstep on every `next.N`.
+- **New packages introduced during a prerelease cycle publish to the `latest` dist-tag, not `next`.** A package being published for the first time always goes to `latest`, and continues going to `latest` for subsequent prereleases until the cycle exits. If a brand-new `@confect/foo` is added mid-cycle, its initial publish is _not_ gated by `@next` and will be visible to all consumers immediately.
+- **Reuse `release.yml` for vN publishes — never add `release-vN.yml`.** npm trusted publishing matches on workflow filename. A separate workflow (e.g. `release-v9.yml`) will not match the trusted publisher entry for `release.yml`, and publish fails with `E404` rather than a clear auth error. Extend the existing workflow instead.
+
+## Entering prerelease mode
+
+1. **Create the release branch off `main`.**
+
+   ```bash
+   git switch main && git pull
+   git switch -c v9
+   ```
+
+2. **Point `baseBranch` at the release branch** in `.changeset/config.json` so `changeset version` compares against the right history:
+
+   ```diff
+   - "baseBranch": "main",
+   + "baseBranch": "v9",
+   ```
+
+3. **Enter pre mode with the `next` tag.** This creates `.changeset/pre.json`, which locks subsequent `changeset version` runs into producing `X.0.0-next.N` and tags the npm publish with `next`.
+
+   ```bash
+   pnpm changeset pre enter next
+   ```
+
+4. **Extend `release.yml` to publish from `vN`.** Add the release branch to the existing workflow's `push.branches`:
+
+   ```diff
+    on:
+      push:
+        branches:
+          - main
+   +      - v9
+   ```
+
+   The other pieces of branch-awareness are permanent fixtures of `release.yml` (kept in place between prerelease cycles) — verify they are still present rather than adding them: `changesets/action@v2` opens its Version Packages PR against the pushed branch by default (its `pr-base-branch` input defaults to `github.ref_name`, so no explicit input is needed), and the docs deployment step is gated with `if: steps.changesets.outputs.published == 'true' && github.ref_name == 'main'`. The prerelease cycle must not touch the docs `release` branch — that tracks the stable line.
+
+5. **Mirror the branch into the other CI workflows.** Add `- v9` to the `push.branches` and `pull_request.branches` lists in any CI workflows that gate `main` (typically `docs.yml`, `example.yml`, `packages.yml`) so PRs against `v9` run the same checks as PRs against `main`.
+
+6. **Commit and push.**
+
+   ```bash
+   git add .changeset/config.json .changeset/pre.json .github/workflows
+   git commit -m "Enter v9 prerelease mode and extend release workflow"
+   git push -u origin v9
+   ```
+
+After the push, `changesets/action` opens a `Version Packages (next)` PR against `v9`. From this point on, retarget every PR that should ship as part of the v9 line at `v9` instead of `main`.
+
+## Publishing iterative prereleases
+
+While `.changeset/pre.json` exists on `v9`:
+
+- Author changesets normally with `pnpm changeset` on feature branches targeting `v9`. Each merged PR is appended to the open `Version Packages (next)` PR.
+- Merging the `Version Packages (next)` PR bumps the next `X.0.0-next.N` and publishes under the `next` dist-tag.
+- The merged changeset files are kept around (Changesets v3 moves consumed ones into `.changeset/pre/`) — Changesets needs them to compose the final stable changelog on exit. Do not delete them manually.
+
+There is no required cadence; ship as many `next.N`s as the major needs.
+
+## Exiting prerelease mode
+
+1. **Exit pre mode and apply the final versions on the release branch.** Both happen in a single commit, directly on `v9` (no PR), matching the Changesets docs' recommended exit workflow.
+
+   ```bash
+   git switch v9 && git pull
+   pnpm changeset pre exit
+   pnpm changeset version
+   pnpm format
+   git add .
+   git commit -m "Exit prerelease mode and version packages"
+   git push
+   ```
+
+   `pre exit` deletes `.changeset/pre.json`. `changeset version` then consumes every changeset accumulated during the prerelease cycle and writes the final stable versions (e.g. `9.0.0`) into each `package.json`. Run `pnpm format` before committing — `changeset version` writes CHANGELOG entries in its own Markdown style, which fails the Format CI job otherwise. Pushing triggers `release.yml`; with no remaining changesets, `changesets/action` skips opening a Version Packages PR and goes straight to `pnpm release`, publishing the final stable to `latest`.
+
+2. **Open a PR merging `vN` back into `main`** with the major as the title (e.g. `v9`). Use a merge commit so the prerelease history is preserved in `main` — merge commits are enabled repo-wide for exactly this case, even though squash is the norm for regular PRs. If the merge-commit option is missing from the UI (or the API returns `405 Merge commits are not allowed`), check that "Allow merge commits" is still enabled in the repository settings and that no "Require linear history" rule exists on `main` — the rule overrides the repo-level toggle and hides the option.
+
+3. **In a follow-up PR against `main`, clean up the branch-specific machinery.** Direct pushes to `main` are disallowed, so branch off `main` and open a PR. In one commit:
+   - Revert `.changeset/config.json` `baseBranch` back to `main`.
+   - Remove `- v9` from `push.branches` and `pull_request.branches` in every workflow that referenced it (including `release.yml`).
+   - `release.yml` continues to publish stable from `main` with no further changes.
+
+   ```bash
+   git switch main && git pull
+   git switch -c cleanup-v9-machinery
+   # edit configs as above
+   git add .changeset/config.json .github/workflows
+   git commit -m "Update \`v9\` branch references to \`main\`"
+   git push -u origin cleanup-v9-machinery
+   # open a PR against main and merge it once CI is green
+   ```
+
+4. **Delete the release branch** once `main` has fully absorbed it.
+
+   ```bash
+   git push origin --delete v9
+   git branch -d v9
+   ```
+
+## Quick reference
+
+| Step                                                   | Command                         |
+| ------------------------------------------------------ | ------------------------------- |
+| Enter pre mode                                         | `pnpm changeset pre enter next` |
+| Author a changeset                                     | `pnpm changeset`                |
+| Apply versions locally (the action normally does this) | `pnpm changeset version`        |
+| Exit pre mode                                          | `pnpm changeset pre exit`       |
+| Publish manually (the action normally does this)       | `pnpm release`                  |
+| Install a prerelease                                   | `pnpm add @confect/server@next` |

--- a/.agents/skills/release-docs/SKILL.md
+++ b/.agents/skills/release-docs/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: release-docs
+description: Deploy docs for the current release by updating the release branch, without publishing a new version
+---
+
+Deploy the docs on `main` (or the ref given in $ARGUMENTS, if any) by triggering
+the "Docs Release" workflow (`.github/workflows/docs-release.yml`), which
+force-pushes that ref to the `release` branch. Mintlify deploys docs from
+`release`, so this publishes docs updates without cutting a new npm release.
+
+Follow these steps:
+
+1. Run `git fetch origin main release` and show what would be deployed:
+   - Docs changes: `git log --oneline origin/release..<ref> -- apps/docs`
+   - Everything else: `git log --oneline origin/release..<ref> -- ':!apps/docs'`
+2. If there are no commits between `origin/release` and the ref, tell me the
+   release branch is already up to date and stop.
+3. If any of the non-docs commits look like unreleased package changes (e.g.
+   changes under `packages/` or pending changesets in `.changeset/`), point
+   them out and warn me that any docs written for those unreleased changes
+   would go live too. Ask me to confirm before proceeding.
+4. Trigger the workflow: `gh workflow run docs-release.yml --ref <ref>`
+   (default ref: `main`).
+5. Watch it to completion (`gh run list --workflow=docs-release.yml`, then
+   `gh run watch <run-id>`) and report whether the `release` branch was
+   updated successfully.

--- a/.agents/skills/upgrade-effect-rc/SKILL.md
+++ b/.agents/skills/upgrade-effect-rc/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: upgrade-effect-rc
+description: Bump the v10 prerelease branch to the latest Effect v4 release candidate and propagate main, migrating source as needed, with changesets and stacked PRs against v10
+---
+
+Keep the `v10` prerelease line on the latest Effect v4 release candidate and
+current with `main`, and open PRs for review against `v10`. Never merge them
+yourself. (The managing-prereleases skill explains how the prerelease line
+itself works.)
+
+A scheduled routine invokes this command by name, and the name is resolved
+against this directory when the routine fires. Renaming this file therefore
+means updating that schedule in the same pass — otherwise the routine stops
+resolving and goes quiet.
+
+## Scope
+
+- **Target branch:** `v10`. If it's gone, or
+  `git show origin/v10:.changeset/pre.json` no longer says `"mode": "pre"`,
+  the prerelease line has graduated: say so, stop, and suggest deleting this
+  command and its routine — they only exist for the v10 cycle.
+- **Latest release candidate:** effect publishes v4 release candidates under
+  the npm `rc` dist-tag, so `npm view effect@rc version` is the lookup.
+  Compare it against the branch's current pin (`overrides.effect` in
+  `origin/v10:pnpm-workspace.yaml`). Already current → no bump to do, but
+  still check for `main` changes to propagate before stopping.
+  **Do not use `effect@beta`.** That tag stopped moving at `4.0.0-beta.107`
+  when the RC line opened, so a run that reads it reports "already current"
+  forever. RC numbering continues the beta sequence rather than restarting —
+  `4.0.0-rc.108` is the release after `4.0.0-beta.107` — so the pin's shape
+  changes at the boundary but its ordering doesn't.
+- **When 4.0 goes stable:** the RC phase is expected to end in Q3/Q4 2026,
+  at which point `rc` stops moving and `npm view effect version` (the
+  `latest` tag) reads `4.x` instead of `3.x`. That's not a bump this command
+  can do on its own — pinning a stable `effect` is an ordinary dependency
+  upgrade and the peer ranges want rethinking. Say so, do the `main`
+  propagation if there is any, and stop; this file needs rewriting before
+  the next run.
+- **Changes from `main`:** the prerelease line absorbs `main` continuously
+  so the eventual `v10` → `main` merge stays small. Whether there's
+  anything to absorb is a **content** question, never an ancestry one.
+  Sync PRs land with their merge commit intact (the repo's merge settings
+  enforce it), so ancestry converges from here on — but the line still
+  carries a long tail of earlier squash-merged syncs, and
+  `git log origin/v10..origin/main`
+  cannot tell the two regimes apart. It is therefore not the trigger:
+  wrong for the squashed tail, and merely redundant once ancestry has
+  caught up. Instead, every run performs the sync merge locally per the
+  merge rules and keeps it only if it changes content:
+  `git diff origin/v10 HEAD` non-empty → deliver it as a sync PR (see
+  Branches and PRs); empty → `main` has nothing new, discard the merge.
+  Never open a PR whose only effect would be recording merge ancestry.
+  No release candidate to bump **and** no content to propagate → say so and
+  stop — no branch, no PR.
+- **In-scope packages:** `effect` plus its lockstep companions from the
+  effect monorepo already present in the workspace (`@effect/platform-node`,
+  `@effect/platform-bun`, `@effect/vitest`) — all carry the same `rc`
+  dist-tag and move to the same prerelease number together. Everything else,
+  including `@effect/tsgo` (which versions independently), belongs to the
+  other upgrade commands.
+
+## Branches and PRs
+
+A run produces up to two PRs, stacked when both are needed, so the merge is
+reviewed as what it is and the bump PR's diff shows only the bump and its
+migration:
+
+- **Sync PR** — branch `sync/main-into-v10`, only when the sync merge
+  changes content (see Scope). Reset from `origin/v10` at the start of
+  the run, then merge `origin/main` into it per the merge rules below.
+  The PR targets `v10`.
+- **Bump PR** — branch `deps/effect-v4-rc`, only when there's a release
+  candidate to bump. Reset from the tip of `sync/main-into-v10` when that
+  branch is in play this run, otherwise from `origin/v10`. In the stacked
+  case the PR targets `sync/main-into-v10` — merge the sync PR first, and
+  when its branch is deleted GitHub retargets the bump PR to `v10`
+  automatically — otherwise it targets `v10`.
+
+Push both branches with `--force-with-lease` so successive runs update the
+same open PRs instead of stacking new ones; refresh an existing PR's title,
+body, and base branch to match the current run's shape. Neither PR ever
+targets `main`.
+
+## Rules
+
+- Perform the sync merge as a real `git merge` of `origin/main` — not a
+  rebase or cherry-picks — so each conflict is resolved exactly once and
+  the resulting commit carries `main`'s tip as its second parent.
+  Take `main`'s side of conflicts except where it would undo the
+  prerelease line: keep `.changeset/pre.json`, `"baseBranch": "v10"` in
+  `.changeset/config.json`, the `v10` entries in the workflow branch lists, the `X.0.0-next.N`
+  versions and their changelog entries, and the Effect v4 pins (`main` is
+  still on v3 — its Effect version bumps never apply here). Never
+  hand-merge `pnpm-lock.yaml`; take either side and let `pnpm install`
+  regenerate it.
+- Changes reaching `v10` through the merge fall into two cases for
+  changelog purposes. Commits whose changesets are still pending on `main`
+  (merged there but not yet released) arrive with their changeset files
+  and ship as-is — don't fold or re-document them. Commits already
+  released on `main` arrive with their changesets consumed, so nothing
+  would mention them in the next `X.0.0-next.N` changelog entry — add a
+  `patch` changeset on the sync branch naming the stable range absorbed,
+  e.g. "Sync with `main`: this prerelease line now includes all changes
+  released in `@confect/*` 9.3.2–9.4.0 — see those versions' changelog
+  entries." Derive the range mechanically from changelogs, not from
+  `git merge-base` (which the line's tail of squash-merged syncs still
+  holds back at an ancient commit): the versions absorbed are the
+  stable `## 9.x.y` headings present in `origin/main`'s CHANGELOG for a
+  `@confect/*` package but absent from `origin/v10`'s copy of the same
+  file before the merge —
+  the fixed group versions together, so any one package's CHANGELOG
+  suffices. No missing headings → no released changes absorbed → skip
+  this changeset.
+- If code arriving from `main` doesn't compile against the branch's
+  current Effect v4 pin (`main` is on v3), migrate it on the sync branch:
+  the sync PR must be green at the current pin on its own, since it merges
+  into `v10` before — and independently of — the bump.
+- On the bump branch, bump every occurrence by searching the repo for the
+  old version string rather than enumerating locations from memory — that
+  catches the `pnpm-workspace.yaml` `overrides` entry (which nothing
+  lints, and a stale entry silently forces the old version at install
+  time), the `minimumReleaseAgeExclude` entries beside it, the exact
+  devDependency pins, and the `^4.0.0-rc.N` peer ranges. Raising the peer
+  floor is deliberate and correct here: the source is compiled against the
+  new release candidate's APIs. Then `pnpm install`, `pnpm lint:fix`
+  (Syncpack) to normalize, and confirm the new version actually resolved
+  with `pnpm why effect`.
+- Read the effect changelogs for every release between old and new
+  **before** touching source, then migrate the Confect source to the new
+  APIs until checks pass. Effect considers its v4 interfaces final as of
+  the RC, so breakage should now be rare and narrow rather than routine —
+  but "rare" is not "none", and when it happens the migration is this
+  command's job, not a reason to bail. A bump that needs no source changes
+  at all is the expected shape from here on.
+- If a migration genuinely can't be brought green with reasonable effort,
+  stop that PR: a blocked sync means no branches and no PRs at all (the
+  bump would build on a broken base); a blocked bump still delivers the
+  sync PR on its own. Either way, report what's blocking and the rough
+  scope — the next scheduled run will retry.
+- If the convex codegen surface is affected, re-run the server codegen
+  scripts (`pnpm codegen:server:mock-backend` /
+  `codegen:server:local-backend`) and commit the complete fixture output —
+  check `git status` for newly generated files, since CI's codegen check
+  only diffs tracked files.
+
+## Delivering
+
+1. Verify with the full repo checks (`pnpm check`, `pnpm test`,
+   `pnpm build`) plus the server backend suites
+   (`pnpm test:server:mock-backend` and `pnpm test:server:local-backend`).
+   In the stacked case, run them on the sync branch before building the
+   bump on top, then again on the bump branch. Anything the local
+   environment genuinely can't run, leave to the PRs' CI — and get it
+   green.
+2. Author the changesets following the create-changeset skill. The sync
+   changeset (rules above) lives on the sync branch. The bump branch gets
+   its own changeset — the published peer ranges changed, so this is
+   user-facing. Use `patch` for both: the prerelease line's pending major
+   changeset already governs the `X.0.0-next.N` version. The bump
+   changeset states the new required release candidate and any
+   consumer-visible consequences of the API changes.
+3. Push the branches (unless this session was assigned a branch) and
+   open or refresh the PRs per Branches and PRs. Sync PR body: what the
+   merge changes, summarized from the content diff against `origin/v10`
+   rather than from `git log` (which still lists the commits absorbed by
+   earlier squash-merged syncs), the stable version range absorbed
+   (matching the changeset), and any migrations needed to keep the merge
+   green at the current pin. Bump PR body: old → new version,
+   links to the release notes covered, and a summary of the source
+   migrations made (or a note that none were needed).

--- a/.agents/skills/upgrade-internal-deps/SKILL.md
+++ b/.agents/skills/upgrade-internal-deps/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: upgrade-internal-deps
+description: Upgrade internal-only dependencies (toolchain devDependencies and the private workspace packages' deps) and open a PR — no changeset
+---
+
+Upgrade the dependencies that consumers of the `@confect/*` packages can never
+see, and open a PR for review. Never merge it yourself.
+
+## Scope
+
+Every `package.json` dependency that is **not** claimed by
+`/upgrade-published-deps` (whose scope covers the published packages'
+`dependencies`/`peerDependencies` plus their lockstep companions, such as
+`react-dom` with `react`): the workspace's devDependencies (build/test/lint
+toolchain, types) and the dependencies of every private workspace package —
+the apps under `apps/*` and the server-test fixture workspaces. Skip
+published-surface deps here even where they appear as devDependency pins,
+since their pins move with their ranges.
+
+## Rules
+
+- Discover updates with `pnpm outdated -r` and bump to latest. Don't restate
+  or hand-enforce the workspace's pinning conventions — apply the bumps, then
+  run `pnpm lint:fix` (Syncpack) to normalize.
+- Majors are fair game: attempt them, and if one requires more than mechanical
+  changes to get green, drop it from the batch and explain what it would take
+  in the PR description (or in your final report, if the run ends up applying
+  nothing and opens no PR).
+- Bumping `@effect/tsgo` also means updating
+  `lsp.effect-tsgo.settings.package_version` in `.zed/settings.json` to the same
+  version. That pins the copy of the binary Zed's `effect-tsgo` extension
+  downloads, and it lives outside any dependency map, so `pnpm outdated` will
+  never surface the drift. Left stale, the editor reports Effect diagnostics
+  from a different version than `tsc` does.
+- These upgrades are not user-facing: **no changeset**.
+
+## Delivering
+
+1. If nothing gets applied, say so and stop — no branch, no PR, even if some
+   upgrades were spotted and deferred; the next scheduled run will surface
+   them again.
+2. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`).
+   Anything the local environment genuinely can't run, leave to the PR's CI —
+   and get it green.
+3. Push a branch (`deps/<short-description>`, unless this session was assigned
+   a branch) and open a PR against `main`. In the body, list what was bumped
+   and note anything deliberately skipped and why.

--- a/.agents/skills/upgrade-published-deps/SKILL.md
+++ b/.agents/skills/upgrade-published-deps/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: upgrade-published-deps
+description: Upgrade dependencies on the published surface of the @confect/* packages (their dependencies/peerDependencies), with a changeset and a PR
+---
+
+Upgrade the dependencies that consumers of the `@confect/*` packages can see,
+and open a PR for review. Never merge it yourself.
+
+## Scope
+
+A package is published iff its `package.json` does not say `"private": true` —
+note that some private fixture workspaces also carry `@confect/*` names, so go
+by the field, not the name. A dependency is in scope iff it appears in the
+`dependencies` or `peerDependencies` of any published package, together with
+its lockstep companions: packages that must match its version (e.g.
+`react-dom` with `react`) and any `overrides` entry in `pnpm-workspace.yaml`
+that pins one of its transitive dependencies (e.g. `@effect/typeclass` with
+`effect`). Everything else is handled by `/upgrade-internal-deps`.
+
+When bumping an in-scope dependency, move every occurrence across the
+workspace together — search the repo for the dependency's name rather than
+enumerating locations from memory. Syncpack (`pnpm lint`) polices consistency
+between `package.json` files, but **nothing lints the `overrides` block**, and
+a stale override silently forces the old version at install time. After
+bumping, confirm the new versions actually resolved (e.g. `pnpm why <dep>`).
+
+## Rules
+
+- Read the release notes/changelogs for each pending update before applying
+  it. Treat minor bumps of `0.x` packages (most of the `@effect/*` ecosystem,
+  `convex-test`) as potentially breaking, not routine.
+- **Never attempt a major of a peer ecosystem** (effect, convex, react).
+  Instead, summarize what's available, what it breaks, and a rough migration
+  scope — in the PR description if this run opens one, otherwise in your final
+  report (the no-PR rule below still applies).
+- If a non-major upgrade snowballs into a real migration (API rewrites,
+  behavioral changes beyond mechanical fixes), drop it from the batch and
+  document it the same way.
+- Leave peer ranges alone unless the upgraded code actually requires raising a
+  floor. Raising or widening a published range is a deliberate act that must
+  be called out in the changeset.
+- If the behavior of convex or the Confect CLI changed, re-run the server
+  codegen scripts (`pnpm codegen:server:mock-backend` /
+  `codegen:server:local-backend`) and commit the complete fixture output —
+  check `git status` for newly generated files, since CI's codegen check only
+  diffs tracked files.
+
+## Delivering
+
+1. If nothing gets applied, say so and stop — no branch, no PR, even if
+   deferred upgrades (e.g. a peer-ecosystem major) were spotted; the next
+   scheduled run will surface them again.
+2. Verify with the full repo checks (`pnpm check`, `pnpm test`, `pnpm build`)
+   plus the server backend suites (`pnpm test:server:mock-backend` and
+   `pnpm test:server:local-backend`). Anything the local environment genuinely
+   can't run, leave to the PR's CI — and get it green. Drop upgrades that fail
+   here before moving on.
+3. Add a changeset iff any published `package.json` changed — follow the
+   create-changeset skill.
+4. Push a branch (`deps/<short-description>`, unless this session was assigned
+   a branch) and open a PR against `main`. In the body, list what was bumped
+   with links to release notes, and note anything deliberately skipped and why.

--- a/.agents/skills/upgrade-runtime-pins/SKILL.md
+++ b/.agents/skills/upgrade-runtime-pins/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: upgrade-runtime-pins
+description: Upgrade the runtime version pins that live outside package.json dependency maps (Node, pnpm, bun) and open a PR
+---
+
+Upgrade the repo's pinned runtime versions and open a PR for review. Never
+merge it yourself.
+
+## Scope
+
+Version pins that live outside `package.json` dependency maps: `.node-version`,
+the `packageManager` field in the root `package.json`, and the tool versions in
+`mise.toml`. Not every consumer reads these files — some CI setup actions under
+`.github/actions/` resolve Node or pnpm from other sources — so after updating
+a pin, check where each version is actually resolved and call out any consumer
+the bump doesn't reach in the PR description. Do not touch GitHub Actions
+`uses:` versions or devcontainer config — Dependabot owns those.
+
+## Rules
+
+- Bump within each tool's current major line. Take a major line (a new Node
+  LTS, a pnpm or bun major) only if the release notes show nothing that
+  affects this repo and the checks stay green; otherwise describe the
+  available jump in the PR description (or in your final report, if the run
+  ends up applying nothing and opens no PR).
+- **Never change `engines` floors** in the published packages — those are
+  published-surface policy and belong to a deliberate, changeset-recorded
+  decision, not this routine.
+
+## Delivering
+
+1. If nothing gets applied, say so and stop — no branch, no PR, even if a
+   major-line jump was spotted and deferred; the next scheduled run will
+   surface it again.
+2. Verify by reinstalling with the new versions and running the full repo
+   checks (`pnpm check`, `pnpm test`, `pnpm build`). Anything the local
+   environment genuinely can't run, leave to the PR's CI — and get it green.
+3. Push a branch (`deps/<short-description>`, unless this session was assigned
+   a branch) and open a PR against `main`, noting in the body which pins moved
+   and linking their release notes.

--- a/.agents/skills/writing-commit-messages/SKILL.md
+++ b/.agents/skills/writing-commit-messages/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: writing-commit-messages
+description: >-
+  Write thoughtful, prose-style git commit messages with a sentence-case
+  imperative-mood subject under 50 characters, a blank line, then a
+  Markdown-formatted body that explains *why* the change was needed — never just
+  *what* it did. Use this skill whenever writing a commit message, running `git
+  commit`, preparing to commit code on the user's behalf, or drafting PR
+  descriptions that follow commit-message conventions — even when the user
+  doesn't explicitly ask for commit-message help. Also use when the user asks
+  about git commit style or conventions.
+---
+
+# Writing commit messages
+
+A commit message is documentation written for your future self and your colleagues. The diff already shows _what_ changed; the message exists to explain _why_ it needed to change, what was wrong before, and what reviewers or future readers should watch for. The size of the diff has nothing to do with the appropriate size of the message — a one-character whitespace fix may deserve three paragraphs of context, and a 500-line mechanical refactor may need only two sentences.
+
+## Structure
+
+Every commit message has this shape:
+
+```
+Subject line in sentence case, imperative mood, under 50 chars
+
+A body that explains the motivation for this change. Use as many paragraphs as you need.
+
+If the old behavior was wrong, describe what it was and why. Then describe the new behavior and how it addresses the problem.
+
+Mention tradeoffs, alternatives considered, or side effects that reviewers should watch for.
+
+Refs: #123
+```
+
+The blank line between subject and body is required. Many tools (GitHub, `git log --oneline`, `git shortlog`) depend on it to distinguish the two.
+
+## Markdown
+
+The body is rendered as Markdown by GitHub, GitLab, and most code-review tools. Use formatting — inline `code` for symbols and paths, fenced code blocks for commands or output, lists for enumerated points, links for issues and external references — where it aids readability. Don't decorate prose with bold or headings for their own sake.
+
+## Rules
+
+1. **Separate subject from body with a blank line.**
+2. **Limit the subject line to 50 characters.** 72 is the hard ceiling; GitHub truncates beyond that.
+3. **Use sentence case for the subject.** Capitalize only the first word. Leave the rest lowercase, except proper nouns, acronyms (`API`, `README`), and code identifiers (`useState`, `CartContext`, file paths), which keep their natural casing.
+4. **Do not end the subject line with a period.**
+5. **Use the imperative mood in the subject.** Write "Fix bug" not "Fixed bug" or "Fixes bug". A reliable test: the subject should complete the sentence "If applied, this commit will \_\_\_".
+6. **Use the body to explain _what_ and _why_, not _how_.** The how is in the diff.
+
+## Writing the subject
+
+The subject is the highest-leverage part of the message — it's what shows up in `git log --oneline`, GitHub PR titles, blame views, and `git bisect` output. Treat it like a headline.
+
+- Be specific. "Fix login bug" → "Fix logout redirect when session has expired".
+- Drop filler verbs like "Update", "Change", "Modify" when you can name what you actually did.
+- Don't invent a scope prefix (`[auth]:`, `auth:`) unless the surrounding history uses one.
+- If you can't fit the subject in 50 chars, the commit is probably doing too much — consider splitting it.
+
+## Writing the body
+
+A good body answers three questions, in roughly this order:
+
+1. **Why was this change needed?** What problem does it solve? What was the symptom, motivation, or upstream request?
+2. **What was wrong with the old behavior?** Describe it concretely. This is the hardest thing to reconstruct from the diff later, so it's the highest-value content.
+3. **What does the new behavior do?** A high-level description — not a line-by-line walkthrough of the diff.
+
+Then add anything else a reviewer or future reader needs:
+
+- Tradeoffs and alternatives considered
+- Side effects, edge cases, performance implications
+- Follow-ups that are intentionally out of scope
+- Links to issues, RFCs, related commits, or external discussion
+
+If the change is genuinely trivial and self-explanatory ("Fix typo in README"), the body is optional. For anything non-obvious, write it. A useful test: would a reader five years from now understand this commit without any other context?
+
+## Examples
+
+**Bad — subject only, no context:**
+
+```
+Update files
+```
+
+**Bad — narrates the diff instead of explaining motivation:**
+
+```
+Change useState to useReducer in CartContext
+
+Refactored the cart state management to use useReducer instead of useState. Added an action dispatcher and moved the state updates into a reducer function. Updated all the consumers.
+```
+
+A reader can see all of that themselves. The message adds nothing.
+
+**Good — explains why, what was wrong, and tradeoffs considered:**
+
+```
+Switch cart state to useReducer
+
+The cart was using `useState` with deeply nested updates, which made several recent bugs (#412, #418) hard to trace — each consumer was mutating state in slightly different ways and the order of updates mattered.
+
+Moving to a reducer centralizes the transitions and makes the valid state machine explicit. As a side effect, this also fixes #412 by serializing the "add item" and "apply coupon" actions.
+
+Considered Zustand but kept the change minimal to avoid pulling in a new dependency for one context.
+```
+
+**Good — trivial change, body legitimately omitted:**
+
+```
+Fix typo in installation docs
+```
+
+## When committing on the user's behalf
+
+If running `git commit` as part of an agentic task:
+
+- Stage and review the diff first; the message should reflect what's actually in the diff, not what was planned.
+- If the change touches multiple unrelated concerns, propose splitting it into multiple commits before writing the message.
+- Use `git commit -F <file>` or a heredoc rather than `-m "..."` for multi-line messages — `-m` makes multi-paragraph bodies awkward.
+- Never invent issue numbers, ticket IDs, or co-author trailers. Only include them if the user provided them or they're visible in the repo context.

--- a/.agents/skills/writing-technical-documentation/SKILL.md
+++ b/.agents/skills/writing-technical-documentation/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: writing-technical-documentation
+description: >-
+  Guides writing clear, well-structured technical documentation following
+  Mintlify's best practices (Diátaxis framework, audience awareness, style/tone,
+  navigation, SEO/AEO). Use when writing, reviewing, or improving documentation,
+  guides, tutorials, API references, or any user-facing technical content.
+---
+
+# Writing technical documentation
+
+Best practices for technical documentation, distilled from [Mintlify's Guide to Technical Writing](https://www.mintlify.com/guides/introduction).
+
+## Content types (Diátaxis framework)
+
+Categorize every page into exactly one type before writing:
+
+| Type             | Reader Goal              | Structure                          | Assumed Knowledge         |
+| ---------------- | ------------------------ | ---------------------------------- | ------------------------- |
+| **Tutorial**     | Learn through practice   | Sequential steps, guided tasks     | None (beginner)           |
+| **How-to guide** | Solve a specific problem | Problem-solution, logical sequence | Some (intermediate)       |
+| **Reference**    | Look up precise details  | Scannable facts, tables, specs     | Significant (experienced) |
+| **Explanation**  | Understand concepts      | Conceptual discussion, background  | Any level                 |
+
+### Writing approach per type
+
+**Tutorials**: Set expectations upfront on what the reader will achieve. Use incremental steps. Minimize choices. Point out milestones. Focus on actions over theory.
+
+**How-to guides**: Write from the user's perspective, not the product's. Describe a logical sequence. Skip obvious steps ("Press enter to submit"). Minimize extraneous context.
+
+**Reference**: Optimize for scannability. Prioritize consistency (tables, naming, specs). Avoid explanatory prose. Provide copy-paste-ready examples.
+
+**Explanation**: Provide background context and design decisions. Acknowledge alternatives. Connect to other product areas or industry concepts.
+
+## Know your audience
+
+Each piece of content should target **one specific persona**. Common personas:
+
+- **Technical decision maker** evaluating architecture
+- **End user** learning to get started or complete tasks
+- **Developer** integrating the product
+- **AI agents/LLMs** retrieving structured answers
+
+Before writing, answer: _What is the reader trying to accomplish? How much do they already know?_
+
+### Writing for AI agents
+
+Practices that help LLMs also help humans:
+
+- Clear, descriptive headings
+- Correct semantic markup
+- Explicit prerequisites
+- No vague references ("this", "it" without clear antecedent)
+- Consistent terminology
+- Defined acronyms and jargon
+- Complete, runnable code examples
+
+## Style and tone
+
+### Core principles
+
+1. **Be concise**—readers want to achieve a goal, not read prose. Cut unnecessary words.
+2. **Clarity over cleverness**—simple, direct language. Avoid jargon and complex sentences.
+3. **Active voice**—"Create a configuration file" not "A configuration file should be created."
+4. **Skimmable**—use headings to orient. Break up text-heavy paragraphs.
+5. **Second person**—address the reader as "you."
+
+### Common mistakes to avoid
+
+- Spelling and grammar errors (erode trust in the product)
+- Inconsistent terminology ("API key" in one place, "API token" in another)
+- Product-centric language the user wouldn't understand
+- "Duh" documentation ("Click Save to save")
+- Colloquialisms (hurt clarity, especially with localization)
+
+### Style guide references
+
+When standardizing, lean on established guides:
+
+- [Google Developer Documentation Style Guide](https://developers.google.com/style)
+- [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
+
+## Navigation and organization
+
+### Structural principles
+
+- **Descriptive headings**: accurately describe what follows; avoid vague or clever labels.
+- **Self-contained pages**: each page should be understandable independently (users and AI may land on any page).
+- **Semantic markup**: use heading levels hierarchically; lists for lists, tables for tabular data, code blocks for code.
+- **Logical ordering**: definitions before edge cases, common use case before advanced scenarios.
+- **Consistent terminology**: one term per concept, everywhere.
+
+### Common pitfalls
+
+- Overloaded categories (too many top-level sections)
+- Buried essential content
+- Unclear section names
+- Outdated or deprecated content left without markers
+
+## Media
+
+Use screenshots, GIFs, and videos **sparingly and intentionally**. Media is supplementary, not primary.
+
+| Media      | When to use                                     | Maintenance cost       |
+| ---------- | ----------------------------------------------- | ---------------------- |
+| Screenshot | UI elements that are hard to describe in text   | Low (~5 min to update) |
+| GIF        | Short, complex workflows or promotional content | Medium (~1 hour)       |
+| Video      | Abstract concepts and long workflows            | High (several hours)   |
+
+Always provide alt text for images, subtitles for videos, and transcripts for audio.
+
+## SEO and answer engine optimization
+
+### Content SEO
+
+- Clear H1/H2/H3 structure with keywords in headings
+- Short paragraphs and bullet points
+- Descriptive internal links ("Learn more about rate limiting" not "Click here")
+
+### Technical SEO
+
+- Meta titles (50-60 chars) and descriptions (150-160 chars) per page
+- Descriptive alt text on images
+- Mobile-friendly layout
+- Up-to-date sitemap
+
+### AEO (for AI-powered search)
+
+- Define terms explicitly on first use
+- Provide complete, runnable code examples
+- Make each section self-contained (AI retrieves sections independently)
+- Document errors and edge cases with causes and solutions
+- Mark deprecated features clearly
+
+## Maintenance
+
+- **Automate**: track stale content, detect product changes, enforce standards with linters (e.g. Vale).
+- **Prioritize**: focus review effort on high-traffic pages, not every page equally.
+- **Remove wrong docs**: outdated/misleading content is worse than no content.
+- **Plan periodic resets**: every 1-2 years, consider a structured audit and rewrite of the most impactful sections.
+
+## Content freshness
+
+Optimize for evergreen content. If something represents a point-in-time snapshot, it's better as a blog post. Avoid embedding frequently-changing information (e.g. pricing) directly in docs.
+
+## Additional resources
+
+For the full guide with expert quotes and detailed examples, see [reference.md](reference.md).

--- a/.agents/skills/writing-technical-documentation/reference.md
+++ b/.agents/skills/writing-technical-documentation/reference.md
@@ -1,0 +1,235 @@
+# Technical writing reference
+
+Detailed reference material from [Mintlify's Guide to Technical Writing](https://www.mintlify.com/guides/introduction). This supplements the main SKILL.md with expert quotes, expanded guidance, and full examples.
+
+## Content types—expanded
+
+### Selecting a content type
+
+| Question                               | Tutorial               | How-To                   | Reference                | Explanation             |
+| -------------------------------------- | ---------------------- | ------------------------ | ------------------------ | ----------------------- |
+| What is the user's goal?               | Learn through practice | Solve a specific problem | Find precise information | Understand concepts     |
+| How knowledgeable is the user?         | Beginner               | Intermediate             | Experienced              | Any level               |
+| How is the content structured?         | Step-by-step           | Problem-solution         | Organized facts          | Conceptual explanations |
+| Is it task-oriented?                   | Yes, guided tasks      | Yes, specific tasks      | No, informational        | No, conceptual          |
+| Is it designed for linear progression? | Yes                    | No                       | No                       | No                      |
+
+### Expert advice
+
+> Reference documentation should be super scannable. As a developer, you want to find "How do I do this specific task?" When I get there, I want to be able to clearly understand the parameters.
+> —**Sarah Edwards, Documentation Engineer at Datastax**
+
+> For complex or multi-threaded releases that touch many parts of your product, you need to provide both practical guidance and conceptual understanding in your documentation. Users need to grasp when and why to use something, not just how.
+> —**CT Smith, Head of Docs at Payabli**
+
+> The trap is to think one framework can rule them all. Don't be so inflexible in enforcing content types that you forget the reader.
+> —**CT Smith, Head of Docs at Payabli**
+
+### Content freshness
+
+Optimize for evergreen documentation. If something represents a moment in time, it's better suited for a blog post. If something changes frequently (e.g., pricing), avoid putting it directly in docs.
+
+---
+
+## Audience—expanded
+
+### The curse of knowledge
+
+> You have the curse of knowledge. You know how everything works, but that's detrimental to your end user.
+> —**CT Smith, Head of Docs at Payabli**
+
+### User research questions
+
+Talk to users to understand:
+
+- How do they describe your product functionality?
+- Do they use unexpected words or names?
+- What do they wish they had more knowledge of?
+- What is explicitly missing from your documentation?
+
+### Feedback mechanisms
+
+- Incorporate thumbs up/down or open-ended surveys directly in docs
+- Use analytics: page views, search queries, drop-off rates
+- Embed in support channels to see user pain points firsthand
+- Test your docs with AI agents—if an AI struggles to answer questions using your docs, that signals improvement areas
+
+### When to stop
+
+> There can be an urge to document every single thing because all information is potentially valuable to someone. But too much content becomes difficult to navigate and maintain. Use communities—like socials or Slack—to serve niche use cases.
+> —**Ethan Palm, Senior Manager of Docs at GitHub**
+
+---
+
+## Navigation—expanded
+
+### Why navigation matters
+
+> Your navigation is like a subway map. It tells you how the whole system hangs together, which is crucial for users evaluating your product.
+> —**CT Smith, Head of Docs at Payabli**
+
+### Mapping the foundation
+
+Align with stakeholders (founders, PMs, engineering leads) on:
+
+- What is the simplest way to explain how the product works?
+- What are the core features?
+- How do users typically adopt the product? Where do they get stuck?
+- How does the architecture influence usage?
+- What are the most important integrations or dependencies?
+- What is changing or evolving?
+- How do people conceptualize the product—by features, use cases, or technical details?
+
+### Validating structure
+
+Track real user journeys with analytics tools:
+
+- **Entry points**: Where do users start? Search, support ticket, or in-product link?
+- **Navigation patterns**: Do they follow the expected hierarchy or take detours?
+- **Friction points**: Where do users pause, loop back, or abandon?
+- **Search behavior**: Are they searching for terms that don't exist in your docs?
+
+> If you're able to hop on a call and ask users, "Show me how you find answers," you might be surprised. They're often using documentation in ways you don't understand.
+> —**Sarah Edwards, Documentation Engineer at Datastax**
+
+### Testing with fresh eyes
+
+New hires are great proxies for new users. Before they become familiar with the product, ask them to complete a task using only the documentation and narrate their thought process.
+
+> Creating a nav structure that makes sense to everyone can be difficult, but try to find something that works for a majority of customers.
+> —**Brody Klapko, Technical Writer at Stash**
+
+> You don't have to be right on the first try. Use all available tools and perspectives to inform your decisions, but be ready to adjust based on how users actually interact with your documentation.
+> —**Ethan Palm, Senior Manager of Docs at GitHub**
+
+---
+
+## Style and tone—expanded
+
+### Enforcing style
+
+Leverage established style guides:
+
+- [Microsoft Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/)
+- [Splunk Style Guide](https://docs.splunk.com/Documentation/StyleGuide/current/StyleGuide/Howtouse)
+- [Google Developer Documentation Style Guide](https://developers.google.com/style)
+
+Automate enforcement with linters like [Vale](https://vale.sh) or CI checks from your documentation provider.
+
+### Consistency
+
+> Consistency is key! You may not be complimented on your consistency, but people will absolutely notice and be frustrated by a lack thereof.
+> —**CT Smith, Head of Docs at Payabli**
+
+---
+
+## Media—expanded
+
+### Decision table
+
+| Media Type  | When to use                                   | Example                           | Update time   |
+| ----------- | --------------------------------------------- | --------------------------------- | ------------- |
+| Screenshots | Tasks difficult to explain with words         | Hidden UI element, obscure button | ~5 min        |
+| GIFs        | Promotional purposes, short complex workflows | Product changelog                 | ~1 hour       |
+| Videos      | Abstract concepts, long workflows             | Tutorials                         | Several hours |
+
+_Table courtesy of Idan Englander, Manager of Technical Writing at Anaconda._
+
+### Guidelines
+
+- Media should be supplementary—if the workflow is clear in text alone, skip visuals
+- Always provide alt text, subtitles, and transcripts for accessibility
+- Balance clarity with maintainability—frequent UI changes make screenshots stale quickly
+
+---
+
+## SEO—expanded
+
+### Content basics
+
+- Use clear H1, H2, H3 with keywords in headings
+- Short paragraphs and bullet points
+- Internal linking with descriptive anchor text ("Learn more about rate limiting" not "Click here")
+
+### Technical SEO
+
+- Meta titles: 50-60 characters; descriptions: 150-160 characters
+- Descriptive alt text on images (e.g., "OAuth 2.0 API authentication flow" not "diagram")
+- Mobile-friendly layout
+- Up-to-date sitemap
+
+### Advanced
+
+- Compress images (WebP/AVIF), target page load under 3 seconds
+- Add schema markup (HowTo, FAQ) for richer search results
+- Keyword research with tools like Google Keyword Planner or Keywords Everywhere
+- Integrate keywords naturally—never stuff
+
+### Answer engine optimization (AEO)
+
+For AI-powered search (ChatGPT, Google AI Overviews, Perplexity):
+
+- Use clear, descriptive headings (no clever/vague labels)
+- Define terms and concepts explicitly on first use
+- Include specific, complete, runnable code examples
+- Make each section self-contained (AI often retrieves individual sections)
+- Structure data logically with tables, lists, code blocks
+- Be explicit about prerequisites and requirements
+- Document errors, edge cases, causes, and solutions
+- Keep content current; mark deprecated features clearly
+
+---
+
+## Maintenance—expanded
+
+### Automation strategies
+
+- **Track stale content**: Flag docs not updated in X days
+- **Detect product changes**: Monitor engineering artifacts (OpenAPI specs, etc.) for changes
+- **Enforce standards**: Use linters (Vale) or CI checks on every PR
+- **AI maintenance**: Use AI tools to identify outdated content and suggest improvements
+
+### Review process
+
+- Trigger reviews based on relevance (usage, search demand, product changes), not just time
+- Focus on the top 10 most-viewed pages
+- Empower community contributors via open-source PRs
+
+### When to rewrite
+
+- Plan periodic resets every 1-2 years
+- Start with a structured audit: interview support teams, analyze feedback, document gaps
+- Tackle rewrites in focused sprints, prioritizing highest-impact sections
+
+### The golden rule
+
+Outdated or misleading documentation is worse than no documentation. If a doc is inaccurate and unfixable short-term, remove it entirely.
+
+---
+
+## Measuring success
+
+### Quantitative metrics (with context)
+
+> Metrics that work for the sales website may not translate well for docs: is a high "time spent on page" count actually good? Were they really digging into the content, or were they struggling to find the answers?
+> —**Idan Englander, Manager of Technical Writing at Anaconda**
+
+- **Page views**: Good proxy, but could be bots or repeat visitors. High views on error pages may signal product issues.
+- **Time on page**: Could mean engagement or that users are stuck.
+- **CTR**: Higher clicks might mean engagement, but verify users reach the right resources.
+
+> In general, don't fall into the trap that a bigger number means better performance.
+> —**Ethan Palm, Senior Manager of Docs at GitHub**
+
+### Qualitative signals
+
+- User ratings and open-ended surveys
+- Stakeholder input from support, engineering, customer success
+- Usability testing
+- AI assistant analytics (what questions do users ask?)
+
+### Business alignment
+
+- **Support efficiency**: Does documentation reduce ticket volume?
+- **Onboarding/adoption**: Do docs help new users get up to speed faster?
+- **Retention**: Do well-maintained docs reduce churn?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,119 @@
+# Codex repository instructions
+
+- Never read `.env.local` files.
+- Do not inspect dependency source in `node_modules`, `.pnpm-store`, or `.pnpm`. Run `pnpm opensrc path <package-name>` and inspect the returned source path instead. Cached package versions are listed in `~/.opensrc/sources.json`.
+- After editing a file type supported by Oxfmt, run `pnpm oxfmt --write <file>` on the edited file.
+- After editing JavaScript or TypeScript, run `pnpm oxlint --fix <file>` on the edited file and report any remaining diagnostics.
+
+# Repo Overview
+
+Confect is a library that integrates Effect with the Convex backend platform. It is a pnpm monorepo (requires Node >= 22, pnpm >= 10).
+
+## Package Dependency Graph
+
+- `@confect/core` - Shared specs, schemas, and types (no workspace deps)
+- `@confect/server` - Backend bindings to Convex (depends on core)
+- `@confect/js` - Runtime-agnostic JavaScript client (depends on core)
+- `@confect/react` - Client-side React hooks (depends on core)
+- `@confect/cli` - CLI tooling for codegen and dev-mode watching (depends on core, server)
+- `@confect/test` - Testing utilities via convex-test (depends on core, server)
+
+## Apps
+
+- `apps/example` - Vite + React example app demonstrating Confect usage
+- `apps/docs` - Documentation site powered by Mintlify
+
+## Tools
+
+- `tools/bench-harness` - Private package that hands `@ark/attest` the TypeScript version the type benchmarks need; see its README
+
+## TypeScript
+
+The workspace is on TypeScript 7, so `tsc` is a native binary and the `typescript` package no longer exports a JavaScript compiler API — anything that needs to _drive_ the compiler rather than _run_ it has to either spawn `tsc` or use `typescript/unstable/*`. Effect's language service comes from `@effect/tsgo` (not `@effect/language-service`, which supports only TypeScript 5 and 6): the root `prepare` script runs `effect-tsgo patch --typescript`, which swaps in a `tsc` that also reports Effect diagnostics, so the `deterministicKeys: "error"` severity in `tsconfig.base.json` fails a build and not just an editor.
+
+## Build System
+
+Packages are built with tsdown (JavaScript output) plus TypeScript project references: each package has a composite `tsconfig.src.json`, and `tsc -b` typechecks the graph in dependency order and emits the `.d.ts` declarations (tsdown is configured with `dts: false`). The exception is `@confect/cli`, which ships only a binary: it has no `tsconfig.src.json` and emits no declarations; its build is tsdown-only and its sources are typechecked by the root `tsconfig.json`.
+
+**Critical: packages must be rebuilt with `pnpm build` after source changes for those changes to be reflected outside their package directory.** Consumers import from `dist/`, not `src/`. During development, use `pnpm dev` to watch-rebuild all packages automatically: it runs tsdown in watch mode in every package (JavaScript output) alongside a single root `tsc -b --watch` over the project-reference graph (declaration output, in dependency order).
+
+Build, lint, and format run through Vite+ (`vp`), which orders packages by their dependency graph and caches results. There are no per-package script variants at the root; target a single package ad hoc with `vp run --filter <pkg> <task>` (e.g. `vp run --filter @confect/core build`). Tests run through Vitest directly (not `vp`); target one package's suite with `vitest run --project @confect/core`.
+
+### Key Commands (run from repo root)
+
+- `pnpm build` - Build all @confect packages (cached, dependency-ordered)
+- `pnpm dev` - Watch-rebuild all packages (tsdown watchers + `tsc -b --watch` for declarations)
+- `pnpm dev:example` / `pnpm dev:docs` - Run the example app / docs site
+- `pnpm test` - Run all package test suites via Vitest (`vitest run`)
+- `pnpm typecheck` - Typecheck the package graph and test suites via `tsc -b` (project references, incremental)
+- `pnpm lint` / `pnpm lint:fix` - Lint (Oxlint + Syncpack); `lint:fix` writes fixes
+- `pnpm format` / `pnpm format:check` - Format (Oxfmt + Syncpack); `format` writes, `format:check` only checks
+- `pnpm check` - Format, lint, and type checks together (`vp check`)
+- `pnpm clean` - Remove dist, coverage, and node_modules everywhere
+
+## Testing
+
+Tests use Vitest with a root-level `vitest.config.ts` (which uses `projects: ["packages/*"]` to discover per-package test projects) and shared config in `vitest.shared.ts`. The core, js, react, server, and cli packages all have tests. The @confect/server package has integration tests using convex-test.
+
+Tests import the public package specifiers (e.g. `@confect/core/Ref`); `vitest.shared.ts` aliases those to each package's `src/` so suites run against source rather than built `dist/`.
+
+Run `pnpm test` to run all suites at once, or target a single package with `vitest run --project @confect/<pkg>` (e.g. `vitest run --project @confect/core`). Run tests with `vitest run`, not `vp test` — the Vite+ test runner mishandles type-only test files. The server's Convex integration suites have dedicated scripts: `pnpm test:server:mock-backend` and `pnpm test:server:local-backend`.
+
+## Versioning and Publishing
+
+All @confect packages are in a fixed version group via Changesets, meaning they are always versioned and released together. Use `pnpm changeset` to create a changeset before merging a PR with user-facing changes.
+
+## Cursor Cloud specific instructions
+
+### Running the example app
+
+The example app is in `apps/example`. To start it:
+
+```bash
+cd apps/example
+pnpm dev
+```
+
+This runs Vite, the Convex local backend, and the Confect codegen watcher concurrently.
+
+#### Convex environment variables
+
+The Convex local backend requires certain environment variables. After starting the dev server for the first time (so the local backend is initialized), set them from the checked-in defaults file:
+
+```bash
+cd apps/example
+pnpm convex env set < .env.defaults
+```
+
+This bulk-sets all variables from `.env.defaults` (added in convex 1.33.0). The values are stored in the local backend's state (`.convex/`) and persist across restarts, but not across fresh clones or environment resets.
+
+#### Ports
+
+The example app uses three local ports, all accessible from the browser:
+
+- **5173**: Vite dev server (frontend)
+- **3210**: Convex backend (WebSocket sync, used by `VITE_CONVEX_URL`)
+- **3211**: Convex HTTP actions server (used by `VITE_CONVEX_SITE_URL`)
+
+<!-- opensrc:start -->
+
+## Source Code Reference
+
+Source code for dependencies is available in `opensrc/` for deeper understanding of implementation details.
+
+See `opensrc/sources.json` for the list of available packages and their versions.
+
+Use this source code when you need to understand how a package works internally, not just its types/interface.
+
+### Fetching Additional Source Code
+
+To fetch source code for a package or repository you need to understand, run:
+
+```bash
+npx opensrc <package>           # npm package (e.g., npx opensrc zod)
+npx opensrc pypi:<package>      # Python package (e.g., npx opensrc pypi:requests)
+npx opensrc crates:<package>    # Rust crate (e.g., npx opensrc crates:serde)
+npx opensrc <owner>/<repo>      # GitHub repo (e.g., npx opensrc vercel/ai)
+```
+
+<!-- opensrc:end -->


### PR DESCRIPTION
### Motivation

- Make the repository instructions and reusable skills discoverable to Codex-native tooling by mirroring Claude Code guidance into Codex paths while retaining the original Claude configuration. 
- Enable Codex-based agents to run repository-level policies (no `.env.local`, dependency-source lookup via `pnpm opensrc`, formatting and lint hooks) and to reuse existing command workflows as skills. 
- Preserve the existing `.claude/` files and `CLAUDE.md` so contributors who still rely on the Claude configuration are not disrupted.

### Description

- Add a root `AGENTS.md` that contains Codex-oriented repository instructions plus the repo overview copied from `CLAUDE.md`. 
- Add `.agents/skills/*/SKILL.md` entries for the migrated skills and commands, including `create-changeset`, `managing-prereleases`, `release-docs`, `upgrade-effect-rc`, `upgrade-internal-deps`, `upgrade-published-deps`, `upgrade-runtime-pins`, `writing-commit-messages`, and `writing-technical-documentation` with its `reference.md`. 
- Include a Codex preamble documenting policy and hook expectations (format with `oxfmt` and lint fixes with `oxlint`) and apply formatting to the new files. 
- Do not remove or modify the existing `.claude/` directory or `CLAUDE.md`; the Claude configuration is preserved alongside the new Codex configuration.

### Testing

- Ran `pnpm oxfmt --check AGENTS.md .agents/skills/*/SKILL.md .agents/skills/writing-technical-documentation/reference.md` and the check completed successfully. 
- Ran `git diff --check` to surface whitespace/format issues and there were no failures. 
- Executed a custom Python parity validation that verified the migrated skill bodies match the original Claude command content and confirmed `.claude/` files remain unchanged, and that validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8b9ef11644832185915661fab68386)