### PR TITLE
Declare function args as struct fields

### DIFF
--- a/.changeset/function-args-fields.md
+++ b/.changeset/function-args-fields.md
@@ -2,4 +2,4 @@
 "@confect/core": minor
 ---
 
-Declare Confect function arguments as lazy `Schema.Struct` field maps instead of constructed struct schemas. Confect now derives and builds the struct schema itself, matching Convex's object-only argument model and preserving exact field types through function specs and refs.
+Declare Confect function arguments as optional lazy `Schema.Struct` field maps instead of constructed struct schemas. Confect now derives and builds the struct schema itself, defaults omitted args to `{}`, matches Convex's object-only argument model, and preserves exact field types through function specs and refs.

--- a/.changeset/function-args-fields.md
+++ b/.changeset/function-args-fields.md
@@ -1,0 +1,5 @@
+---
+"@confect/core": minor
+---
+
+Declare Confect function arguments as lazy `Schema.Struct` field maps instead of constructed struct schemas. Confect now derives and builds the struct schema itself, matching Convex's object-only argument model and preserving exact field types through function specs and refs.

--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -45,7 +45,6 @@ import notes from "./_generated/tables/notes";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => ({}),
     returns: () => Schema.Array(notes.Doc),
   }),
 );
@@ -267,7 +266,6 @@ Same shape as `useMutation`: returns `Promise<A>` when the ref has no `error` sc
 ```ts confect/random.spec.ts
 FunctionSpec.publicAction({
   name: "getNumber",
-  args: () => ({}),
   returns: () => Schema.Number,
 });
 ```

--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -45,7 +45,7 @@ import notes from "./_generated/tables/notes";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Array(notes.Doc),
   }),
 );
@@ -205,7 +205,7 @@ import { Id } from "./_generated/id";
 
 FunctionSpec.publicMutation({
   name: "insert",
-  args: () => Schema.Struct({ text: Schema.String }),
+  args: () => ({ text: Schema.String }),
   returns: () => Id("notes"),
 });
 ```
@@ -234,7 +234,7 @@ import { Id } from "./_generated/id";
 
 FunctionSpec.publicMutation({
   name: "deleteOrFail",
-  args: () => Schema.Struct({ noteId: Id("notes") }),
+  args: () => ({ noteId: Id("notes") }),
   returns: () => Schema.Null,
   error: () => Schema.Union([NoteNotFound, Forbidden]),
 });
@@ -267,7 +267,7 @@ Same shape as `useMutation`: returns `Promise<A>` when the ref has no `error` sc
 ```ts confect/random.spec.ts
 FunctionSpec.publicAction({
   name: "getNumber",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Number,
 });
 ```

--- a/apps/docs/concepts/file-naming-conventions.mdx
+++ b/apps/docs/concepts/file-naming-conventions.mdx
@@ -20,7 +20,6 @@ import notes from "./_generated/tables/notes";
 
 const list = FunctionSpec.publicQuery({
   name: "list",
-  args: () => ({}),
   returns: () => Schema.Array(notes.Doc),
 });
 

--- a/apps/docs/concepts/file-naming-conventions.mdx
+++ b/apps/docs/concepts/file-naming-conventions.mdx
@@ -20,7 +20,7 @@ import notes from "./_generated/tables/notes";
 
 const list = FunctionSpec.publicQuery({
   name: "list",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Array(notes.Doc),
 });
 

--- a/apps/docs/concepts/project-structure.mdx
+++ b/apps/docs/concepts/project-structure.mdx
@@ -71,7 +71,7 @@ Contains a named TypeScript `interface` for each table's document — `NotesDoc`
 
 #### `id.ts`
 
-Contains a type-constrained `Id` constructor whose only argument is the union of your table names — for example, `Id("users")` returns the `Schema` for an `_id` value in the `users` table. Use this when defining cross-table references (e.g. a `userId: Id("users")` field) and inside spec `args`/`returns` schemas. The type-level constraint catches typos at compile time, replacing the loosely-typed `GenericId.GenericId("users")` form.
+Contains a type-constrained `Id` constructor whose only argument is the union of your table names — for example, `Id("users")` returns the `Schema` for an `_id` value in the `users` table. Use this when defining cross-table references (e.g. a `userId: Id("users")` field) and inside spec `args` fields or `returns` schemas. The type-level constraint catches typos at compile time, replacing the loosely-typed `GenericId.GenericId("users")` form.
 
 #### `registeredFunctions/`
 

--- a/apps/docs/concepts/schema-restrictions.mdx
+++ b/apps/docs/concepts/schema-restrictions.mdx
@@ -48,7 +48,6 @@ FunctionSpec.publicQuery({
 ```typescript ❌
 FunctionSpec.publicQuery({
   name: "myQuery",
-  args: () => ({}),
   returns: () => Schema.Undefined,
 });
 ```
@@ -56,7 +55,6 @@ FunctionSpec.publicQuery({
 ```typescript ❌
 FunctionSpec.publicQuery({
   name: "myQuery",
-  args: () => ({}),
   returns: () => Schema.Void,
 });
 ```

--- a/apps/docs/concepts/schema-restrictions.mdx
+++ b/apps/docs/concepts/schema-restrictions.mdx
@@ -30,6 +30,8 @@ FunctionSpec.publicQuery({
 
 Confect lazily wraps that field map in `Schema.Struct`. A full schema such as `args: () => Schema.String` or `args: () => Schema.Struct(...)` is therefore not accepted. Top-level struct checks and annotations cannot be attached directly to function args; if you need a cross-field check, nest the checked struct under an argument field.
 
+For a function with no arguments, omit `args`; Confect defaults it to an empty field map (`{}`).
+
 ## Additional caveats
 
 ### No-op returns from Convex functions
@@ -39,7 +41,6 @@ Unlike the vanilla APIs, Convex functions defined with Confect may not return `u
 ```typescript ✅
 FunctionSpec.publicQuery({
   name: "myQuery",
-  args: () => ({}),
   returns: () => Schema.Null,
 });
 ```

--- a/apps/docs/concepts/schema-restrictions.mdx
+++ b/apps/docs/concepts/schema-restrictions.mdx
@@ -16,6 +16,20 @@ For `Schema`s used in Confect:
 - `Encoded` represents the value that is stored in the database or serialized as the argument/output of a Convex function. This must be a valid [Convex value](https://docs.convex.dev/database/types#convex-values).
 - `Context` is not currently supported. It should always be `never`.
 
+## Function argument fields
+
+Convex functions always receive an object, so Confect function specs declare `args` as a `Schema.Struct` field map rather than as an arbitrary schema:
+
+```typescript
+FunctionSpec.publicQuery({
+  name: "byAuthor",
+  args: () => ({ author: Schema.String }),
+  returns: () => Schema.Array(Schema.String),
+});
+```
+
+Confect lazily wraps that field map in `Schema.Struct`. A full schema such as `args: () => Schema.String` or `args: () => Schema.Struct(...)` is therefore not accepted. Top-level struct checks and annotations cannot be attached directly to function args; if you need a cross-field check, nest the checked struct under an argument field.
+
 ## Additional caveats
 
 ### No-op returns from Convex functions
@@ -25,7 +39,7 @@ Unlike the vanilla APIs, Convex functions defined with Confect may not return `u
 ```typescript ✅
 FunctionSpec.publicQuery({
   name: "myQuery",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Null,
 });
 ```
@@ -33,7 +47,7 @@ FunctionSpec.publicQuery({
 ```typescript ❌
 FunctionSpec.publicQuery({
   name: "myQuery",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Undefined,
 });
 ```
@@ -41,7 +55,7 @@ FunctionSpec.publicQuery({
 ```typescript ❌
 FunctionSpec.publicQuery({
   name: "myQuery",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Void,
 });
 ```

--- a/apps/docs/concepts/spec-impl-model.mdx
+++ b/apps/docs/concepts/spec-impl-model.mdx
@@ -8,7 +8,7 @@ Your Confect API is broken up into two parts: a **spec** and its implementation 
 
 ## Spec
 
-A spec defines the interface of your Confect API. It is made up of group specs and function specs. Each function spec defines the function's name, argument fields, and returns schema—but not the function's logic. `args` is a callback returning a `Schema.Struct` field map; `returns` and the optional `error` are callbacks returning schemas. They are evaluated lazily on first invocation.
+A spec defines the interface of your Confect API. It is made up of group specs and function specs. Each function spec defines the function's name, argument fields, and returns schema—but not the function's logic. The optional `args` callback returns a `Schema.Struct` field map and defaults to `{}` when omitted; `returns` and the optional `error` are callbacks returning schemas. Provided callbacks are evaluated lazily on first invocation.
 
 Specs are built using `@confect/core`, which means they can be shared between the server and client. This separation is what enables end-to-end schema decoding and encoding: the client knows the exact shape of every function's arguments and return value without importing any server code.
 
@@ -23,7 +23,6 @@ import notes from "../_generated/tables/notes";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => ({}),
     returns: () => Schema.Array(notes.Doc),
   }),
 );

--- a/apps/docs/concepts/spec-impl-model.mdx
+++ b/apps/docs/concepts/spec-impl-model.mdx
@@ -8,7 +8,7 @@ Your Confect API is broken up into two parts: a **spec** and its implementation 
 
 ## Spec
 
-A spec defines the interface of your Confect API. It is made up of group specs and function specs. Each function spec defines the function's name, arguments schema, and returns schema—but not the function's logic. The `args` and `returns` schemas (and an optional `error` schema) are passed as `() => Schema` callbacks, evaluated lazily on first invocation.
+A spec defines the interface of your Confect API. It is made up of group specs and function specs. Each function spec defines the function's name, argument fields, and returns schema—but not the function's logic. `args` is a callback returning a `Schema.Struct` field map; `returns` and the optional `error` are callbacks returning schemas. They are evaluated lazily on first invocation.
 
 Specs are built using `@confect/core`, which means they can be shared between the server and client. This separation is what enables end-to-end schema decoding and encoding: the client knows the exact shape of every function's arguments and return value without importing any server code.
 
@@ -23,7 +23,7 @@ import notes from "../_generated/tables/notes";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Array(notes.Doc),
   }),
 );

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -71,14 +71,14 @@ bun add convex @confect/core @confect/server @confect/cli @confect/react
       .addFunction(
         FunctionSpec.publicQuery({
           name: "list",
-          args: () => Schema.Struct({}),
+          args: () => ({}),
           returns: () => Schema.Array(notes.Doc),
         }),
       )
       .addFunction(
         FunctionSpec.publicMutation({
           name: "create",
-          args: () => Schema.Struct({ text: Schema.String }),
+          args: () => ({ text: Schema.String }),
           returns: () => Id("notes"),
         }),
       );

--- a/apps/docs/getting-started/quickstart.mdx
+++ b/apps/docs/getting-started/quickstart.mdx
@@ -71,7 +71,6 @@ bun add convex @confect/core @confect/server @confect/cli @confect/react
       .addFunction(
         FunctionSpec.publicQuery({
           name: "list",
-          args: () => ({}),
           returns: () => Schema.Array(notes.Doc),
         }),
       )

--- a/apps/docs/server/error-handling.mdx
+++ b/apps/docs/server/error-handling.mdx
@@ -31,7 +31,7 @@ export class NoteNotFound extends Schema.TaggedError<NoteNotFound>()(
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "getOrFail",
-    args: () => Schema.Struct({ noteId: Id("notes") }),
+    args: () => ({ noteId: Id("notes") }),
     returns: () => notes.Doc,
     error: () => NoteNotFound,
   }),
@@ -57,7 +57,7 @@ export class Forbidden extends Schema.TaggedError<Forbidden>()(
 
 FunctionSpec.publicMutation({
   name: "deleteOrFail",
-  args: () => Schema.Struct({ noteId: Id("notes") }),
+  args: () => ({ noteId: Id("notes") }),
   returns: () => Schema.Null,
   error: () => Schema.Union([NoteNotFound, Forbidden]),
 });

--- a/apps/docs/server/functions.mdx
+++ b/apps/docs/server/functions.mdx
@@ -23,7 +23,7 @@ For Node.js actions, see [Node Actions](/server/node-actions). To integrate plai
 
 ## Defining a spec
 
-Each function spec defines the function's name, arguments schema, and returns schema. The `args`, `returns`, and (optional) `error` schemas are passed as `() => Schema` callbacks, evaluated lazily the first time the function is invoked. Function specs are added to a `GroupSpec` and default-exported from a `*.spec.ts` file. See [The Spec/Impl Model](/concepts/spec-impl-model) for a full walkthrough.
+Each function spec defines the function's name, argument fields, and returns schema. `args` is a callback returning a `Schema.Struct` field map, while `returns` and the optional `error` are callbacks returning schemas. All three are evaluated lazily the first time the function is invoked. Function specs are added to a `GroupSpec` and default-exported from a `*.spec.ts` file. See [The Spec/Impl Model](/concepts/spec-impl-model) for a full walkthrough.
 
 ```ts confect/notes.spec.ts
 import { GroupSpec, FunctionSpec } from "@confect/core";
@@ -33,7 +33,7 @@ import notes from "./_generated/tables/notes";
 
 const list = FunctionSpec.publicQuery({
   name: "list",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Array(notes.Doc),
 });
 
@@ -59,7 +59,7 @@ class NoteNotFound extends Schema.TaggedError<NoteNotFound>()("NoteNotFound", {
 
 FunctionSpec.publicQuery({
   name: "getOrFail",
-  args: () => Schema.Struct({ noteId: Id("notes") }),
+  args: () => ({ noteId: Id("notes") }),
   returns: () => notes.Doc,
   error: () => NoteNotFound,
 });
@@ -67,7 +67,7 @@ FunctionSpec.publicQuery({
 
 ### Paginated queries
 
-Define a paginated query with `FunctionSpec.publicPaginatedQuery` (or `internalPaginatedQuery`). Instead of `returns`, pass an `item` schema — the type of one element in a page. The optional `args` schema declares only your own arguments; Confect composes the Convex-facing schemas for you, adding the `paginationOpts` argument (with all of Convex's [pagination protocol fields](https://docs.convex.dev/database/pagination)) and wrapping `item` in a `PaginationResult` returns schema.
+Define a paginated query with `FunctionSpec.publicPaginatedQuery` (or `internalPaginatedQuery`). Instead of `returns`, pass an `item` schema — the type of one element in a page. The optional `args` field map declares only your own arguments; Confect composes the Convex-facing schemas for you, adding the `paginationOpts` argument (with all of Convex's [pagination protocol fields](https://docs.convex.dev/database/pagination)) and wrapping `item` in a `PaginationResult` returns schema.
 
 ```ts confect/notes.spec.ts
 import { FunctionSpec } from "@confect/core";
@@ -77,7 +77,7 @@ import notes from "./_generated/tables/notes";
 
 FunctionSpec.publicPaginatedQuery({
   name: "listByAuthor",
-  args: () => Schema.Struct({ author: Schema.String }), // optional; omit for no extra args
+  args: () => ({ author: Schema.String }), // optional; omit for no extra args
   item: () => notes.Doc,
 });
 ```

--- a/apps/docs/server/functions.mdx
+++ b/apps/docs/server/functions.mdx
@@ -23,7 +23,7 @@ For Node.js actions, see [Node Actions](/server/node-actions). To integrate plai
 
 ## Defining a spec
 
-Each function spec defines the function's name, argument fields, and returns schema. `args` is a callback returning a `Schema.Struct` field map, while `returns` and the optional `error` are callbacks returning schemas. All three are evaluated lazily the first time the function is invoked. Function specs are added to a `GroupSpec` and default-exported from a `*.spec.ts` file. See [The Spec/Impl Model](/concepts/spec-impl-model) for a full walkthrough.
+Each function spec defines the function's name, argument fields, and returns schema. The optional `args` callback returns a `Schema.Struct` field map and defaults to `{}` when omitted, while `returns` and the optional `error` are callbacks returning schemas. All provided callbacks are evaluated lazily the first time the function is invoked. Function specs are added to a `GroupSpec` and default-exported from a `*.spec.ts` file. See [The Spec/Impl Model](/concepts/spec-impl-model) for a full walkthrough.
 
 ```ts confect/notes.spec.ts
 import { GroupSpec, FunctionSpec } from "@confect/core";
@@ -33,7 +33,6 @@ import notes from "./_generated/tables/notes";
 
 const list = FunctionSpec.publicQuery({
   name: "list",
-  args: () => ({}),
   returns: () => Schema.Array(notes.Doc),
 });
 

--- a/apps/docs/server/middleware.mdx
+++ b/apps/docs/server/middleware.mdx
@@ -116,7 +116,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "deleteAll",
-      args: () => ({}),
       returns: () => Schema.Null,
     }).middleware(RequireAdmin), // RequireUser → RequireAdmin → handler
   );

--- a/apps/docs/server/middleware.mdx
+++ b/apps/docs/server/middleware.mdx
@@ -90,7 +90,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "create",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Id("notes"),
     }),
   );
@@ -116,7 +116,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "deleteAll",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Null,
     }).middleware(RequireAdmin), // RequireUser → RequireAdmin → handler
   );

--- a/apps/docs/server/node-actions.mdx
+++ b/apps/docs/server/node-actions.mdx
@@ -17,12 +17,11 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.makeNode().addFunction(
   FunctionSpec.publicNodeAction({
     name: "send",
-    args: () =>
-      Schema.Struct({
-        to: Schema.String,
-        subject: Schema.String,
-        body: Schema.String,
-      }),
+    args: () => ({
+      to: Schema.String,
+      subject: Schema.String,
+      body: Schema.String,
+    }),
     returns: () => Schema.Null,
   }),
 );

--- a/apps/docs/server/plain-convex-functions.mdx
+++ b/apps/docs/server/plain-convex-functions.mdx
@@ -224,7 +224,6 @@ import notes from "./_generated/tables/notes";
 
 const list = FunctionSpec.publicQuery({
   name: "list",
-  args: () => ({}),
   returns: () => Schema.Array(notes.Doc),
 });
 

--- a/apps/docs/server/plain-convex-functions.mdx
+++ b/apps/docs/server/plain-convex-functions.mdx
@@ -224,7 +224,7 @@ import notes from "./_generated/tables/notes";
 
 const list = FunctionSpec.publicQuery({
   name: "list",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Array(notes.Doc),
 });
 

--- a/apps/example/confect/email.spec.ts
+++ b/apps/example/confect/email.spec.ts
@@ -16,7 +16,6 @@ export default GroupSpec.makeNode()
   .addFunction(
     FunctionSpec.publicNodeAction({
       name: "getInbox",
-      args: () => ({}),
       returns: () =>
         Schema.Array(
           Schema.Struct({

--- a/apps/example/confect/email.spec.ts
+++ b/apps/example/confect/email.spec.ts
@@ -5,19 +5,18 @@ export default GroupSpec.makeNode()
   .addFunction(
     FunctionSpec.publicNodeAction({
       name: "send",
-      args: () =>
-        Schema.Struct({
-          to: Schema.String,
-          subject: Schema.String,
-          body: Schema.String,
-        }),
+      args: () => ({
+        to: Schema.String,
+        subject: Schema.String,
+        body: Schema.String,
+      }),
       returns: () => Schema.Null,
     }),
   )
   .addFunction(
     FunctionSpec.publicNodeAction({
       name: "getInbox",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () =>
         Schema.Array(
           Schema.Struct({

--- a/apps/example/confect/env.spec.ts
+++ b/apps/example/confect/env.spec.ts
@@ -4,7 +4,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "readEnvVar",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/apps/example/confect/env.spec.ts
+++ b/apps/example/confect/env.spec.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "readEnvVar",
-    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/apps/example/confect/notes_and_random/notes.spec.ts
+++ b/apps/example/confect/notes_and_random/notes.spec.ts
@@ -19,7 +19,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => ({}),
       returns: () => Schema.Array(notes.Doc),
     }),
   )
@@ -47,21 +46,18 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getFirst",
-      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.internalQuery({
       name: "internalGetFirst",
-      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.internalMutation({
       name: "clearAll",
-      args: () => ({}),
       returns: () => Schema.Null,
     }),
   )

--- a/apps/example/confect/notes_and_random/notes.spec.ts
+++ b/apps/example/confect/notes_and_random/notes.spec.ts
@@ -12,21 +12,21 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "insert",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Id("notes"),
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Array(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "delete_",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => Schema.Null,
     }),
   )
@@ -39,7 +39,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getOrFail",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => notes.Doc,
       error: () => NoteNotFound,
     }),
@@ -47,28 +47,28 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getFirst",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.internalQuery({
       name: "internalGetFirst",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.internalMutation({
       name: "clearAll",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Null,
     }),
   )
   .addFunction(
     FunctionSpec.internalMutation({
       name: "insertDefault",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Schema.Null,
     }),
   );

--- a/apps/example/confect/notes_and_random/random.spec.ts
+++ b/apps/example/confect/notes_and_random/random.spec.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => ({}),
     returns: () => Schema.Finite,
   }),
 );

--- a/apps/example/confect/notes_and_random/random.spec.ts
+++ b/apps/example/confect/notes_and_random/random.spec.ts
@@ -4,7 +4,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Finite,
   }),
 );

--- a/apps/example/confect/users.spec.ts
+++ b/apps/example/confect/users.spec.ts
@@ -5,14 +5,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "create",
-      args: () => Schema.Struct({ username: Schema.String }),
+      args: () => ({ username: Schema.String }),
       returns: () => Schema.Null,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "clearAll",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Null,
     }),
   );

--- a/apps/example/confect/users.spec.ts
+++ b/apps/example/confect/users.spec.ts
@@ -12,7 +12,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "clearAll",
-      args: () => ({}),
       returns: () => Schema.Null,
     }),
   );

--- a/apps/example/confect/viewer.spec.ts
+++ b/apps/example/confect/viewer.spec.ts
@@ -7,7 +7,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "whoAmI",
-      args: () => ({}),
       returns: () => Schema.String,
     }),
   )

--- a/apps/example/confect/viewer.spec.ts
+++ b/apps/example/confect/viewer.spec.ts
@@ -7,14 +7,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "whoAmI",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "postNote",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Schema.Null,
     }),
   );

--- a/packages/cli/test/FunctionPaths.test.ts
+++ b/packages/cli/test/FunctionPaths.test.ts
@@ -42,7 +42,6 @@ describe("FunctionPaths.make", () => {
       GroupSpec.makeAt("myGroup").addFunction(
         FunctionSpec.publicQuery({
           name: "myQuery",
-          args: () => ({}),
           returns: () => Schema.Null,
         }),
       ),
@@ -64,7 +63,6 @@ describe("FunctionPaths.make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => ({}),
             returns: () => Schema.Array(Schema.String),
           }),
         )
@@ -78,7 +76,6 @@ describe("FunctionPaths.make", () => {
         .addFunction(
           FunctionSpec.publicAction({
             name: "doSomething",
-            args: () => ({}),
             returns: () => Schema.Void,
           }),
         ),
@@ -113,7 +110,6 @@ describe("FunctionPaths.make", () => {
         GroupSpec.makeAt("posts").addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => ({}),
             returns: () => Schema.Array(Schema.Unknown),
           }),
         ),
@@ -136,7 +132,6 @@ describe("FunctionPaths.make", () => {
     const innerGroup = GroupSpec.makeAt("inner").addFunction(
       FunctionSpec.publicQuery({
         name: "innerQuery",
-        args: () => ({}),
         returns: () => Schema.Null,
       }),
     );
@@ -146,7 +141,6 @@ describe("FunctionPaths.make", () => {
       .addFunction(
         FunctionSpec.publicMutation({
           name: "outerMutation",
-          args: () => ({}),
           returns: () => Schema.Null,
         }),
       );
@@ -170,7 +164,6 @@ describe("FunctionPaths.make", () => {
     const level3 = GroupSpec.makeAt("level3").addFunction(
       FunctionSpec.publicQuery({
         name: "deepQuery",
-        args: () => ({}),
         returns: () => Schema.Finite,
       }),
     );
@@ -205,7 +198,6 @@ describe("FunctionPaths.make", () => {
       .addFunction(
         FunctionSpec.publicQuery({
           name: "list",
-          args: () => ({}),
           returns: () => Schema.Array(Schema.String),
         }),
       );
@@ -213,7 +205,6 @@ describe("FunctionPaths.make", () => {
     const random = GroupSpec.makeAt("random").addFunction(
       FunctionSpec.publicAction({
         name: "getNumber",
-        args: () => ({}),
         returns: () => Schema.Finite,
       }),
     );
@@ -244,42 +235,36 @@ describe("FunctionPaths.make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "publicQuery",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.internalQuery({
             name: "internalQuery",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.publicMutation({
             name: "publicMutation",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.internalMutation({
             name: "internalMutation",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.publicAction({
             name: "publicAction",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.internalAction({
             name: "internalAction",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         ),

--- a/packages/cli/test/FunctionPaths.test.ts
+++ b/packages/cli/test/FunctionPaths.test.ts
@@ -42,7 +42,7 @@ describe("FunctionPaths.make", () => {
       GroupSpec.makeAt("myGroup").addFunction(
         FunctionSpec.publicQuery({
           name: "myQuery",
-          args: () => Schema.Struct({}),
+          args: () => ({}),
           returns: () => Schema.Null,
         }),
       ),
@@ -64,21 +64,21 @@ describe("FunctionPaths.make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Array(Schema.String),
           }),
         )
         .addFunction(
           FunctionSpec.publicMutation({
             name: "insert",
-            args: () => Schema.Struct({ text: Schema.String }),
+            args: () => ({ text: Schema.String }),
             returns: () => Schema.String,
           }),
         )
         .addFunction(
           FunctionSpec.publicAction({
             name: "doSomething",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Void,
           }),
         ),
@@ -104,7 +104,7 @@ describe("FunctionPaths.make", () => {
         GroupSpec.makeAt("users").addFunction(
           FunctionSpec.publicQuery({
             name: "getById",
-            args: () => Schema.Struct({ id: Schema.String }),
+            args: () => ({ id: Schema.String }),
             returns: () => Schema.Unknown,
           }),
         ),
@@ -113,7 +113,7 @@ describe("FunctionPaths.make", () => {
         GroupSpec.makeAt("posts").addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Array(Schema.Unknown),
           }),
         ),
@@ -136,7 +136,7 @@ describe("FunctionPaths.make", () => {
     const innerGroup = GroupSpec.makeAt("inner").addFunction(
       FunctionSpec.publicQuery({
         name: "innerQuery",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Null,
       }),
     );
@@ -146,7 +146,7 @@ describe("FunctionPaths.make", () => {
       .addFunction(
         FunctionSpec.publicMutation({
           name: "outerMutation",
-          args: () => Schema.Struct({}),
+          args: () => ({}),
           returns: () => Schema.Null,
         }),
       );
@@ -170,7 +170,7 @@ describe("FunctionPaths.make", () => {
     const level3 = GroupSpec.makeAt("level3").addFunction(
       FunctionSpec.publicQuery({
         name: "deepQuery",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Finite,
       }),
     );
@@ -198,14 +198,14 @@ describe("FunctionPaths.make", () => {
       .addFunction(
         FunctionSpec.publicMutation({
           name: "insert",
-          args: () => Schema.Struct({ text: Schema.String }),
+          args: () => ({ text: Schema.String }),
           returns: () => Schema.String,
         }),
       )
       .addFunction(
         FunctionSpec.publicQuery({
           name: "list",
-          args: () => Schema.Struct({}),
+          args: () => ({}),
           returns: () => Schema.Array(Schema.String),
         }),
       );
@@ -213,7 +213,7 @@ describe("FunctionPaths.make", () => {
     const random = GroupSpec.makeAt("random").addFunction(
       FunctionSpec.publicAction({
         name: "getNumber",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Finite,
       }),
     );
@@ -244,42 +244,42 @@ describe("FunctionPaths.make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "publicQuery",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.internalQuery({
             name: "internalQuery",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.publicMutation({
             name: "publicMutation",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.internalMutation({
             name: "internalMutation",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.publicAction({
             name: "publicAction",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )
         .addFunction(
           FunctionSpec.internalAction({
             name: "internalAction",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         ),

--- a/packages/cli/test/LeafModule.test.ts
+++ b/packages/cli/test/LeafModule.test.ts
@@ -261,7 +261,7 @@ layer(LeafModuleLayer)("validateSpec", (it) => {
               },
               {
                 relativePath: "groups/_leakyTable.spec.ts",
-                contents: `import { FunctionSpec, GroupSpec } from "@confect/core";\nimport * as Schema from "effect/Schema";\nimport leaky from "../_generated/tables/_leaky";\nexport default GroupSpec.make().addFunction(FunctionSpec.publicQuery({ name: "get", args: () => Schema.Struct({}), returns: () => leaky.Doc }));\n`,
+                contents: `import { FunctionSpec, GroupSpec } from "@confect/core";\nimport * as Schema from "effect/Schema";\nimport leaky from "../_generated/tables/_leaky";\nexport default GroupSpec.make().addFunction(FunctionSpec.publicQuery({ name: "get", args: () => ({}), returns: () => leaky.Doc }));\n`,
               },
             ],
             validateSpec(leaf),

--- a/packages/cli/test/LeafModule.test.ts
+++ b/packages/cli/test/LeafModule.test.ts
@@ -261,7 +261,7 @@ layer(LeafModuleLayer)("validateSpec", (it) => {
               },
               {
                 relativePath: "groups/_leakyTable.spec.ts",
-                contents: `import { FunctionSpec, GroupSpec } from "@confect/core";\nimport * as Schema from "effect/Schema";\nimport leaky from "../_generated/tables/_leaky";\nexport default GroupSpec.make().addFunction(FunctionSpec.publicQuery({ name: "get", args: () => ({}), returns: () => leaky.Doc }));\n`,
+                contents: `import { FunctionSpec, GroupSpec } from "@confect/core";\nimport leaky from "../_generated/tables/_leaky";\nexport default GroupSpec.make().addFunction(FunctionSpec.publicQuery({ name: "get", returns: () => leaky.Doc }));\n`,
               },
             ],
             validateSpec(leaf),

--- a/packages/cli/test/codegen.test.ts
+++ b/packages/cli/test/codegen.test.ts
@@ -220,7 +220,7 @@ const leaf = (
   specImportPath: `../${relativePath.slice(0, -".ts".length)}`,
 });
 
-const emptyArgs = Schema.Struct({});
+const emptyArgs = {};
 const emptyReturns = Schema.Null;
 
 layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {

--- a/packages/cli/test/codegen.test.ts
+++ b/packages/cli/test/codegen.test.ts
@@ -220,7 +220,6 @@ const leaf = (
   specImportPath: `../${relativePath.slice(0, -".ts".length)}`,
 });
 
-const emptyArgs = {};
 const emptyReturns = Schema.Null;
 
 layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {
@@ -231,7 +230,6 @@ layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {
       const parentGroupSpec = GroupSpec.make().addFunction(
         FunctionSpec.publicQuery({
           name: "list",
-          args: () => emptyArgs,
           returns: () => emptyReturns,
         }),
       );
@@ -252,7 +250,6 @@ layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {
         const parentGroupSpec = GroupSpec.make().addFunction(
           FunctionSpec.publicQuery({
             name: "archived",
-            args: () => emptyArgs,
             returns: () => emptyReturns,
           }),
         );
@@ -282,7 +279,6 @@ layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {
         const inner = GroupSpec.makeAt("inner").addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => emptyArgs,
             returns: () => emptyReturns,
           }),
         );
@@ -343,7 +339,6 @@ for (const { name, pathLayer, sep } of [
             const parentGroupSpec = GroupSpec.make().addFunction(
               FunctionSpec.publicQuery({
                 name: "archived",
-                args: () => emptyArgs,
                 returns: () => emptyReturns,
               }),
             );

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -57,14 +57,12 @@ const GenerateFunctionsLayer = Layer.mergeAll(
   NodeFileSystem.layer,
 );
 
-const emptyArgs = {};
 const emptyReturns = Schema.Null;
 
 const nodeGroup = () =>
   GroupSpec.makeNode().addFunction(
     FunctionSpec.publicNodeAction({
       name: "failingNodeAction",
-      args: () => emptyArgs,
       returns: () => emptyReturns,
     }),
   );

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -57,7 +57,7 @@ const GenerateFunctionsLayer = Layer.mergeAll(
   NodeFileSystem.layer,
 );
 
-const emptyArgs = Schema.Struct({});
+const emptyArgs = {};
 const emptyReturns = Schema.Null;
 
 const nodeGroup = () =>

--- a/packages/core/src/FunctionProvenance.ts
+++ b/packages/core/src/FunctionProvenance.ts
@@ -5,9 +5,27 @@ import * as Lazy from "./Lazy";
 import * as PaginationOptions from "./PaginationOptions";
 import * as PaginationResult from "./PaginationResult";
 
+/**
+ * A field map accepted as Confect function args. Restricting each field to a
+ * context-free codec means the struct assembled from the fields can always be
+ * encoded and decoded synchronously at a Convex boundary.
+ */
+// eslint-disable-next-line import/namespace -- oxlint's namespace resolution misses type-only exports, and `Schema` is an interface/namespace
+export type ArgsFields = {
+  readonly [key: PropertyKey]: Schema.ConstraintCodec<any, any>;
+};
+
+/**
+ * An erased, struct-shaped Confect args schema. This structural view is used
+ * only after a concrete field map has been captured by a provenance.
+ */
+export interface AnyArgs extends Schema.Codec<any, any> {
+  readonly fields: ArgsFields;
+}
+
 export type FunctionProvenance = Data.TaggedEnum<{
   Confect: {
-    args: Schema.Codec<any, any>;
+    args: AnyArgs;
     returns: Schema.Codec<any, any>;
     error?: Schema.Codec<any, any>;
     kind: ConfectKind;
@@ -21,47 +39,57 @@ export type FunctionProvenance = Data.TaggedEnum<{
 /**
  * The declaration shape of a Confect function — orthogonal to both the
  * provenance origin (Confect vs Convex) and the function type
- * (query/mutation/action). A `Standard` function declares its `args` and
- * `returns` schemas directly; a `Paginated` function declares `userArgs` and
- * `item` schemas from which the Convex-facing `args`/`returns` are composed.
+ * (query/mutation/action). A `Standard` function declares its args fields and
+ * returns schema directly; a `Paginated` function declares user-args fields
+ * and an item schema from which the Convex-facing `args`/`returns` are
+ * composed.
  */
-export type ConfectKind = Standard | Paginated;
+export type ConfectKind = Standard | AnyPaginated;
 
 export interface Standard {
   readonly _tag: "Standard";
 }
 
 export interface Paginated<
-  UserArgs extends AnyUserArgs = AnyUserArgs,
+  UserArgsFields_ extends ArgsFields,
   Item extends Schema.Codec<any, any> = Schema.Codec<any, any>,
 > {
   readonly _tag: "Paginated";
   /** User-declared args — no `paginationOpts`. */
-  readonly userArgs: UserArgs;
+  readonly userArgs: Schema.Struct<UserArgsFields_>;
   /** Page element schema. */
   readonly item: Item;
   /** Mutable array of items — the page decode target. */
   readonly page: Schema.Codec<any, any>;
 }
 
+export interface AnyPaginated {
+  readonly _tag: "Paginated";
+  readonly userArgs: AnyArgs;
+  readonly item: Schema.Codec<any, any>;
+  readonly page: Schema.Codec<any, any>;
+}
+
 export interface Confect<
-  Args extends Schema.Codec<any, any>,
+  ArgsFields_ extends ArgsFields,
   Returns extends Schema.Codec<any, any>,
   Error extends Schema.Codec<any, any> = never,
   Kind extends ConfectKind = ConfectKind,
 > {
   readonly _tag: "Confect";
-  readonly args: Args;
+  readonly args: Schema.Struct<ArgsFields_>;
   readonly returns: Returns;
   readonly error?: Error;
   readonly kind: Kind;
 }
 
-export interface AnyConfect extends Confect<
-  Schema.Codec<any, any>,
-  Schema.Codec<any, any>,
-  Schema.Codec<any, any>
-> {}
+export interface AnyConfect {
+  readonly _tag: "Confect";
+  readonly args: AnyArgs;
+  readonly returns: Schema.Codec<any, any>;
+  readonly error?: Schema.Codec<any, any>;
+  readonly kind: ConfectKind;
+}
 
 export interface Convex<Args extends DefaultFunctionArgs, Returns> {
   readonly _tag: "Convex";
@@ -76,13 +104,13 @@ export const FunctionProvenance = Data.taggedEnum<FunctionProvenance>();
 const Standard: Standard = { _tag: "Standard" };
 
 /**
- * Build a `Confect` provenance from lazy schema thunks. `args`, `returns`,
- * and `error` are exposed as sync lazy memoised getters (via {@link Lazy.defineProperty})
- * that only evaluate their thunk on first access, mirroring how `Table`
- * defers `Fields`/`Doc`. This keeps importing the assembled
- * `_generated/spec.ts` cheap — no `Schema.Struct(...)` / `Schema.Array(...)`
- * work runs at module load; it is deferred to the first invocation that
- * actually compiles validators or runs a codec.
+ * Build a `Confect` provenance from lazy args-fields and schema thunks.
+ * `args`, `returns`, and `error` are exposed as sync lazy memoised getters
+ * (via {@link Lazy.defineProperty}) that only evaluate their thunk on first
+ * access, mirroring how `Table` defers `Fields`/`Doc`. This keeps importing the
+ * assembled `_generated/spec.ts` cheap — no `Schema.Struct(...)` /
+ * `Schema.Array(...)` work runs at module load; it is deferred to the first
+ * invocation that actually compiles validators or runs a codec.
  *
  * The object is built by hand rather than through `FunctionProvenance.Confect`
  * because the `Data` constructor copies its input with `Object.assign`, which
@@ -92,53 +120,40 @@ const Standard: Standard = { _tag: "Standard" };
  * relies on `Data`'s structural `Equal`/`Hash` for provenance values.
  */
 export const Confect = <
-  Args extends Schema.Codec<any, any>,
+  const ArgsFields_ extends ArgsFields,
   Returns extends Schema.Codec<any, any>,
   Error extends Schema.Codec<any, any> = never,
 >(
-  args: () => Args,
+  args: () => ArgsFields_,
   returns: () => Returns,
   error?: () => Error,
-): Confect<Args, Returns, Error, Standard> => {
+): Confect<ArgsFields_, Returns, Error, Standard> => {
   const provenance = { _tag: "Confect" as const, kind: Standard };
 
-  Lazy.defineProperty(provenance, "args", args);
+  Lazy.defineProperty(provenance, "args", () => Schema.Struct(args()));
   Lazy.defineProperty(provenance, "returns", returns);
   if (error !== undefined) {
     Lazy.defineProperty(provenance, "error", error);
   }
 
-  return provenance as Confect<Args, Returns, Error, Standard>;
+  return provenance as Confect<ArgsFields_, Returns, Error, Standard>;
 };
-
-/**
- * Any struct-shaped, context-free schema usable as a paginated query's user
- * args. A structural bound rather than `Schema.Struct<Schema.Struct.Fields>`
- * because `Schema.Struct` is not covariant in its fields parameter — concrete
- * structs do not extend `Schema.Struct<Schema.Struct.Fields>`.
- */
-// eslint-disable-next-line import/namespace -- oxlint's namespace resolution misses type-only exports, and `Schema` is an interface/namespace
-export interface AnyUserArgs extends Schema.Codec<any, any> {
-  readonly fields: Schema.Struct.Fields;
-}
 
 /**
  * The composed args schema of a paginated query: the user-declared fields
  * plus the `paginationOpts` field managed by Convex's pagination protocol.
  *
- * The `extends infer ... extends` conditional lets TypeScript accept the
- * composed struct where `Schema.Codec<any, any>` is required even while
- * `UserArgs` is an unresolved type parameter; for concrete user args it
- * evaluates away entirely.
+ * The fields-first representation keeps the user-declared map available for
+ * type-level composition without reconstructing it from an erased schema.
  */
-export type PaginatedArgs<UserArgs extends AnyUserArgs> =
-  Schema.Struct<
-    UserArgs["fields"] & {
-      paginationOpts: typeof PaginationOptions.PaginationOptions;
-    }
-  > extends infer ComposedArgs extends Schema.Codec<any, any>
-    ? ComposedArgs
-    : never;
+export type PaginatedArgsFields<UserArgsFields extends ArgsFields> =
+  UserArgsFields & {
+    readonly paginationOpts: typeof PaginationOptions.PaginationOptions;
+  };
+
+export type PaginatedArgs<UserArgsFields extends ArgsFields> = Schema.Struct<
+  PaginatedArgsFields<UserArgsFields>
+>;
 
 /**
  * The composed returns schema of a paginated query: a `PaginationResult` of
@@ -151,21 +166,19 @@ export type PaginatedReturns<Item extends Schema.Codec<any, any>> =
     : never;
 
 export interface ConfectPaginated<
-  UserArgs extends AnyUserArgs,
+  UserArgsFields extends ArgsFields,
   Item extends Schema.Codec<any, any>,
   Error extends Schema.Codec<any, any> = never,
 > extends Confect<
-  PaginatedArgs<UserArgs>,
+  PaginatedArgsFields<UserArgsFields>,
   PaginatedReturns<Item>,
   Error,
-  Paginated<UserArgs, Item>
+  Paginated<UserArgsFields, Item>
 > {}
 
-export interface AnyConfectPaginated extends ConfectPaginated<
-  AnyUserArgs,
-  Schema.Codec<any, any>,
-  Schema.Codec<any, any>
-> {}
+export interface AnyConfectPaginated extends AnyConfect {
+  readonly kind: AnyPaginated;
+}
 
 /**
  * Build the provenance of a paginated query from lazy schema thunks, with the
@@ -178,25 +191,25 @@ export interface AnyConfectPaginated extends ConfectPaginated<
  * composed schemas can never drift from the stored user schemas.
  */
 export const ConfectPaginated = <
-  UserArgs extends AnyUserArgs,
+  const UserArgsFields_ extends ArgsFields,
   Item extends Schema.Codec<any, any>,
   Error extends Schema.Codec<any, any> = never,
 >(
-  userArgs: () => UserArgs,
+  userArgs: () => UserArgsFields_,
   item: () => Item,
   error?: () => Error,
-): ConfectPaginated<UserArgs, Item, Error> => {
+): ConfectPaginated<UserArgsFields_, Item, Error> => {
   const kind = { _tag: "Paginated" as const };
-  const paginatedKind = kind as Paginated<UserArgs, Item>;
+  const paginatedKind = kind as Paginated<UserArgsFields_, Item>;
 
-  Lazy.defineProperty(kind, "userArgs", userArgs);
+  Lazy.defineProperty(kind, "userArgs", () => Schema.Struct(userArgs()));
   Lazy.defineProperty(kind, "item", item);
   Lazy.defineProperty(kind, "page", () =>
     Schema.mutable(Schema.Array(paginatedKind.item)),
   );
 
   const provenance = { _tag: "Confect" as const, kind: paginatedKind };
-  const self = provenance as ConfectPaginated<UserArgs, Item, Error>;
+  const self = provenance as ConfectPaginated<UserArgsFields_, Item, Error>;
 
   Lazy.defineProperty(provenance, "args", () => {
     const fields = paginatedKind.userArgs.fields;

--- a/packages/core/src/FunctionProvenance.ts
+++ b/packages/core/src/FunctionProvenance.ts
@@ -29,11 +29,11 @@ export interface ArgsSchema<
 }
 
 /** Erased structural view used after the exact field map is no longer needed. */
-export type AnyArgs = ArgsSchema<ArgsFields>;
+export type AnyArgsSchema = ArgsSchema<ArgsFields>;
 
 export type FunctionProvenance = Data.TaggedEnum<{
   Confect: {
-    args: AnyArgs;
+    args: AnyArgsSchema;
     returns: Schema.Codec<any, any>;
     error?: Schema.Codec<any, any>;
     kind: ConfectKind;
@@ -87,7 +87,7 @@ export interface Confect<
 
 export interface AnyConfect {
   readonly _tag: "Confect";
-  readonly args: AnyArgs;
+  readonly args: AnyArgsSchema;
   readonly returns: Schema.Codec<any, any>;
   readonly error?: Schema.Codec<any, any>;
   readonly kind: ConfectKind;

--- a/packages/core/src/FunctionProvenance.ts
+++ b/packages/core/src/FunctionProvenance.ts
@@ -52,14 +52,14 @@ export type FunctionProvenance = Data.TaggedEnum<{
  * and an item schema from which the Convex-facing `args`/`returns` are
  * composed.
  */
-export type ConfectKind = Standard | AnyPaginated;
+export type ConfectKind = Standard | Paginated;
 
 export interface Standard {
   readonly _tag: "Standard";
 }
 
 export interface Paginated<
-  UserArgsFields_ extends ArgsFields,
+  UserArgsFields_ extends ArgsFields = ArgsFields,
   Item extends Schema.Codec<any, any> = Schema.Codec<any, any>,
 > {
   readonly _tag: "Paginated";
@@ -71,13 +71,6 @@ export interface Paginated<
   readonly page: Schema.Codec<any, any>;
 }
 
-export interface AnyPaginated {
-  readonly _tag: "Paginated";
-  readonly userArgs: AnyArgs;
-  readonly item: Schema.Codec<any, any>;
-  readonly page: Schema.Codec<any, any>;
-}
-
 export interface Confect<
   ArgsFields_ extends ArgsFields,
   Returns extends Schema.Codec<any, any>,
@@ -85,7 +78,6 @@ export interface Confect<
   Kind extends ConfectKind = ConfectKind,
 > {
   readonly _tag: "Confect";
-  /** @internal Type-only metadata; no corresponding runtime property. */
   readonly "~ArgsFields": ArgsFields_;
   readonly args: ArgsSchema<ArgsFields_>;
   readonly returns: Returns;
@@ -187,7 +179,7 @@ export interface ConfectPaginated<
 > {}
 
 export interface AnyConfectPaginated extends AnyConfect {
-  readonly kind: AnyPaginated;
+  readonly kind: Paginated;
 }
 
 /**

--- a/packages/core/src/FunctionProvenance.ts
+++ b/packages/core/src/FunctionProvenance.ts
@@ -16,12 +16,20 @@ export type ArgsFields = {
 };
 
 /**
- * An erased, struct-shaped Confect args schema. This structural view is used
- * only after a concrete field map has been captured by a provenance.
+ * A struct-shaped Confect args schema that keeps its exact field map while
+ * erasing the rest of `Schema.Struct`'s large implementation type. Decoded and
+ * encoded args are derived directly from `ArgsFields_`; keeping the runtime
+ * codec structural prevents every ref lookup from expanding the full Effect
+ * schema type.
  */
-export interface AnyArgs extends Schema.Codec<any, any> {
-  readonly fields: ArgsFields;
+export interface ArgsSchema<
+  ArgsFields_ extends ArgsFields,
+> extends Schema.Codec<any, any> {
+  readonly fields: ArgsFields_;
 }
+
+/** Erased structural view used after the exact field map is no longer needed. */
+export type AnyArgs = ArgsSchema<ArgsFields>;
 
 export type FunctionProvenance = Data.TaggedEnum<{
   Confect: {
@@ -56,7 +64,7 @@ export interface Paginated<
 > {
   readonly _tag: "Paginated";
   /** User-declared args — no `paginationOpts`. */
-  readonly userArgs: Schema.Struct<UserArgsFields_>;
+  readonly userArgs: ArgsSchema<UserArgsFields_>;
   /** Page element schema. */
   readonly item: Item;
   /** Mutable array of items — the page decode target. */
@@ -77,7 +85,9 @@ export interface Confect<
   Kind extends ConfectKind = ConfectKind,
 > {
   readonly _tag: "Confect";
-  readonly args: Schema.Struct<ArgsFields_>;
+  /** @internal Type-only metadata; no corresponding runtime property. */
+  readonly "~ArgsFields": ArgsFields_;
+  readonly args: ArgsSchema<ArgsFields_>;
   readonly returns: Returns;
   readonly error?: Error;
   readonly kind: Kind;

--- a/packages/core/src/FunctionSpec.ts
+++ b/packages/core/src/FunctionSpec.ts
@@ -128,6 +128,9 @@ export type GetRuntimeAndFunctionType<FunctionSpec_ extends AnyWithProps> =
 export type GetFunctionVisibility<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_["functionVisibility"];
 
+export type GetFunctionProvenance<FunctionSpec_ extends AnyWithProps> =
+  FunctionSpec_["functionProvenance"];
+
 export type Name<FunctionSpec_ extends AnyWithProps> = FunctionSpec_["name"];
 
 export type MiddlewareSpecs<FunctionSpec_ extends AnyWithProps> =
@@ -136,7 +139,7 @@ export type MiddlewareSpecs<FunctionSpec_ extends AnyWithProps> =
 /** The field map declared by a Confect-provenance spec. */
 export type ArgsFields<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: {
+    readonly functionProvenance: {
       readonly _tag: "Confect";
       readonly "~ArgsFields": infer ArgsFields_ extends
         FunctionProvenance.ArgsFields;
@@ -144,7 +147,7 @@ export type ArgsFields<FunctionSpec_ extends AnyWithProps> =
   }
     ? ArgsFields_
     : FunctionSpec_ extends {
-          functionProvenance: { readonly _tag: "Confect" };
+          readonly functionProvenance: { readonly _tag: "Confect" };
         }
       ? FunctionProvenance.ArgsFields
       : never;
@@ -152,7 +155,7 @@ export type ArgsFields<FunctionSpec_ extends AnyWithProps> =
 /** The args schema assembled from a Confect-provenance spec's field map. */
 export type ArgsSchema<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: {
+    readonly functionProvenance: {
       readonly _tag: "Confect";
       readonly "~ArgsFields": infer ArgsFields_ extends
         FunctionProvenance.ArgsFields;
@@ -160,7 +163,7 @@ export type ArgsSchema<FunctionSpec_ extends AnyWithProps> =
   }
     ? Schema.Struct<ArgsFields_>
     : FunctionSpec_ extends {
-          functionProvenance: {
+          readonly functionProvenance: {
             readonly _tag: "Confect";
             readonly args: infer ArgsSchema_ extends FunctionProvenance.AnyArgs;
           };
@@ -170,119 +173,76 @@ export type ArgsSchema<FunctionSpec_ extends AnyWithProps> =
 
 export type ReturnsSchema<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: FunctionProvenance.Confect<
-      any,
-      infer ReturnsSchema_ extends Schema.Codec<any, any>,
-      any,
-      any
-    >;
+    readonly functionProvenance: {
+      readonly _tag: "Confect";
+      readonly returns: infer ReturnsSchema_ extends Schema.Codec<any, any>;
+    };
   }
     ? ReturnsSchema_
     : never;
 
 export type ErrorSchema<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: FunctionProvenance.Confect<
-      any,
-      any,
-      infer ErrorSchema_ extends Schema.Codec<any, any>,
-      any
-    >;
+    readonly functionProvenance: {
+      readonly _tag: "Confect";
+      readonly error?: infer ErrorSchema_ extends Schema.Codec<any, any>;
+    };
   }
     ? ErrorSchema_
     : never;
 
 export type Args<FunctionSpec_ extends AnyWithProps> = FunctionSpec_ extends {
-  functionProvenance: {
-    readonly _tag: "Confect";
-    readonly "~ArgsFields": infer ArgsFields_ extends
-      FunctionProvenance.ArgsFields;
-  };
+  readonly functionProvenance: { readonly _tag: "Confect" };
 }
-  ? Schema.Struct.Type<ArgsFields_>
-  : FunctionSpec_ extends {
-        functionProvenance: {
-          _tag: "Confect";
-          args: infer ArgsSchema_ extends Schema.Codec<any, any>;
-        };
-      }
-    ? ArgsSchema_["Type"]
-    : FunctionSpec_ extends {
-          functionProvenance: { _tag: "Convex"; "~args": infer Args_ };
-        }
-      ? Args_
-      : never;
+  ? ArgsSchema<FunctionSpec_>["Type"]
+  : GetFunctionProvenance<FunctionSpec_> extends FunctionProvenance.Convex<
+        infer Args_,
+        any
+      >
+    ? Args_
+    : never;
 
 export type Returns<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: {
-      _tag: "Confect";
-      returns: infer ReturnsSchema_ extends Schema.Codec<any, any>;
-    };
+    readonly functionProvenance: { readonly _tag: "Confect" };
   }
-    ? ReturnsSchema_["Type"]
-    : FunctionSpec_ extends {
-          functionProvenance: { _tag: "Convex"; "~returns": infer Returns_ };
-        }
+    ? ReturnsSchema<FunctionSpec_>["Type"]
+    : GetFunctionProvenance<FunctionSpec_> extends FunctionProvenance.Convex<
+          any,
+          infer Returns_
+        >
       ? Awaited<Returns_>
       : never;
 
 export type EncodedArgs<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: {
-      readonly _tag: "Confect";
-      readonly "~ArgsFields": infer ArgsFields_ extends
-        FunctionProvenance.ArgsFields;
-    };
+    readonly functionProvenance: { readonly _tag: "Confect" };
   }
-    ? Schema.Struct.Encoded<ArgsFields_>
-    : FunctionSpec_ extends {
-          functionProvenance: {
-            _tag: "Confect";
-            args: infer ArgsSchema_ extends Schema.Codec<any, any>;
-          };
-        }
-      ? ArgsSchema_["Encoded"]
-      : FunctionSpec_ extends {
-            functionProvenance: { _tag: "Convex"; "~args": infer Args_ };
-          }
-        ? Args_
-        : never;
+    ? ArgsSchema<FunctionSpec_>["Encoded"]
+    : GetFunctionProvenance<FunctionSpec_> extends FunctionProvenance.Convex<
+          infer Args_,
+          any
+        >
+      ? Args_
+      : never;
 
 export type EncodedReturns<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: {
-      _tag: "Confect";
-      returns: infer ReturnsSchema_ extends Schema.Codec<any, any>;
-    };
+    readonly functionProvenance: { readonly _tag: "Confect" };
   }
-    ? ReturnsSchema_["Encoded"]
-    : FunctionSpec_ extends {
-          functionProvenance: { _tag: "Convex"; "~returns": infer Returns_ };
-        }
+    ? ReturnsSchema<FunctionSpec_>["Encoded"]
+    : GetFunctionProvenance<FunctionSpec_> extends FunctionProvenance.Convex<
+          any,
+          infer Returns_
+        >
       ? Returns_
       : never;
 
-export type Error<FunctionSpec_ extends AnyWithProps> = FunctionSpec_ extends {
-  functionProvenance: FunctionProvenance.Confect<
-    any,
-    any,
-    infer ErrorSchema_ extends Schema.Codec<any, any>
-  >;
-}
-  ? ErrorSchema_["Type"]
-  : never;
+export type Error<FunctionSpec_ extends AnyWithProps> =
+  ErrorSchema<FunctionSpec_>["Type"];
 
 export type EncodedError<FunctionSpec_ extends AnyWithProps> =
-  FunctionSpec_ extends {
-    functionProvenance: FunctionProvenance.Confect<
-      any,
-      any,
-      infer ErrorSchema_ extends Schema.Codec<any, any>
-    >;
-  }
-    ? ErrorSchema_["Encoded"]
-    : never;
+  ErrorSchema<FunctionSpec_>["Encoded"];
 
 export type WithName<
   FunctionSpec_ extends AnyWithProps,

--- a/packages/core/src/FunctionSpec.ts
+++ b/packages/core/src/FunctionSpec.ts
@@ -136,28 +136,37 @@ export type MiddlewareSpecs<FunctionSpec_ extends AnyWithProps> =
 /** The field map declared by a Confect-provenance spec. */
 export type ArgsFields<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: FunctionProvenance.Confect<
-      infer ArgsFields_ extends FunctionProvenance.ArgsFields,
-      any,
-      any,
-      any
-    >;
+    functionProvenance: {
+      readonly _tag: "Confect";
+      readonly "~ArgsFields": infer ArgsFields_ extends
+        FunctionProvenance.ArgsFields;
+    };
   }
     ? ArgsFields_
-    : never;
+    : FunctionSpec_ extends {
+          functionProvenance: { readonly _tag: "Confect" };
+        }
+      ? FunctionProvenance.ArgsFields
+      : never;
 
 /** The args schema assembled from a Confect-provenance spec's field map. */
 export type ArgsSchema<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: FunctionProvenance.Confect<
-      infer ArgsFields_ extends FunctionProvenance.ArgsFields,
-      any,
-      any,
-      any
-    >;
+    functionProvenance: {
+      readonly _tag: "Confect";
+      readonly "~ArgsFields": infer ArgsFields_ extends
+        FunctionProvenance.ArgsFields;
+    };
   }
     ? Schema.Struct<ArgsFields_>
-    : never;
+    : FunctionSpec_ extends {
+          functionProvenance: {
+            readonly _tag: "Confect";
+            readonly args: infer ArgsSchema_ extends FunctionProvenance.AnyArgs;
+          };
+        }
+      ? ArgsSchema_
+      : never;
 
 export type ReturnsSchema<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
@@ -184,12 +193,11 @@ export type ErrorSchema<FunctionSpec_ extends AnyWithProps> =
     : never;
 
 export type Args<FunctionSpec_ extends AnyWithProps> = FunctionSpec_ extends {
-  functionProvenance: FunctionProvenance.Confect<
-    infer ArgsFields_ extends FunctionProvenance.ArgsFields,
-    any,
-    any,
-    any
-  >;
+  functionProvenance: {
+    readonly _tag: "Confect";
+    readonly "~ArgsFields": infer ArgsFields_ extends
+      FunctionProvenance.ArgsFields;
+  };
 }
   ? Schema.Struct.Type<ArgsFields_>
   : FunctionSpec_ extends {
@@ -221,12 +229,11 @@ export type Returns<FunctionSpec_ extends AnyWithProps> =
 
 export type EncodedArgs<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: FunctionProvenance.Confect<
-      infer ArgsFields_ extends FunctionProvenance.ArgsFields,
-      any,
-      any,
-      any
-    >;
+    functionProvenance: {
+      readonly _tag: "Confect";
+      readonly "~ArgsFields": infer ArgsFields_ extends
+        FunctionProvenance.ArgsFields;
+    };
   }
     ? Schema.Struct.Encoded<ArgsFields_>
     : FunctionSpec_ extends {

--- a/packages/core/src/FunctionSpec.ts
+++ b/packages/core/src/FunctionSpec.ts
@@ -1,11 +1,12 @@
 import type {
+  DefaultFunctionArgs,
   FunctionType,
   FunctionVisibility,
   RegisteredAction,
   RegisteredMutation,
   RegisteredQuery,
 } from "convex/server";
-import * as Schema from "effect/Schema";
+import type * as Schema from "effect/Schema";
 import * as Predicate from "effect/Predicate";
 import * as FunctionProvenance from "./FunctionProvenance";
 import { validateConfectFunctionIdentifier } from "./Identifier";
@@ -132,18 +133,77 @@ export type Name<FunctionSpec_ extends AnyWithProps> = FunctionSpec_["name"];
 export type MiddlewareSpecs<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_["middlewareSpecs"][number];
 
-export type Args<FunctionSpec_ extends AnyWithProps> = FunctionSpec_ extends {
-  functionProvenance: {
-    _tag: "Confect";
-    args: infer ArgsSchema_ extends Schema.Codec<any, any>;
-  };
-}
-  ? ArgsSchema_["Type"]
-  : FunctionSpec_ extends {
-        functionProvenance: { _tag: "Convex"; "~args": infer Args_ };
-      }
-    ? Args_
+/** The field map declared by a Confect-provenance spec. */
+export type ArgsFields<FunctionSpec_ extends AnyWithProps> =
+  FunctionSpec_ extends {
+    functionProvenance: FunctionProvenance.Confect<
+      infer ArgsFields_ extends FunctionProvenance.ArgsFields,
+      any,
+      any,
+      any
+    >;
+  }
+    ? ArgsFields_
     : never;
+
+/** The args schema assembled from a Confect-provenance spec's field map. */
+export type ArgsSchema<FunctionSpec_ extends AnyWithProps> =
+  FunctionSpec_ extends {
+    functionProvenance: FunctionProvenance.Confect<
+      infer ArgsFields_ extends FunctionProvenance.ArgsFields,
+      any,
+      any,
+      any
+    >;
+  }
+    ? Schema.Struct<ArgsFields_>
+    : never;
+
+export type ReturnsSchema<FunctionSpec_ extends AnyWithProps> =
+  FunctionSpec_ extends {
+    functionProvenance: FunctionProvenance.Confect<
+      any,
+      infer ReturnsSchema_ extends Schema.Codec<any, any>,
+      any,
+      any
+    >;
+  }
+    ? ReturnsSchema_
+    : never;
+
+export type ErrorSchema<FunctionSpec_ extends AnyWithProps> =
+  FunctionSpec_ extends {
+    functionProvenance: FunctionProvenance.Confect<
+      any,
+      any,
+      infer ErrorSchema_ extends Schema.Codec<any, any>,
+      any
+    >;
+  }
+    ? ErrorSchema_
+    : never;
+
+export type Args<FunctionSpec_ extends AnyWithProps> = FunctionSpec_ extends {
+  functionProvenance: FunctionProvenance.Confect<
+    infer ArgsFields_ extends FunctionProvenance.ArgsFields,
+    any,
+    any,
+    any
+  >;
+}
+  ? Schema.Struct.Type<ArgsFields_>
+  : FunctionSpec_ extends {
+        functionProvenance: {
+          _tag: "Confect";
+          args: infer ArgsSchema_ extends Schema.Codec<any, any>;
+        };
+      }
+    ? ArgsSchema_["Type"]
+    : FunctionSpec_ extends {
+          functionProvenance: { _tag: "Convex"; "~args": infer Args_ };
+        }
+      ? Args_
+      : never;
 
 export type Returns<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
@@ -161,17 +221,26 @@ export type Returns<FunctionSpec_ extends AnyWithProps> =
 
 export type EncodedArgs<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
-    functionProvenance: {
-      _tag: "Confect";
-      args: infer ArgsSchema_ extends Schema.Codec<any, any>;
-    };
+    functionProvenance: FunctionProvenance.Confect<
+      infer ArgsFields_ extends FunctionProvenance.ArgsFields,
+      any,
+      any,
+      any
+    >;
   }
-    ? ArgsSchema_["Encoded"]
+    ? Schema.Struct.Encoded<ArgsFields_>
     : FunctionSpec_ extends {
-          functionProvenance: { _tag: "Convex"; "~args": infer Args_ };
+          functionProvenance: {
+            _tag: "Confect";
+            args: infer ArgsSchema_ extends Schema.Codec<any, any>;
+          };
         }
-      ? Args_
-      : never;
+      ? ArgsSchema_["Encoded"]
+      : FunctionSpec_ extends {
+            functionProvenance: { _tag: "Convex"; "~args": infer Args_ };
+          }
+        ? Args_
+        : never;
 
 export type EncodedReturns<FunctionSpec_ extends AnyWithProps> =
   FunctionSpec_ extends {
@@ -291,7 +360,7 @@ const make =
   ) =>
   <
     const Name_ extends string,
-    Args_ extends Schema.Codec<any, any>,
+    const ArgsFields_ extends FunctionProvenance.ArgsFields,
     Returns_ extends Schema.Codec<any, any>,
     Error_ extends Schema.Codec<any, any> = never,
   >({
@@ -301,14 +370,14 @@ const make =
     error,
   }: {
     name: Name_;
-    args: () => Args_;
+    args: () => ArgsFields_;
     returns: () => Returns_;
     error?: () => Error_;
   }): Builder<
     RuntimeAndFunctionType_,
     FunctionVisibility_,
     Name_,
-    FunctionProvenance.Confect<Args_, Returns_, Error_>
+    FunctionProvenance.Confect<ArgsFields_, Returns_, Error_>
   > => {
     validateConfectFunctionIdentifier(name);
 
@@ -327,58 +396,74 @@ const make =
  * constructors add themselves; the check reports at the `args` thunk with an
  * unsatisfiable type when violated.
  */
-type ForbidPaginationOpts<UserArgs extends FunctionProvenance.AnyUserArgs> =
-  "paginationOpts" extends keyof UserArgs["fields"]
-    ? { readonly fields: { readonly paginationOpts: never } }
-    : unknown;
+type ForbidPaginationOpts<
+  UserArgsFields extends FunctionProvenance.ArgsFields,
+> = "paginationOpts" extends keyof UserArgsFields
+  ? { readonly paginationOpts: never }
+  : unknown;
 
-const makePaginated =
-  <
-    RuntimeAndFunctionType_ extends
-      RuntimeAndFunctionType.RuntimeAndFunctionType,
-    FunctionVisibility_ extends FunctionVisibility,
-  >(
-    runtimeAndFunctionType: RuntimeAndFunctionType_,
-    functionVisibility: FunctionVisibility_,
-  ) =>
-  <
+interface AnyPaginatedOptions {
+  readonly name: string;
+  readonly args?: () => FunctionProvenance.ArgsFields;
+  readonly item: () => Schema.Codec<any, any>;
+  readonly error?: () => Schema.Codec<any, any>;
+}
+
+const makePaginated = <
+  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
+  FunctionVisibility_ extends FunctionVisibility,
+>(
+  runtimeAndFunctionType: RuntimeAndFunctionType_,
+  functionVisibility: FunctionVisibility_,
+) => {
+  function makeSpec<
     const Name_ extends string,
     Item_ extends Schema.Codec<any, any>,
-    UserArgs_ extends FunctionProvenance.AnyUserArgs = Schema.Struct<{}>,
     Error_ extends Schema.Codec<any, any> = never,
-  >({
-    name,
-    args,
-    item,
-    error,
-  }: {
+  >(options: {
     name: Name_;
-    /** User-declared args, without `paginationOpts` — it is added automatically. */
-    args?: (() => UserArgs_) & ForbidPaginationOpts<UserArgs_>;
-    /** The page element schema. */
+    args?: never;
     item: () => Item_;
     error?: () => Error_;
   }): Builder<
     RuntimeAndFunctionType_,
     FunctionVisibility_,
     Name_,
-    FunctionProvenance.ConfectPaginated<UserArgs_, Item_, Error_>
-  > => {
+    FunctionProvenance.ConfectPaginated<{}, Item_, Error_>
+  >;
+  function makeSpec<
+    const Name_ extends string,
+    const UserArgsFields_ extends FunctionProvenance.ArgsFields,
+    Item_ extends Schema.Codec<any, any>,
+    Error_ extends Schema.Codec<any, any> = never,
+  >(options: {
+    name: Name_;
+    args: () => UserArgsFields_ & ForbidPaginationOpts<UserArgsFields_>;
+    item: () => Item_;
+    error?: () => Error_;
+  }): Builder<
+    RuntimeAndFunctionType_,
+    FunctionVisibility_,
+    Name_,
+    FunctionProvenance.ConfectPaginated<UserArgsFields_, Item_, Error_>
+  >;
+  function makeSpec({ name, args, item, error }: AnyPaginatedOptions) {
     validateConfectFunctionIdentifier(name);
 
     return Object.assign(Object.create(Proto), {
       runtimeAndFunctionType,
       functionVisibility,
       name,
-      functionProvenance: FunctionProvenance.ConfectPaginated(
-        // When `args` is omitted, `UserArgs_` is its `Schema.Struct<{}>` default.
-        args ?? ((() => Schema.Struct({})) as unknown as () => UserArgs_),
-        item,
-        error,
-      ),
+      functionProvenance:
+        args === undefined
+          ? FunctionProvenance.ConfectPaginated(() => ({}), item, error)
+          : FunctionProvenance.ConfectPaginated(args, item, error),
       middlewareSpecs: [],
     });
-  };
+  }
+
+  return makeSpec;
+};
 
 export const publicQuery = make(RuntimeAndFunctionType.ConvexQuery, "public");
 export const internalQuery = make(
@@ -429,11 +514,19 @@ type MatchingRegisteredFunction<
         : never;
 
 type ExtractArgs<F> =
-  F extends RegisteredQuery<any, infer A, any>
+  F extends RegisteredQuery<any, infer A extends DefaultFunctionArgs, any>
     ? A
-    : F extends RegisteredMutation<any, infer A, any>
+    : F extends RegisteredMutation<
+          any,
+          infer A extends DefaultFunctionArgs,
+          any
+        >
       ? A
-      : F extends RegisteredAction<any, infer A, any>
+      : F extends RegisteredAction<
+            any,
+            infer A extends DefaultFunctionArgs,
+            any
+          >
         ? A
         : never;
 

--- a/packages/core/src/FunctionSpec.ts
+++ b/packages/core/src/FunctionSpec.ts
@@ -165,7 +165,8 @@ export type ArgsSchema<FunctionSpec_ extends AnyWithProps> =
     : FunctionSpec_ extends {
           readonly functionProvenance: {
             readonly _tag: "Confect";
-            readonly args: infer ArgsSchema_ extends FunctionProvenance.AnyArgs;
+            readonly args: infer ArgsSchema_ extends
+              FunctionProvenance.AnyArgsSchema;
           };
         }
       ? ArgsSchema_
@@ -316,7 +317,7 @@ const Proto = {
   },
 };
 
-interface AnyOptions {
+interface Options {
   readonly name: string;
   readonly args?: () => FunctionProvenance.ArgsFields;
   readonly returns: () => Schema.Codec<any, any>;
@@ -361,7 +362,7 @@ const make = <
     Name_,
     FunctionProvenance.Confect<{}, Returns_, Error_>
   >;
-  function makeSpec({ name, args, returns, error }: AnyOptions) {
+  function makeSpec({ name, args, returns, error }: Options) {
     validateConfectFunctionIdentifier(name);
 
     return Object.assign(Object.create(Proto), {
@@ -391,7 +392,7 @@ type ForbidPaginationOpts<
   ? { readonly paginationOpts: never }
   : unknown;
 
-interface AnyPaginatedOptions {
+interface PaginatedOptions {
   readonly name: string;
   readonly args?: () => FunctionProvenance.ArgsFields;
   readonly item: () => Schema.Codec<any, any>;
@@ -405,21 +406,6 @@ const makePaginated = <
   runtimeAndFunctionType: RuntimeAndFunctionType_,
   functionVisibility: FunctionVisibility_,
 ) => {
-  function makeSpec<
-    const Name_ extends string,
-    Item_ extends Schema.Codec<any, any>,
-    Error_ extends Schema.Codec<any, any> = never,
-  >(options: {
-    name: Name_;
-    args?: never;
-    item: () => Item_;
-    error?: () => Error_;
-  }): Builder<
-    RuntimeAndFunctionType_,
-    FunctionVisibility_,
-    Name_,
-    FunctionProvenance.ConfectPaginated<{}, Item_, Error_>
-  >;
   function makeSpec<
     const Name_ extends string,
     const UserArgsFields_ extends FunctionProvenance.ArgsFields,
@@ -436,7 +422,22 @@ const makePaginated = <
     Name_,
     FunctionProvenance.ConfectPaginated<UserArgsFields_, Item_, Error_>
   >;
-  function makeSpec({ name, args, item, error }: AnyPaginatedOptions) {
+  function makeSpec<
+    const Name_ extends string,
+    Item_ extends Schema.Codec<any, any>,
+    Error_ extends Schema.Codec<any, any> = never,
+  >(options: {
+    name: Name_;
+    args?: never;
+    item: () => Item_;
+    error?: () => Error_;
+  }): Builder<
+    RuntimeAndFunctionType_,
+    FunctionVisibility_,
+    Name_,
+    FunctionProvenance.ConfectPaginated<{}, Item_, Error_>
+  >;
+  function makeSpec({ name, args, item, error }: PaginatedOptions) {
     validateConfectFunctionIdentifier(name);
 
     return Object.assign(Object.create(Proto), {

--- a/packages/core/src/FunctionSpec.ts
+++ b/packages/core/src/FunctionSpec.ts
@@ -356,26 +356,26 @@ const Proto = {
   },
 };
 
-const make =
-  <
-    RuntimeAndFunctionType_ extends
-      RuntimeAndFunctionType.RuntimeAndFunctionType,
-    FunctionVisibility_ extends FunctionVisibility,
-  >(
-    runtimeAndFunctionType: RuntimeAndFunctionType_,
-    functionVisibility: FunctionVisibility_,
-  ) =>
-  <
+interface AnyOptions {
+  readonly name: string;
+  readonly args?: () => FunctionProvenance.ArgsFields;
+  readonly returns: () => Schema.Codec<any, any>;
+  readonly error?: () => Schema.Codec<any, any>;
+}
+
+const make = <
+  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
+  FunctionVisibility_ extends FunctionVisibility,
+>(
+  runtimeAndFunctionType: RuntimeAndFunctionType_,
+  functionVisibility: FunctionVisibility_,
+) => {
+  function makeSpec<
     const Name_ extends string,
     const ArgsFields_ extends FunctionProvenance.ArgsFields,
     Returns_ extends Schema.Codec<any, any>,
     Error_ extends Schema.Codec<any, any> = never,
-  >({
-    name,
-    args,
-    returns,
-    error,
-  }: {
+  >(options: {
     name: Name_;
     args: () => ArgsFields_;
     returns: () => Returns_;
@@ -385,17 +385,39 @@ const make =
     FunctionVisibility_,
     Name_,
     FunctionProvenance.Confect<ArgsFields_, Returns_, Error_>
-  > => {
+  >;
+  function makeSpec<
+    const Name_ extends string,
+    Returns_ extends Schema.Codec<any, any>,
+    Error_ extends Schema.Codec<any, any> = never,
+  >(options: {
+    name: Name_;
+    args?: never;
+    returns: () => Returns_;
+    error?: () => Error_;
+  }): Builder<
+    RuntimeAndFunctionType_,
+    FunctionVisibility_,
+    Name_,
+    FunctionProvenance.Confect<{}, Returns_, Error_>
+  >;
+  function makeSpec({ name, args, returns, error }: AnyOptions) {
     validateConfectFunctionIdentifier(name);
 
     return Object.assign(Object.create(Proto), {
       runtimeAndFunctionType,
       functionVisibility,
       name,
-      functionProvenance: FunctionProvenance.Confect(args, returns, error),
+      functionProvenance:
+        args === undefined
+          ? FunctionProvenance.Confect(() => ({}), returns, error)
+          : FunctionProvenance.Confect(args, returns, error),
       middlewareSpecs: [],
     });
-  };
+  }
+
+  return makeSpec;
+};
 
 /**
  * `Schema.Struct` fields that must not declare `paginationOpts`. Used to

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -121,23 +121,21 @@ export interface ConvexRef<
   readonly _tag: "Convex";
 }
 
-type ErasedRef<
-  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
-  FunctionVisibility_ extends FunctionVisibility,
-> = Ref<RuntimeAndFunctionType_, FunctionVisibility_, any, any, any>;
-
 export type Any = Ref<any, any, any, any, any>;
 
 /** Erased Confect-provenance ref used by provenance-specific APIs. */
 export type AnyConfect = Extract<Any, { readonly _tag: "Confect" }>;
 
-export type AnyInternal = ErasedRef<any, "internal">;
+export type AnyInternal = Ref<any, "internal", any, any, any>;
 
-export type AnyPublic = ErasedRef<any, "public">;
+export type AnyPublic = Ref<any, "public", any, any, any>;
 
-export type AnyQuery = ErasedRef<
+export type AnyQuery = Ref<
   RuntimeAndFunctionType.AnyQuery,
-  FunctionVisibility
+  FunctionVisibility,
+  any,
+  any,
+  any
 >;
 
 export type AnyPublicPaginatedQuery = AnyPublicQuery &
@@ -152,29 +150,44 @@ export type AnyPublicPaginatedQuery = AnyPublicQuery &
     any
   >;
 
-export type AnyMutation = ErasedRef<
+export type AnyMutation = Ref<
   RuntimeAndFunctionType.AnyMutation,
-  FunctionVisibility
+  FunctionVisibility,
+  any,
+  any,
+  any
 >;
 
-export type AnyAction = ErasedRef<
+export type AnyAction = Ref<
   RuntimeAndFunctionType.AnyAction,
-  FunctionVisibility
+  FunctionVisibility,
+  any,
+  any,
+  any
 >;
 
-export type AnyPublicQuery = ErasedRef<
+export type AnyPublicQuery = Ref<
   RuntimeAndFunctionType.AnyQuery,
-  "public"
+  "public",
+  any,
+  any,
+  any
 >;
 
-export type AnyPublicMutation = ErasedRef<
+export type AnyPublicMutation = Ref<
   RuntimeAndFunctionType.AnyMutation,
-  "public"
+  "public",
+  any,
+  any,
+  any
 >;
 
-export type AnyPublicAction = ErasedRef<
+export type AnyPublicAction = Ref<
   RuntimeAndFunctionType.AnyAction,
-  "public"
+  "public",
+  any,
+  any,
+  any
 >;
 
 export type GetRuntimeAndFunctionType<Ref_> = Ref_ extends {

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -51,26 +51,48 @@ export type Ref<
       any
     >;
 
-export interface ConfectRef<
+export type ConfectRef<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
   ArgsFields_ extends FunctionProvenance.ArgsFields,
   ReturnsSchema_ extends Schema.Codec<any, any>,
   ErrorSchema_ extends Schema.Codec<any, any> = never,
   MiddlewareError_ = never,
-> extends Base<
+> = ConfectRefWithArgs<
   RuntimeAndFunctionType_,
   FunctionVisibility_,
+  ArgsFields_,
   Schema.Struct.Type<ArgsFields_>,
   ReturnsSchema_["Type"],
   ErrorSchema_["Type"] | MiddlewareError_
+>;
+
+/**
+ * Internal form used while mapping a spec to a ref. Supplying the already
+ * derived value types avoids repeatedly expanding `Schema.Struct` for every
+ * leaf in a generated ref tree; the public `ConfectRef` alias still derives
+ * the same values from its fields and schemas.
+ */
+interface ConfectRefWithArgs<
+  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
+  FunctionVisibility_ extends FunctionVisibility,
+  ArgsFields_ extends FunctionProvenance.ArgsFields,
+  Args_,
+  Returns_,
+  Error_,
+> extends Base<
+  RuntimeAndFunctionType_,
+  FunctionVisibility_,
+  Args_,
+  Returns_,
+  Error_
 > {
   readonly _tag: "Confect";
-  readonly args: Schema.Struct<ArgsFields_>;
-  readonly returns: ReturnsSchema_;
+  readonly args: FunctionProvenance.ArgsSchema<ArgsFields_>;
+  readonly returns: Schema.Codec<any, any>;
   readonly kind: FunctionProvenance.ConfectKind;
   readonly middlewareSpecs: ReadonlyArray<MiddlewareSpec.AnyMiddlewareSpec>;
-  readonly error?: ErrorSchema_;
+  readonly error?: Schema.Codec<any, any>;
 }
 
 /** Erased structural view used by provenance-agnostic ref APIs. */
@@ -210,14 +232,20 @@ export type FromFunctionSpec<
   FunctionSpec_,
   FunctionSpec.GetRuntimeAndFunctionType<FunctionSpec_>,
   FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
-  MiddlewareError
+  FunctionSpec.ArgsFields<FunctionSpec_>,
+  FunctionSpec.Args<FunctionSpec_>,
+  FunctionSpec.Returns<FunctionSpec_>,
+  FunctionSpec.Error<FunctionSpec_> | MiddlewareError
 >;
 
 type FromFunctionSpecHelper<
   FunctionSpec_ extends FunctionSpec.AnyWithProps,
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-  MiddlewareError_,
+  ArgsFields_ extends FunctionProvenance.ArgsFields,
+  Args_,
+  Returns_,
+  Error_,
 > =
   FunctionSpec_ extends FunctionSpec.WithFunctionProvenance<
     FunctionSpec_,
@@ -226,32 +254,29 @@ type FromFunctionSpecHelper<
     ? ConvexRef<
         RuntimeAndFunctionType_,
         FunctionVisibility_,
-        FunctionSpec.Args<FunctionSpec_> extends infer Args_ extends
-          DefaultFunctionArgs
-          ? Args_
-          : never,
-        FunctionSpec.Returns<FunctionSpec_>,
+        Args_ extends DefaultFunctionArgs ? Args_ : never,
+        Returns_,
         never
       >
     : FunctionSpec_ extends FunctionSpec.WithFunctionProvenance<
           FunctionSpec_,
           FunctionProvenance.AnyConfect
         >
-      ? ConfectRef<
+      ? ConfectRefWithArgs<
           RuntimeAndFunctionType_,
           FunctionVisibility_,
-          FunctionSpec.ArgsFields<FunctionSpec_>,
-          FunctionSpec.ReturnsSchema<FunctionSpec_>,
-          FunctionSpec.ErrorSchema<FunctionSpec_>,
-          MiddlewareError_
+          ArgsFields_,
+          Args_,
+          Returns_,
+          Error_
         >
       : Ref<RuntimeAndFunctionType_, FunctionVisibility_> &
           Base<
             RuntimeAndFunctionType_,
             FunctionVisibility_,
-            FunctionSpec.Args<FunctionSpec_>,
-            FunctionSpec.Returns<FunctionSpec_>,
-            FunctionSpec.Error<FunctionSpec_> | MiddlewareError_
+            Args_,
+            Returns_,
+            Error_
           >;
 
 export const make = <FunctionSpec_ extends FunctionSpec.AnyWithProps>(

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -42,7 +42,7 @@ export type Ref<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
 > =
-  | AnyConfectRef<RuntimeAndFunctionType_, FunctionVisibility_>
+  | ErasedConfectRef<RuntimeAndFunctionType_, FunctionVisibility_>
   | ConvexRef<
       RuntimeAndFunctionType_,
       FunctionVisibility_,
@@ -58,7 +58,7 @@ export type ConfectRef<
   ReturnsSchema_ extends Schema.Codec<any, any>,
   ErrorSchema_ extends Schema.Codec<any, any> = never,
   MiddlewareError_ = never,
-> = ConfectRefWithArgs<
+> = ConfectRefWithTypes<
   RuntimeAndFunctionType_,
   FunctionVisibility_,
   ArgsFields_,
@@ -73,7 +73,7 @@ export type ConfectRef<
  * leaf in a generated ref tree; the public `ConfectRef` alias still derives
  * the same values from its fields and schemas.
  */
-interface ConfectRefWithArgs<
+interface ConfectRefWithTypes<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
   ArgsFields_ extends FunctionProvenance.ArgsFields,
@@ -95,18 +95,17 @@ interface ConfectRefWithArgs<
   readonly error?: Schema.Codec<any, any>;
 }
 
-/** Erased structural view used by provenance-agnostic ref APIs. */
-export interface AnyConfectRef<
+type ErasedConfectRef<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-> extends Base<RuntimeAndFunctionType_, FunctionVisibility_, any, any, any> {
-  readonly _tag: "Confect";
-  readonly args: FunctionProvenance.AnyArgs;
-  readonly returns: Schema.Codec<any, any>;
-  readonly kind: FunctionProvenance.ConfectKind;
-  readonly middlewareSpecs: ReadonlyArray<MiddlewareSpec.AnyMiddlewareSpec>;
-  readonly error?: Schema.Codec<any, any>;
-}
+> = ConfectRefWithTypes<
+  RuntimeAndFunctionType_,
+  FunctionVisibility_,
+  FunctionProvenance.ArgsFields,
+  any,
+  any,
+  any
+>;
 
 export interface ConvexRef<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
@@ -126,7 +125,8 @@ export interface ConvexRef<
 
 export type Any = Ref<any, any>;
 
-export type AnyConfect = AnyConfectRef<any, any>;
+/** Erased Confect-provenance ref used by provenance-specific APIs. */
+export type AnyConfect = ErasedConfectRef<any, any>;
 
 export type AnyInternal = Ref<any, "internal">;
 
@@ -203,7 +203,7 @@ export type ArgsFields<Ref_> = Ref_ extends {
 /** The assembled args schema carried by a Confect-provenance ref. */
 export type ArgsSchema<Ref_> = Ref_ extends {
   readonly _tag: "Confect";
-  readonly args: infer ArgsSchema_ extends FunctionProvenance.AnyArgs;
+  readonly args: infer ArgsSchema_ extends FunctionProvenance.AnyArgsSchema;
 }
   ? ArgsSchema_
   : never;
@@ -262,7 +262,7 @@ type FromFunctionSpecHelper<
           FunctionSpec_,
           FunctionProvenance.AnyConfect
         >
-      ? ConfectRefWithArgs<
+      ? ConfectRefWithTypes<
           RuntimeAndFunctionType_,
           FunctionVisibility_,
           ArgsFields_,
@@ -540,9 +540,7 @@ const missingPaginatedProvenanceError = (ref: Any) =>
       "  })",
   );
 
-const paginatedKind = (
-  ref: AnyConfectRef<any, any>,
-): FunctionProvenance.Paginated =>
+const paginatedKind = (ref: AnyConfect): FunctionProvenance.Paginated =>
   Match.value(ref.kind).pipe(
     Match.tag("Paginated", (kind) => kind),
     Match.tag("Standard", () => {

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -1,4 +1,5 @@
 import type {
+  DefaultFunctionArgs,
   FunctionReference as ConvexFunctionReference,
   FunctionVisibility,
   PaginationOptions,
@@ -40,40 +41,45 @@ export interface Base<
 export type Ref<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-  Args_,
-  Returns_,
-  Error_ = never,
 > =
-  | ConfectRef<
-      RuntimeAndFunctionType_,
-      FunctionVisibility_,
-      Args_,
-      Returns_,
-      Error_
-    >
+  | AnyConfectRef<RuntimeAndFunctionType_, FunctionVisibility_>
   | ConvexRef<
       RuntimeAndFunctionType_,
       FunctionVisibility_,
-      Args_,
-      Returns_,
-      Error_
+      DefaultFunctionArgs,
+      any,
+      any
     >;
 
 export interface ConfectRef<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-  Args_,
-  Returns_,
-  Error_ = never,
+  ArgsFields_ extends FunctionProvenance.ArgsFields,
+  ReturnsSchema_ extends Schema.Codec<any, any>,
+  ErrorSchema_ extends Schema.Codec<any, any> = never,
+  MiddlewareError_ = never,
 > extends Base<
   RuntimeAndFunctionType_,
   FunctionVisibility_,
-  Args_,
-  Returns_,
-  Error_
+  Schema.Struct.Type<ArgsFields_>,
+  ReturnsSchema_["Type"],
+  ErrorSchema_["Type"] | MiddlewareError_
 > {
   readonly _tag: "Confect";
-  readonly args: Schema.Codec<any, any>;
+  readonly args: Schema.Struct<ArgsFields_>;
+  readonly returns: ReturnsSchema_;
+  readonly kind: FunctionProvenance.ConfectKind;
+  readonly middlewareSpecs: ReadonlyArray<MiddlewareSpec.AnyMiddlewareSpec>;
+  readonly error?: ErrorSchema_;
+}
+
+/** Erased structural view used by provenance-agnostic ref APIs. */
+export interface AnyConfectRef<
+  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
+  FunctionVisibility_ extends FunctionVisibility,
+> extends Base<RuntimeAndFunctionType_, FunctionVisibility_, any, any, any> {
+  readonly _tag: "Confect";
+  readonly args: FunctionProvenance.AnyArgs;
   readonly returns: Schema.Codec<any, any>;
   readonly kind: FunctionProvenance.ConfectKind;
   readonly middlewareSpecs: ReadonlyArray<MiddlewareSpec.AnyMiddlewareSpec>;
@@ -83,7 +89,7 @@ export interface ConfectRef<
 export interface ConvexRef<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-  Args_,
+  Args_ extends DefaultFunctionArgs,
   Returns_,
   Error_ = never,
 > extends Base<
@@ -96,70 +102,46 @@ export interface ConvexRef<
   readonly _tag: "Convex";
 }
 
-export type Any = Ref<any, any, any, any, any>;
+export type Any = Ref<any, any>;
 
-export type AnyInternal = Ref<any, "internal", any, any, any>;
+export type AnyConfect = AnyConfectRef<any, any>;
 
-export type AnyPublic = Ref<any, "public", any, any, any>;
+export type AnyInternal = Ref<any, "internal">;
 
-export type AnyQuery = Ref<
-  RuntimeAndFunctionType.AnyQuery,
-  FunctionVisibility,
-  any,
-  any,
-  any
->;
+export type AnyPublic = Ref<any, "public">;
 
-export type AnyPublicPaginatedQuery = Ref<
-  RuntimeAndFunctionType.AnyQuery,
-  "public",
-  {
-    [key: string]: any;
-    paginationOpts: PaginationOptions;
-  },
-  PaginationResult<any>,
-  any
->;
+export type AnyQuery = Ref<RuntimeAndFunctionType.AnyQuery, FunctionVisibility>;
+
+export type AnyPublicPaginatedQuery = AnyPublicQuery &
+  Base<
+    RuntimeAndFunctionType.AnyQuery,
+    "public",
+    {
+      [key: string]: any;
+      paginationOpts: PaginationOptions;
+    },
+    PaginationResult<any>,
+    any
+  >;
 
 export type AnyMutation = Ref<
   RuntimeAndFunctionType.AnyMutation,
-  FunctionVisibility,
-  any,
-  any,
-  any
+  FunctionVisibility
 >;
 
 export type AnyAction = Ref<
   RuntimeAndFunctionType.AnyAction,
-  FunctionVisibility,
-  any,
-  any,
-  any
+  FunctionVisibility
 >;
 
-export type AnyPublicQuery = Ref<
-  RuntimeAndFunctionType.AnyQuery,
-  "public",
-  any,
-  any,
-  any
->;
+export type AnyPublicQuery = Ref<RuntimeAndFunctionType.AnyQuery, "public">;
 
 export type AnyPublicMutation = Ref<
   RuntimeAndFunctionType.AnyMutation,
-  "public",
-  any,
-  any,
-  any
+  "public"
 >;
 
-export type AnyPublicAction = Ref<
-  RuntimeAndFunctionType.AnyAction,
-  "public",
-  any,
-  any,
-  any
->;
+export type AnyPublicAction = Ref<RuntimeAndFunctionType.AnyAction, "public">;
 
 export type GetRuntimeAndFunctionType<Ref_> = Ref_ extends {
   readonly "~RuntimeAndFunctionType": infer RuntimeAndFunctionType_ extends
@@ -186,6 +168,24 @@ export type Args<Ref_> = Ref_ extends { readonly "~Args": infer Args_ }
   ? Args_
   : never;
 
+/** The field map captured by a Confect-provenance ref. */
+export type ArgsFields<Ref_> = Ref_ extends {
+  readonly _tag: "Confect";
+  readonly args: {
+    readonly fields: infer ArgsFields_ extends FunctionProvenance.ArgsFields;
+  };
+}
+  ? ArgsFields_
+  : never;
+
+/** The assembled args schema carried by a Confect-provenance ref. */
+export type ArgsSchema<Ref_> = Ref_ extends {
+  readonly _tag: "Confect";
+  readonly args: infer ArgsSchema_ extends FunctionProvenance.AnyArgs;
+}
+  ? ArgsSchema_
+  : never;
+
 export type OptionalArgs<Ref_ extends Any> = keyof Args<Ref_> extends never
   ? [args?: Args<Ref_>]
   : [args: Args<Ref_>];
@@ -210,18 +210,14 @@ export type FromFunctionSpec<
   FunctionSpec_,
   FunctionSpec.GetRuntimeAndFunctionType<FunctionSpec_>,
   FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
-  FunctionSpec.Args<FunctionSpec_>,
-  FunctionSpec.Returns<FunctionSpec_>,
-  FunctionSpec.Error<FunctionSpec_> | MiddlewareError
+  MiddlewareError
 >;
 
 type FromFunctionSpecHelper<
   FunctionSpec_ extends FunctionSpec.AnyWithProps,
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-  Args_,
-  Returns_,
-  Error_,
+  MiddlewareError_,
 > =
   FunctionSpec_ extends FunctionSpec.WithFunctionProvenance<
     FunctionSpec_,
@@ -230,9 +226,12 @@ type FromFunctionSpecHelper<
     ? ConvexRef<
         RuntimeAndFunctionType_,
         FunctionVisibility_,
-        Args_,
-        Returns_,
-        Error_
+        FunctionSpec.Args<FunctionSpec_> extends infer Args_ extends
+          DefaultFunctionArgs
+          ? Args_
+          : never,
+        FunctionSpec.Returns<FunctionSpec_>,
+        never
       >
     : FunctionSpec_ extends FunctionSpec.WithFunctionProvenance<
           FunctionSpec_,
@@ -241,17 +240,19 @@ type FromFunctionSpecHelper<
       ? ConfectRef<
           RuntimeAndFunctionType_,
           FunctionVisibility_,
-          Args_,
-          Returns_,
-          Error_
+          FunctionSpec.ArgsFields<FunctionSpec_>,
+          FunctionSpec.ReturnsSchema<FunctionSpec_>,
+          FunctionSpec.ErrorSchema<FunctionSpec_>,
+          MiddlewareError_
         >
-      : Ref<
-          RuntimeAndFunctionType_,
-          FunctionVisibility_,
-          Args_,
-          Returns_,
-          Error_
-        >;
+      : Ref<RuntimeAndFunctionType_, FunctionVisibility_> &
+          Base<
+            RuntimeAndFunctionType_,
+            FunctionVisibility_,
+            FunctionSpec.Args<FunctionSpec_>,
+            FunctionSpec.Returns<FunctionSpec_>,
+            FunctionSpec.Error<FunctionSpec_> | MiddlewareError_
+          >;
 
 export const make = <FunctionSpec_ extends FunctionSpec.AnyWithProps>(
   /**
@@ -509,14 +510,14 @@ const missingPaginatedProvenanceError = (ref: Any) =>
       "those constructors store. Define the function as, e.g.:\n\n" +
       "  FunctionSpec.publicPaginatedQuery({\n" +
       '    name: "...",\n' +
-      "    args: () => Schema.Struct({ ... }), // optional; without paginationOpts\n" +
+      "    args: () => ({ ... }), // optional; without paginationOpts\n" +
       "    item: () => ItemSchema,\n" +
       "  })",
   );
 
 const paginatedKind = (
-  ref: ConfectRef<any, any, any, any, any>,
-): FunctionProvenance.Paginated =>
+  ref: AnyConfectRef<any, any>,
+): FunctionProvenance.AnyPaginated =>
   Match.value(ref.kind).pipe(
     Match.tag("Paginated", (kind) => kind),
     Match.tag("Standard", () => {

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -542,7 +542,7 @@ const missingPaginatedProvenanceError = (ref: Any) =>
 
 const paginatedKind = (
   ref: AnyConfectRef<any, any>,
-): FunctionProvenance.AnyPaginated =>
+): FunctionProvenance.Paginated =>
   Match.value(ref.kind).pipe(
     Match.tag("Paginated", (kind) => kind),
     Match.tag("Standard", () => {

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -21,7 +21,7 @@ import type * as RuntimeAndFunctionType from "./RuntimeAndFunctionType";
 export interface Base<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
-  Args_,
+  Args_ extends DefaultFunctionArgs,
   Returns_,
   Error_ = never,
 > {
@@ -41,14 +41,24 @@ export interface Base<
 export type Ref<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
+  Args_ extends DefaultFunctionArgs,
+  Returns_,
+  Error_ = never,
 > =
-  | ErasedConfectRef<RuntimeAndFunctionType_, FunctionVisibility_>
+  | ConfectRefWithTypes<
+      RuntimeAndFunctionType_,
+      FunctionVisibility_,
+      FunctionProvenance.ArgsFields,
+      Args_,
+      Returns_,
+      Error_
+    >
   | ConvexRef<
       RuntimeAndFunctionType_,
       FunctionVisibility_,
-      DefaultFunctionArgs,
-      any,
-      any
+      Args_,
+      Returns_,
+      Error_
     >;
 
 export type ConfectRef<
@@ -77,7 +87,7 @@ interface ConfectRefWithTypes<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
   ArgsFields_ extends FunctionProvenance.ArgsFields,
-  Args_,
+  Args_ extends DefaultFunctionArgs,
   Returns_,
   Error_,
 > extends Base<
@@ -95,18 +105,6 @@ interface ConfectRefWithTypes<
   readonly error?: Schema.Codec<any, any>;
 }
 
-type ErasedConfectRef<
-  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
-  FunctionVisibility_ extends FunctionVisibility,
-> = ConfectRefWithTypes<
-  RuntimeAndFunctionType_,
-  FunctionVisibility_,
-  FunctionProvenance.ArgsFields,
-  any,
-  any,
-  any
->;
-
 export interface ConvexRef<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
@@ -123,16 +121,24 @@ export interface ConvexRef<
   readonly _tag: "Convex";
 }
 
-export type Any = Ref<any, any>;
+type ErasedRef<
+  RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
+  FunctionVisibility_ extends FunctionVisibility,
+> = Ref<RuntimeAndFunctionType_, FunctionVisibility_, any, any, any>;
+
+export type Any = Ref<any, any, any, any, any>;
 
 /** Erased Confect-provenance ref used by provenance-specific APIs. */
-export type AnyConfect = ErasedConfectRef<any, any>;
+export type AnyConfect = Extract<Any, { readonly _tag: "Confect" }>;
 
-export type AnyInternal = Ref<any, "internal">;
+export type AnyInternal = ErasedRef<any, "internal">;
 
-export type AnyPublic = Ref<any, "public">;
+export type AnyPublic = ErasedRef<any, "public">;
 
-export type AnyQuery = Ref<RuntimeAndFunctionType.AnyQuery, FunctionVisibility>;
+export type AnyQuery = ErasedRef<
+  RuntimeAndFunctionType.AnyQuery,
+  FunctionVisibility
+>;
 
 export type AnyPublicPaginatedQuery = AnyPublicQuery &
   Base<
@@ -146,24 +152,30 @@ export type AnyPublicPaginatedQuery = AnyPublicQuery &
     any
   >;
 
-export type AnyMutation = Ref<
+export type AnyMutation = ErasedRef<
   RuntimeAndFunctionType.AnyMutation,
   FunctionVisibility
 >;
 
-export type AnyAction = Ref<
+export type AnyAction = ErasedRef<
   RuntimeAndFunctionType.AnyAction,
   FunctionVisibility
 >;
 
-export type AnyPublicQuery = Ref<RuntimeAndFunctionType.AnyQuery, "public">;
+export type AnyPublicQuery = ErasedRef<
+  RuntimeAndFunctionType.AnyQuery,
+  "public"
+>;
 
-export type AnyPublicMutation = Ref<
+export type AnyPublicMutation = ErasedRef<
   RuntimeAndFunctionType.AnyMutation,
   "public"
 >;
 
-export type AnyPublicAction = Ref<RuntimeAndFunctionType.AnyAction, "public">;
+export type AnyPublicAction = ErasedRef<
+  RuntimeAndFunctionType.AnyAction,
+  "public"
+>;
 
 export type GetRuntimeAndFunctionType<Ref_> = Ref_ extends {
   readonly "~RuntimeAndFunctionType": infer RuntimeAndFunctionType_ extends
@@ -243,7 +255,7 @@ type FromFunctionSpecHelper<
   RuntimeAndFunctionType_ extends RuntimeAndFunctionType.RuntimeAndFunctionType,
   FunctionVisibility_ extends FunctionVisibility,
   ArgsFields_ extends FunctionProvenance.ArgsFields,
-  Args_,
+  Args_ extends DefaultFunctionArgs,
   Returns_,
   Error_,
 > =
@@ -270,14 +282,13 @@ type FromFunctionSpecHelper<
           Returns_,
           Error_
         >
-      : Ref<RuntimeAndFunctionType_, FunctionVisibility_> &
-          Base<
-            RuntimeAndFunctionType_,
-            FunctionVisibility_,
-            Args_,
-            Returns_,
-            Error_
-          >;
+      : Ref<
+          RuntimeAndFunctionType_,
+          FunctionVisibility_,
+          Args_,
+          Returns_,
+          Error_
+        >;
 
 export const make = <FunctionSpec_ extends FunctionSpec.AnyWithProps>(
   /**

--- a/packages/core/src/Refs.ts
+++ b/packages/core/src/Refs.ts
@@ -40,9 +40,7 @@ type FunctionSpecMatchesPredicate<
 > =
   Ref.Ref<
     FunctionSpec.GetRuntimeAndFunctionType<FunctionSpec_>,
-    FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
-    any,
-    any
+    FunctionSpec.GetFunctionVisibility<FunctionSpec_>
   > extends Predicate
     ? true
     : false;

--- a/packages/core/src/Refs.ts
+++ b/packages/core/src/Refs.ts
@@ -40,7 +40,10 @@ type FunctionSpecMatchesPredicate<
 > =
   Ref.Ref<
     FunctionSpec.GetRuntimeAndFunctionType<FunctionSpec_>,
-    FunctionSpec.GetFunctionVisibility<FunctionSpec_>
+    FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
+    any,
+    any,
+    any
   > extends Predicate
     ? true
     : false;

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -2,15 +2,16 @@ import { describe, expect, it } from "@effect/vitest";
 import { expectTypeOf } from "vitest";
 import * as MutableRef from "effect/MutableRef";
 import * as Schema from "effect/Schema";
-import type * as FunctionProvenance from "@confect/core/FunctionProvenance";
 import * as FunctionSpec from "@confect/core/FunctionSpec";
 import * as Ref from "@confect/core/Ref";
+
+declare const ServicefulString: Schema.Codec<string, string, "RequiredService">;
 
 describe("isFunctionSpec", () => {
   it("checks whether a value is a function spec", () => {
     const functionSpec: unknown = FunctionSpec.publicQuery({
       name: "myFunction",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     });
 
@@ -19,11 +20,29 @@ describe("isFunctionSpec", () => {
 });
 
 describe("make", () => {
+  it("only accepts context-free struct fields as args", () => {
+    const nonStruct = FunctionSpec.publicQuery({
+      name: "nonStruct",
+      // @ts-expect-error — function args must be a struct field map
+      args: () => Schema.String,
+      returns: () => Schema.String,
+    });
+    const serviceful = FunctionSpec.publicQuery({
+      name: "serviceful",
+      // @ts-expect-error — function args must be synchronously encodable and decodable
+      args: () => ({ value: ServicefulString }),
+      returns: () => Schema.String,
+    });
+
+    void nonStruct;
+    void serviceful;
+  });
+
   it("disallows invalid JS identifiers as function names", () => {
     expect(() =>
       FunctionSpec.publicQuery({
         name: "123",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.String,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -35,7 +54,7 @@ describe("make", () => {
     expect(() =>
       FunctionSpec.publicQuery({
         name: "if",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.String,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -47,7 +66,7 @@ describe("make", () => {
     expect(() =>
       FunctionSpec.publicQuery({
         name: "schema",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.String,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -58,10 +77,11 @@ describe("make", () => {
 
 // LAZINESS INVARIANT — DO NOT REGRESS.
 //
-// `args`/`returns`/`error` are passed as `() => Schema` thunks and exposed as
-// lazy memoised getters so that importing the assembled `_generated/spec.ts`
-// (which transitively references every function in the project) does not build
-// any schemas at module load. The cold-start win depends on two rules:
+// `args` fields and `returns`/`error` schemas are passed as thunks and exposed
+// as lazy memoised schema getters so that importing the assembled
+// `_generated/spec.ts` (which transitively references every function in the
+// project) does not build any schemas at module load. The cold-start win
+// depends on two rules:
 //
 //   1. Constructing a `FunctionSpec` must NOT evaluate any schema thunk.
 //   2. Code that only needs to know WHETHER an `error` schema exists must use a
@@ -81,7 +101,7 @@ describe("laziness invariant", () => {
       name: "tracked",
       args: () => {
         track.args?.();
-        return Schema.Struct({});
+        return {};
       },
       returns: () => {
         track.returns?.();
@@ -151,7 +171,7 @@ describe("laziness invariant", () => {
   it("a spec without an error schema reports no error without defining the key", () => {
     const spec = FunctionSpec.publicQuery({
       name: "noError",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Null,
     });
     const ref = Ref.make("ns", spec);
@@ -187,7 +207,7 @@ describe("paginated queries", () => {
         name: "tracked",
         args: () => {
           track.args?.();
-          return Schema.Struct({});
+          return {};
         },
         item: () => {
           track.item?.();
@@ -231,7 +251,7 @@ describe("paginated queries", () => {
     it("a standard spec's kind is Standard", () => {
       const spec = FunctionSpec.publicQuery({
         name: "list",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Null,
       });
 
@@ -267,12 +287,11 @@ describe("paginated queries", () => {
     it("composes `paginationOpts` into the args schema", () => {
       const spec = FunctionSpec.publicPaginatedQuery({
         name: "listPaginated",
-        args: () => Schema.Struct({ author: Schema.String }),
+        args: () => ({ author: Schema.String }),
         item: () => item,
       });
 
-      const args = spec.functionProvenance
-        .args as unknown as FunctionProvenance.AnyUserArgs;
+      const args = spec.functionProvenance.args;
       expect(Object.keys(args.fields)).toEqual(["author", "paginationOpts"]);
     });
 
@@ -282,8 +301,7 @@ describe("paginated queries", () => {
         item: () => item,
       });
 
-      const args = spec.functionProvenance
-        .args as unknown as FunctionProvenance.AnyUserArgs;
+      const args = spec.functionProvenance.args;
       expect(Object.keys(args.fields)).toEqual(["paginationOpts"]);
     });
 
@@ -293,8 +311,7 @@ describe("paginated queries", () => {
         item: () => item,
       });
 
-      const returns = spec.functionProvenance
-        .returns as unknown as FunctionProvenance.AnyUserArgs;
+      const returns = spec.functionProvenance.returns;
       expect(Object.keys(returns.fields)).toEqual([
         "page",
         "isDone",
@@ -307,11 +324,10 @@ describe("paginated queries", () => {
     it("throws when the user args schema declares paginationOpts", () => {
       const spec = FunctionSpec.publicPaginatedQuery({
         name: "listPaginated",
-        // @ts-expect-error — paginationOpts must not be declared in user args
-        args: () =>
-          Schema.Struct({
-            paginationOpts: Schema.Struct({ numItems: Schema.Finite }),
-          }),
+        args: () => ({
+          // @ts-expect-error — paginationOpts must not be declared in user args
+          paginationOpts: Schema.Struct({ numItems: Schema.Finite }),
+        }),
         item: () => item,
       });
 
@@ -327,7 +343,7 @@ describe("paginated queries", () => {
     it("derives Args/Returns/Error from the composed schemas", () => {
       const _spec = FunctionSpec.publicPaginatedQuery({
         name: "listPaginated",
-        args: () => Schema.Struct({ author: Schema.String }),
+        args: () => ({ author: Schema.String }),
         item: () => item,
         error: () => Schema.String,
       });
@@ -337,6 +353,9 @@ describe("paginated queries", () => {
         FunctionSpec.Args<Spec>["paginationOpts"]["numItems"]
       >().toEqualTypeOf<number>();
       expectTypeOf<FunctionSpec.Args<Spec>["author"]>().toEqualTypeOf<string>();
+      expectTypeOf<
+        FunctionSpec.ArgsSchema<Spec>["fields"]["author"]
+      >().toEqualTypeOf<typeof Schema.String>();
       expectTypeOf<FunctionSpec.Returns<Spec>["page"][number]>().toEqualTypeOf<{
         readonly value: number;
       }>();

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -365,8 +365,8 @@ describe("paginated queries", () => {
     it("throws when the user args schema declares paginationOpts", () => {
       const spec = FunctionSpec.publicPaginatedQuery({
         name: "listPaginated",
+        // @ts-expect-error — paginationOpts must not be declared in user args
         args: () => ({
-          // @ts-expect-error — paginationOpts must not be declared in user args
           paginationOpts: Schema.Struct({ numItems: Schema.Finite }),
         }),
         item: () => item,

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -29,6 +29,12 @@ describe("make", () => {
 
     expectTypeOf<FunctionSpec.Args<typeof spec>>().toEqualTypeOf<{}>();
     expectTypeOf<FunctionSpec.EncodedArgs<typeof spec>>().toEqualTypeOf<{}>();
+    expectTypeOf<FunctionSpec.ReturnsSchema<typeof spec>>().toEqualTypeOf<
+      typeof Schema.String
+    >();
+    expectTypeOf<FunctionSpec.ErrorSchema<typeof spec>>().toEqualTypeOf<
+      typeof Schema.Finite
+    >();
     expectTypeOf<FunctionSpec.Error<typeof spec>>().toEqualTypeOf<number>();
     expectTypeOf<
       Ref.OptionalArgs<Ref.FromFunctionSpec<typeof spec>>
@@ -38,9 +44,27 @@ describe("make", () => {
 
   it("keeps erased Confect specs safely generic", () => {
     expectTypeOf<FunctionSpec.Args<FunctionSpec.AnyConfect>>().toBeAny();
+    expectTypeOf<FunctionSpec.Returns<FunctionSpec.AnyConfect>>().toBeAny();
+    expectTypeOf<FunctionSpec.Error<FunctionSpec.AnyConfect>>().toBeAny();
     expectTypeOf<
       FunctionSpec.ArgsSchema<FunctionSpec.AnyConfect>
     >().toMatchTypeOf<Schema.Codec<any, any>>();
+    expectTypeOf<
+      FunctionSpec.ReturnsSchema<FunctionSpec.AnyConfect>
+    >().toMatchTypeOf<Schema.Codec<any, any>>();
+    expectTypeOf<
+      FunctionSpec.ErrorSchema<FunctionSpec.AnyConfect>
+    >().toMatchTypeOf<Schema.Codec<any, any>>();
+  });
+
+  it("extracts no error schema when none is declared", () => {
+    const spec = FunctionSpec.publicQuery({
+      name: "withoutError",
+      returns: () => Schema.String,
+    });
+
+    expectTypeOf<FunctionSpec.ErrorSchema<typeof spec>>().toBeNever();
+    expectTypeOf<FunctionSpec.Error<typeof spec>>().toBeNever();
   });
 
   it("only accepts context-free struct fields as args", () => {

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -20,6 +20,22 @@ describe("isFunctionSpec", () => {
 });
 
 describe("make", () => {
+  it("defaults omitted args to an empty field map", () => {
+    const spec = FunctionSpec.publicQuery({
+      name: "withoutArgs",
+      returns: () => Schema.String,
+      error: () => Schema.Finite,
+    });
+
+    expectTypeOf<FunctionSpec.Args<typeof spec>>().toEqualTypeOf<{}>();
+    expectTypeOf<FunctionSpec.EncodedArgs<typeof spec>>().toEqualTypeOf<{}>();
+    expectTypeOf<FunctionSpec.Error<typeof spec>>().toEqualTypeOf<number>();
+    expectTypeOf<
+      Ref.OptionalArgs<Ref.FromFunctionSpec<typeof spec>>
+    >().toEqualTypeOf<[args?: {}]>();
+    expect(spec.functionProvenance.args.fields).toStrictEqual({});
+  });
+
   it("keeps erased Confect specs safely generic", () => {
     expectTypeOf<FunctionSpec.Args<FunctionSpec.AnyConfect>>().toBeAny();
     expectTypeOf<

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -20,6 +20,13 @@ describe("isFunctionSpec", () => {
 });
 
 describe("make", () => {
+  it("keeps erased Confect specs safely generic", () => {
+    expectTypeOf<FunctionSpec.Args<FunctionSpec.AnyConfect>>().toBeAny();
+    expectTypeOf<
+      FunctionSpec.ArgsSchema<FunctionSpec.AnyConfect>
+    >().toMatchTypeOf<Schema.Codec<any, any>>();
+  });
+
   it("only accepts context-free struct fields as args", () => {
     const nonStruct = FunctionSpec.publicQuery({
       name: "nonStruct",

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -11,7 +11,6 @@ describe("isFunctionSpec", () => {
   it("checks whether a value is a function spec", () => {
     const functionSpec: unknown = FunctionSpec.publicQuery({
       name: "myFunction",
-      args: () => ({}),
       returns: () => Schema.String,
     });
 
@@ -89,7 +88,6 @@ describe("make", () => {
     expect(() =>
       FunctionSpec.publicQuery({
         name: "123",
-        args: () => ({}),
         returns: () => Schema.String,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -101,7 +99,6 @@ describe("make", () => {
     expect(() =>
       FunctionSpec.publicQuery({
         name: "if",
-        args: () => ({}),
         returns: () => Schema.String,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -113,7 +110,6 @@ describe("make", () => {
     expect(() =>
       FunctionSpec.publicQuery({
         name: "schema",
-        args: () => ({}),
         returns: () => Schema.String,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -148,7 +144,7 @@ describe("laziness invariant", () => {
       name: "tracked",
       args: () => {
         track.args?.();
-        return {};
+        return { tracked: Schema.Boolean };
       },
       returns: () => {
         track.returns?.();
@@ -218,7 +214,6 @@ describe("laziness invariant", () => {
   it("a spec without an error schema reports no error without defining the key", () => {
     const spec = FunctionSpec.publicQuery({
       name: "noError",
-      args: () => ({}),
       returns: () => Schema.Null,
     });
     const ref = Ref.make("ns", spec);
@@ -254,7 +249,7 @@ describe("paginated queries", () => {
         name: "tracked",
         args: () => {
           track.args?.();
-          return {};
+          return { tracked: Schema.Boolean };
         },
         item: () => {
           track.item?.();
@@ -298,7 +293,6 @@ describe("paginated queries", () => {
     it("a standard spec's kind is Standard", () => {
       const spec = FunctionSpec.publicQuery({
         name: "list",
-        args: () => ({}),
         returns: () => Schema.Null,
       });
 

--- a/packages/core/test/MiddlewareSpec.test.ts
+++ b/packages/core/test/MiddlewareSpec.test.ts
@@ -38,20 +38,17 @@ class MutationOnly extends MiddlewareSpec.MiddlewareSpec<MutationOnly>()(
 
 const query = FunctionSpec.publicQuery({
   name: "getThing",
-  args: () => ({}),
   returns: () => Schema.String,
 });
 
 const queryWithError = FunctionSpec.publicQuery({
   name: "getThingOrFail",
-  args: () => ({}),
   returns: () => Schema.String,
   error: () => NotFound,
 });
 
 const mutation = FunctionSpec.publicMutation({
   name: "setThing",
-  args: () => ({}),
   returns: () => Schema.Null,
 });
 

--- a/packages/core/test/MiddlewareSpec.test.ts
+++ b/packages/core/test/MiddlewareSpec.test.ts
@@ -38,20 +38,20 @@ class MutationOnly extends MiddlewareSpec.MiddlewareSpec<MutationOnly>()(
 
 const query = FunctionSpec.publicQuery({
   name: "getThing",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.String,
 });
 
 const queryWithError = FunctionSpec.publicQuery({
   name: "getThingOrFail",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.String,
   error: () => NotFound,
 });
 
 const mutation = FunctionSpec.publicMutation({
   name: "setThing",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.Null,
 });
 

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -122,6 +122,15 @@ describe("FunctionReference", () => {
     expectTypeOf<Ref.Returns<Ref_>>().toEqualTypeOf<void>();
   });
 
+  test("AnyConfect", () => {
+    expectTypeOf<Ref.Args<Ref.AnyConfect>>().toBeAny();
+    expectTypeOf<Ref.Returns<Ref.AnyConfect>>().toBeAny();
+    expectTypeOf<Ref.Error<Ref.AnyConfect>>().toBeAny();
+    expectTypeOf<Ref.ArgsSchema<Ref.AnyConfect>>().toMatchTypeOf<
+      Schema.Codec<any, any>
+    >();
+  });
+
   test("AnyQuery", () => {
     expectTypeOf<Ref.FunctionReference<Ref.AnyQuery>>().toEqualTypeOf<
       FunctionReference<"query", FunctionVisibility>

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -18,6 +18,7 @@ import * as MiddlewareSpec from "@confect/core/MiddlewareSpec";
 import * as PaginationOptions from "@confect/core/PaginationOptions";
 import * as PaginationResult from "@confect/core/PaginationResult";
 import * as Ref from "@confect/core/Ref";
+import type * as RuntimeAndFunctionType from "@confect/core/RuntimeAndFunctionType";
 
 describe("FunctionReference", () => {
   test("public query", () => {
@@ -128,6 +129,30 @@ describe("FunctionReference", () => {
     expectTypeOf<Ref.Error<Ref.AnyConfect>>().toBeAny();
     expectTypeOf<Ref.ArgsSchema<Ref.AnyConfect>>().toMatchTypeOf<
       Schema.Codec<any, any>
+    >();
+  });
+
+  test("Ref preserves its value types", () => {
+    type Ref_ = Ref.Ref<
+      RuntimeAndFunctionType.ConvexQuery,
+      "public",
+      { readonly id: string },
+      number,
+      "NotFound"
+    >;
+
+    expectTypeOf<Ref.Args<Ref_>>().toEqualTypeOf<{ readonly id: string }>();
+    expectTypeOf<Ref.Returns<Ref_>>().toEqualTypeOf<number>();
+    expectTypeOf<Ref.Error<Ref_>>().toEqualTypeOf<"NotFound">();
+
+    expectTypeOf<
+      Ref.Ref<
+        RuntimeAndFunctionType.ConvexQuery,
+        "public",
+        // @ts-expect-error — ref args must be struct-shaped
+        string,
+        number
+      >
     >();
   });
 

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -95,11 +95,17 @@ describe("FunctionReference", () => {
   test("preserves args and returns", () => {
     const _spec = FunctionSpec.publicQuery({
       name: "get",
-      args: () => Schema.Struct({ id: Schema.String }),
+      args: () => ({ id: Schema.String }),
       returns: () => Schema.Array(Schema.Finite),
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
     expectTypeOf<Ref.Args<Ref_>>().toEqualTypeOf<{ readonly id: string }>();
+    expectTypeOf<Ref.ArgsFields<Ref_>>().toEqualTypeOf<{
+      readonly id: typeof Schema.String;
+    }>();
+    expectTypeOf<Ref.ArgsSchema<Ref_>["fields"]>().toEqualTypeOf<
+      Ref.ArgsFields<Ref_>
+    >();
     expectTypeOf<Ref.Returns<Ref_>>().toEqualTypeOf<readonly number[]>();
     expectTypeOf<Ref.FunctionReference<Ref_>>().toEqualTypeOf<
       FunctionReference<"query", "public">
@@ -109,7 +115,7 @@ describe("FunctionReference", () => {
   test("empty args", () => {
     const _spec = FunctionSpec.internalMutation({
       name: "reset",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
@@ -140,7 +146,7 @@ describe("OptionalArgs", () => {
   test("optional tuple when args are empty", () => {
     const _spec = FunctionSpec.publicQuery({
       name: "list",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
@@ -150,7 +156,7 @@ describe("OptionalArgs", () => {
   test("required tuple when args have keys", () => {
     const _spec = FunctionSpec.publicQuery({
       name: "get",
-      args: () => Schema.Struct({ id: Schema.String }),
+      args: () => ({ id: Schema.String }),
       returns: () => Schema.Void,
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
@@ -165,7 +171,7 @@ describe("getFunctionReference", () => {
     "notes",
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -179,7 +185,7 @@ describe("getFunctionReference", () => {
       "notes",
       FunctionSpec.publicQuery({
         name: "get",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Void,
       }),
     );
@@ -194,7 +200,7 @@ describe("Error type extraction", () => {
   test("no error schema means Error is never", () => {
     const _spec = FunctionSpec.publicMutation({
       name: "create",
-      args: () => Schema.Struct({ name: Schema.String }),
+      args: () => ({ name: Schema.String }),
       returns: () => Schema.Void,
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
@@ -208,7 +214,7 @@ describe("Error type extraction", () => {
 
     const _spec = FunctionSpec.publicMutation({
       name: "update",
-      args: () => Schema.Struct({ id: Schema.String }),
+      args: () => ({ id: Schema.String }),
       returns: () => Schema.Void,
       error: () => NotFound,
     });
@@ -226,7 +232,7 @@ describe("Error type extraction", () => {
 
     const _spec = FunctionSpec.publicMutation({
       name: "remove",
-      args: () => Schema.Struct({ id: Schema.String }),
+      args: () => ({ id: Schema.String }),
       returns: () => Schema.Void,
       error: () => Schema.Union([NotFound, Forbidden]),
     });
@@ -260,7 +266,7 @@ describe("decodeError", () => {
 
     const spec = FunctionSpec.publicMutation({
       name: "update",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
       error: () => NotFound,
     });
@@ -278,7 +284,7 @@ describe("decodeError", () => {
   test("returns None when the ref has no error schema", async () => {
     const spec = FunctionSpec.publicMutation({
       name: "create",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     });
     const ref = Ref.make("test/mod", spec);
@@ -299,7 +305,7 @@ describe("decodeErrorOption", () => {
     "test/mod",
     FunctionSpec.publicQuery({
       name: "getOrFail",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
       error: () => NotFound,
     }),
@@ -333,7 +339,7 @@ describe("decodeErrorOption", () => {
       "test/mod",
       FunctionSpec.publicQuery({
         name: "get",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Void,
       }),
     );
@@ -353,7 +359,7 @@ describe("decodeErrorOrElse", () => {
     "test/mod",
     FunctionSpec.publicMutation({
       name: "update",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
       error: () => NotFound,
     }),
@@ -363,7 +369,7 @@ describe("decodeErrorOrElse", () => {
     "test/mod",
     FunctionSpec.publicMutation({
       name: "create",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -408,7 +414,7 @@ describe("hasErrorSchema", () => {
       "test/mod",
       FunctionSpec.publicMutation({
         name: "update",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Void,
         error: () => NotFound,
       }),
@@ -422,7 +428,7 @@ describe("hasErrorSchema", () => {
       "test/mod",
       FunctionSpec.publicMutation({
         name: "create",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.Void,
       }),
     );
@@ -448,7 +454,7 @@ describe("paginated queries", () => {
     "notes",
     FunctionSpec.publicPaginatedQuery({
       name: "listPaginated",
-      args: () => Schema.Struct({ count: Schema.FiniteFromString }),
+      args: () => ({ count: Schema.FiniteFromString }),
       item: () => paginatedDoc,
     }),
   );
@@ -471,11 +477,10 @@ describe("paginated queries", () => {
     "notes",
     FunctionSpec.publicQuery({
       name: "listPaginated",
-      args: () =>
-        Schema.Struct({
-          count: Schema.FiniteFromString,
-          paginationOpts: PaginationOptions.PaginationOptions,
-        }),
+      args: () => ({
+        count: Schema.FiniteFromString,
+        paginationOpts: PaginationOptions.PaginationOptions,
+      }),
       returns: () => PaginationResult.PaginationResult(paginatedDoc),
     }),
   );
@@ -597,7 +602,7 @@ describe("error schema laziness at decode time", () => {
       "test/mod",
       FunctionSpec.publicQuery({
         name: "get",
-        args: () => Schema.Struct({}),
+        args: () => ({}),
         returns: () => Schema.String,
         error: () => {
           MutableRef.set(specErrorBuilt, true);

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -115,7 +115,6 @@ describe("FunctionReference", () => {
   test("empty args", () => {
     const _spec = FunctionSpec.internalMutation({
       name: "reset",
-      args: () => ({}),
       returns: () => Schema.Void,
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
@@ -146,7 +145,6 @@ describe("OptionalArgs", () => {
   test("optional tuple when args are empty", () => {
     const _spec = FunctionSpec.publicQuery({
       name: "list",
-      args: () => ({}),
       returns: () => Schema.Void,
     });
     type Ref_ = Ref.FromFunctionSpec<typeof _spec>;
@@ -171,7 +169,6 @@ describe("getFunctionReference", () => {
     "notes",
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -185,7 +182,6 @@ describe("getFunctionReference", () => {
       "notes",
       FunctionSpec.publicQuery({
         name: "get",
-        args: () => ({}),
         returns: () => Schema.Void,
       }),
     );
@@ -266,7 +262,6 @@ describe("decodeError", () => {
 
     const spec = FunctionSpec.publicMutation({
       name: "update",
-      args: () => ({}),
       returns: () => Schema.Void,
       error: () => NotFound,
     });
@@ -284,7 +279,6 @@ describe("decodeError", () => {
   test("returns None when the ref has no error schema", async () => {
     const spec = FunctionSpec.publicMutation({
       name: "create",
-      args: () => ({}),
       returns: () => Schema.Void,
     });
     const ref = Ref.make("test/mod", spec);
@@ -305,7 +299,6 @@ describe("decodeErrorOption", () => {
     "test/mod",
     FunctionSpec.publicQuery({
       name: "getOrFail",
-      args: () => ({}),
       returns: () => Schema.Void,
       error: () => NotFound,
     }),
@@ -339,7 +332,6 @@ describe("decodeErrorOption", () => {
       "test/mod",
       FunctionSpec.publicQuery({
         name: "get",
-        args: () => ({}),
         returns: () => Schema.Void,
       }),
     );
@@ -359,7 +351,6 @@ describe("decodeErrorOrElse", () => {
     "test/mod",
     FunctionSpec.publicMutation({
       name: "update",
-      args: () => ({}),
       returns: () => Schema.Void,
       error: () => NotFound,
     }),
@@ -369,7 +360,6 @@ describe("decodeErrorOrElse", () => {
     "test/mod",
     FunctionSpec.publicMutation({
       name: "create",
-      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -414,7 +404,6 @@ describe("hasErrorSchema", () => {
       "test/mod",
       FunctionSpec.publicMutation({
         name: "update",
-        args: () => ({}),
         returns: () => Schema.Void,
         error: () => NotFound,
       }),
@@ -428,7 +417,6 @@ describe("hasErrorSchema", () => {
       "test/mod",
       FunctionSpec.publicMutation({
         name: "create",
-        args: () => ({}),
         returns: () => Schema.Void,
       }),
     );
@@ -602,7 +590,6 @@ describe("error schema laziness at decode time", () => {
       "test/mod",
       FunctionSpec.publicQuery({
         name: "get",
-        args: () => ({}),
         returns: () => Schema.String,
         error: () => {
           MutableRef.set(specErrorBuilt, true);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -347,15 +347,15 @@ void ({} as Refs.Refs<any>);
 
 bench("Refs<Spec> (unfiltered)", () => {
   return {} as Refs.Refs<MediumSpec>;
-}).types([2015, "instantiations"]);
+}).types([2053, "instantiations"]);
 
 bench("Refs<Spec, AnyPublic> (public-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>;
-}).types([1942, "instantiations"]);
+}).types([2084, "instantiations"]);
 
 bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyInternal>;
-}).types([1966, "instantiations"]);
+}).types([2082, "instantiations"]);
 
 // Laziness: accessing one leaf should be cheaper than accessing all leaves.
 // If the type were eagerly evaluated, both benchmarks would have the same
@@ -363,7 +363,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2190, "instantiations"]);
+}).types([2428, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -374,50 +374,50 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([2561, "instantiations"]);
+}).types([3286, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
 bench("small: Refs (unfiltered)", () => {
   return {} as Refs.Refs<SmallSpec>;
-}).types([624, "instantiations"]);
+}).types([822, "instantiations"]);
 
 bench("small: Refs (public-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
-}).types([624, "instantiations"]);
+}).types([838, "instantiations"]);
 
 bench("small: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
-}).types([603, "instantiations"]);
+}).types([856, "instantiations"]);
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([836, "instantiations"]);
+}).types([1150, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([910, "instantiations"]);
+}).types([1520, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
 bench("large: Refs (unfiltered)", () => {
   return {} as Refs.Refs<LargeSpec>;
-}).types([3896, "instantiations"]);
+}).types([3689, "instantiations"]);
 
 bench("large: Refs (public-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>;
-}).types([3771, "instantiations"]);
+}).types([3714, "instantiations"]);
 
 bench("large: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyInternal>;
-}).types([3784, "instantiations"]);
+}).types([3706, "instantiations"]);
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4045, "instantiations"]);
+}).types([4084, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -439,4 +439,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([5257, "instantiations"]);
+}).types([6282, "instantiations"]);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -6,7 +6,7 @@ import type * as Ref from "@confect/core/Ref";
 import type * as Refs from "@confect/core/Refs";
 import * as Spec from "@confect/core/Spec";
 
-const Args = {};
+const Args = { id: Schema.String };
 const Returns = Schema.String;
 
 // --- Small spec: 1 group, 2 functions ---
@@ -15,14 +15,12 @@ const SmallSpec = Spec.make().add(
     .addFunction(
       FunctionSpec.publicQuery({
         name: "login",
-        args: () => Args,
         returns: () => Returns,
       }),
     )
     .addFunction(
       FunctionSpec.publicMutation({
         name: "logout",
-        args: () => Args,
         returns: () => Returns,
       }),
     ),
@@ -363,7 +361,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2375, "instantiations"]);
+}).types([2387, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -374,32 +372,32 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([3228, "instantiations"]);
+}).types([3240, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
 bench("small: Refs (unfiltered)", () => {
   return {} as Refs.Refs<SmallSpec>;
-}).types([822, "instantiations"]);
+}).types([675, "instantiations"]);
 
 bench("small: Refs (public-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
-}).types([838, "instantiations"]);
+}).types([691, "instantiations"]);
 
 bench("small: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
-}).types([856, "instantiations"]);
+}).types([709, "instantiations"]);
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([1097, "instantiations"]);
+}).types([877, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([1463, "instantiations"]);
+}).types([1204, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
@@ -417,7 +415,7 @@ bench("large: Refs (internal-filtered)", () => {
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4031, "instantiations"]);
+}).types([4043, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -439,4 +437,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([6219, "instantiations"]);
+}).types([6231, "instantiations"]);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -363,7 +363,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2428, "instantiations"]);
+}).types([2375, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -374,7 +374,7 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([3286, "instantiations"]);
+}).types([3228, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
@@ -392,14 +392,14 @@ bench("small: Refs (internal-filtered)", () => {
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([1150, "instantiations"]);
+}).types([1097, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([1520, "instantiations"]);
+}).types([1463, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
@@ -417,7 +417,7 @@ bench("large: Refs (internal-filtered)", () => {
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4084, "instantiations"]);
+}).types([4031, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -439,4 +439,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([6282, "instantiations"]);
+}).types([6219, "instantiations"]);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -349,11 +349,11 @@ bench("Refs<Spec> (unfiltered)", () => {
 
 bench("Refs<Spec, AnyPublic> (public-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>;
-}).types([2356, "instantiations"]);
+}).types([2351, "instantiations"]);
 
 bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyInternal>;
-}).types([2340, "instantiations"]);
+}).types([2335, "instantiations"]);
 
 // Laziness: accessing one leaf should be cheaper than accessing all leaves.
 // If the type were eagerly evaluated, both benchmarks would have the same
@@ -361,7 +361,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2659, "instantiations"]);
+}).types([2654, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -372,7 +372,7 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([3284, "instantiations"]);
+}).types([3279, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
@@ -382,22 +382,22 @@ bench("small: Refs (unfiltered)", () => {
 
 bench("small: Refs (public-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
-}).types([914, "instantiations"]);
+}).types([909, "instantiations"]);
 
 bench("small: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
-}).types([955, "instantiations"]);
+}).types([950, "instantiations"]);
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([1100, "instantiations"]);
+}).types([1095, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([1199, "instantiations"]);
+}).types([1194, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
@@ -407,15 +407,15 @@ bench("large: Refs (unfiltered)", () => {
 
 bench("large: Refs (public-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>;
-}).types([3996, "instantiations"]);
+}).types([3991, "instantiations"]);
 
 bench("large: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyInternal>;
-}).types([3974, "instantiations"]);
+}).types([3969, "instantiations"]);
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4325, "instantiations"]);
+}).types([4320, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -437,4 +437,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([6285, "instantiations"]);
+}).types([6280, "instantiations"]);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -345,15 +345,15 @@ void ({} as Refs.Refs<any>);
 
 bench("Refs<Spec> (unfiltered)", () => {
   return {} as Refs.Refs<MediumSpec>;
-}).types([2053, "instantiations"]);
+}).types([2266, "instantiations"]);
 
 bench("Refs<Spec, AnyPublic> (public-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>;
-}).types([2084, "instantiations"]);
+}).types([2335, "instantiations"]);
 
 bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyInternal>;
-}).types([2082, "instantiations"]);
+}).types([2323, "instantiations"]);
 
 // Laziness: accessing one leaf should be cheaper than accessing all leaves.
 // If the type were eagerly evaluated, both benchmarks would have the same
@@ -361,7 +361,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2387, "instantiations"]);
+}).types([2638, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -372,50 +372,50 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([3240, "instantiations"]);
+}).types([3263, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
 bench("small: Refs (unfiltered)", () => {
   return {} as Refs.Refs<SmallSpec>;
-}).types([675, "instantiations"]);
+}).types([880, "instantiations"]);
 
 bench("small: Refs (public-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
-}).types([691, "instantiations"]);
+}).types([901, "instantiations"]);
 
 bench("small: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
-}).types([709, "instantiations"]);
+}).types([942, "instantiations"]);
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([877, "instantiations"]);
+}).types([1087, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([1204, "instantiations"]);
+}).types([1186, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
 bench("large: Refs (unfiltered)", () => {
   return {} as Refs.Refs<LargeSpec>;
-}).types([3689, "instantiations"]);
+}).types([3904, "instantiations"]);
 
 bench("large: Refs (public-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>;
-}).types([3714, "instantiations"]);
+}).types([3972, "instantiations"]);
 
 bench("large: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyInternal>;
-}).types([3706, "instantiations"]);
+}).types([3954, "instantiations"]);
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4043, "instantiations"]);
+}).types([4301, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -437,4 +437,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([6231, "instantiations"]);
+}).types([6261, "instantiations"]);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -345,15 +345,15 @@ void ({} as Refs.Refs<any>);
 
 bench("Refs<Spec> (unfiltered)", () => {
   return {} as Refs.Refs<MediumSpec>;
-}).types([2266, "instantiations"]);
+}).types([2274, "instantiations"]);
 
 bench("Refs<Spec, AnyPublic> (public-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>;
-}).types([2335, "instantiations"]);
+}).types([2356, "instantiations"]);
 
 bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyInternal>;
-}).types([2323, "instantiations"]);
+}).types([2340, "instantiations"]);
 
 // Laziness: accessing one leaf should be cheaper than accessing all leaves.
 // If the type were eagerly evaluated, both benchmarks would have the same
@@ -361,7 +361,7 @@ bench("Refs<Spec, AnyInternal> (internal-filtered)", () => {
 
 bench("resolve one leaf", () => {
   return {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["users"]["list"];
-}).types([2638, "instantiations"]);
+}).types([2659, "instantiations"]);
 
 bench("resolve all leaves", () => {
   return [
@@ -372,50 +372,50 @@ bench("resolve all leaves", () => {
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["list"],
     {} as Refs.Refs<MediumSpec, Ref.AnyPublic>["comments"]["create"],
   ];
-}).types([3263, "instantiations"]);
+}).types([3284, "instantiations"]);
 
 // --- Small spec (1 group, 2 functions) ---
 
 bench("small: Refs (unfiltered)", () => {
   return {} as Refs.Refs<SmallSpec>;
-}).types([880, "instantiations"]);
+}).types([884, "instantiations"]);
 
 bench("small: Refs (public-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>;
-}).types([901, "instantiations"]);
+}).types([914, "instantiations"]);
 
 bench("small: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyInternal>;
-}).types([942, "instantiations"]);
+}).types([955, "instantiations"]);
 
 bench("small: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"];
-}).types([1087, "instantiations"]);
+}).types([1100, "instantiations"]);
 
 bench("small: Refs (resolve all leaves)", () => {
   return [
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["login"],
     {} as Refs.Refs<SmallSpec, Ref.AnyPublic>["auth"]["logout"],
   ];
-}).types([1186, "instantiations"]);
+}).types([1199, "instantiations"]);
 
 // --- Large spec (8 groups, 28 functions) ---
 
 bench("large: Refs (unfiltered)", () => {
   return {} as Refs.Refs<LargeSpec>;
-}).types([3904, "instantiations"]);
+}).types([3913, "instantiations"]);
 
 bench("large: Refs (public-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>;
-}).types([3972, "instantiations"]);
+}).types([3996, "instantiations"]);
 
 bench("large: Refs (internal-filtered)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyInternal>;
-}).types([3954, "instantiations"]);
+}).types([3974, "instantiations"]);
 
 bench("large: Refs (resolve one leaf)", () => {
   return {} as Refs.Refs<LargeSpec, Ref.AnyPublic>["users"]["list"];
-}).types([4301, "instantiations"]);
+}).types([4325, "instantiations"]);
 
 bench("large: Refs (resolve all leaves)", () => {
   type PublicRefs = Refs.Refs<LargeSpec, Ref.AnyPublic>;
@@ -437,4 +437,4 @@ bench("large: Refs (resolve all leaves)", () => {
     {} as PublicRefs["settings"]["get"],
     {} as PublicRefs["settings"]["update"],
   ];
-}).types([6261, "instantiations"]);
+}).types([6285, "instantiations"]);

--- a/packages/core/test/Refs.bench.ts
+++ b/packages/core/test/Refs.bench.ts
@@ -6,7 +6,7 @@ import type * as Ref from "@confect/core/Ref";
 import type * as Refs from "@confect/core/Refs";
 import * as Spec from "@confect/core/Spec";
 
-const Args = Schema.Struct({});
+const Args = {};
 const Returns = Schema.String;
 
 // --- Small spec: 1 group, 2 functions ---

--- a/packages/core/test/Refs.test.ts
+++ b/packages/core/test/Refs.test.ts
@@ -11,11 +11,9 @@ import * as Spec from "@confect/core/Spec";
 
 describe("make", () => {
   it("turns a spec into refs", () => {
-    const FnArgs = {};
     const FnReturns = Schema.Array(Schema.String);
     const list = FunctionSpec.publicQuery({
       name: "list",
-      args: () => FnArgs,
       returns: () => FnReturns,
     });
 
@@ -39,7 +37,6 @@ describe("make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => ({}),
             returns: () => Schema.Array(Schema.String),
           }),
         ),
@@ -50,7 +47,6 @@ describe("make", () => {
   });
 
   it("filters internal refs to only internal functions", () => {
-    const FnArgs = {};
     const FnReturns = Schema.String;
 
     const spec = Spec.make().add(
@@ -58,14 +54,12 @@ describe("make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "publicList",
-            args: () => FnArgs,
             returns: () => FnReturns,
           }),
         )
         .addFunction(
           FunctionSpec.internalQuery({
             name: "internalList",
-            args: () => FnArgs,
             returns: () => FnReturns,
           }),
         ),
@@ -76,7 +70,7 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "internal",
-        typeof FnArgs,
+        {},
         typeof FnReturns
       >
     >();
@@ -86,7 +80,6 @@ describe("make", () => {
   });
 
   it("filters out groups with no matching functions", () => {
-    const FnArgs = {};
     const FnReturns = Schema.String;
 
     const spec = Spec.make()
@@ -94,7 +87,6 @@ describe("make", () => {
         GroupSpec.makeAt("publicOnly").addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => FnArgs,
             returns: () => FnReturns,
           }),
         ),
@@ -103,7 +95,6 @@ describe("make", () => {
         GroupSpec.makeAt("internalOnly").addFunction(
           FunctionSpec.internalQuery({
             name: "list",
-            args: () => FnArgs,
             returns: () => FnReturns,
           }),
         ),
@@ -115,7 +106,7 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "internal",
-        typeof FnArgs,
+        {},
         typeof FnReturns
       >
     >();
@@ -125,7 +116,6 @@ describe("make", () => {
   });
 
   it("filters public refs to only public functions", () => {
-    const FnArgs = {};
     const FnReturns = Schema.String;
 
     const spec = Spec.make().add(
@@ -133,14 +123,12 @@ describe("make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "publicList",
-            args: () => FnArgs,
             returns: () => FnReturns,
           }),
         )
         .addFunction(
           FunctionSpec.internalQuery({
             name: "internalList",
-            args: () => FnArgs,
             returns: () => FnReturns,
           }),
         ),
@@ -151,7 +139,7 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "public",
-        typeof FnArgs,
+        {},
         typeof FnReturns
       >
     >();
@@ -313,7 +301,6 @@ describe("middleware error unions", () => {
         .addFunction(
           FunctionSpec.publicMutation({
             name: "update",
-            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )

--- a/packages/core/test/Refs.test.ts
+++ b/packages/core/test/Refs.test.ts
@@ -11,29 +11,19 @@ import * as Spec from "@confect/core/Spec";
 
 describe("make", () => {
   it("turns a spec into refs", () => {
-    const FnArgs = Schema.Struct({});
+    const FnArgs = {};
     const FnReturns = Schema.Array(Schema.String);
+    const list = FunctionSpec.publicQuery({
+      name: "list",
+      args: () => FnArgs,
+      returns: () => FnReturns,
+    });
 
-    const spec = Spec.make().add(
-      GroupSpec.makeAt("notes").addFunction(
-        FunctionSpec.publicQuery({
-          name: "list",
-          args: () => FnArgs,
-          returns: () => FnReturns,
-        }),
-      ),
-    );
+    const spec = Spec.make().add(GroupSpec.makeAt("notes").addFunction(list));
     const refs = Refs.make(spec);
 
     const actualRef = refs.public.notes.list;
-    const expectedRef = Ref.make(
-      "notes",
-      FunctionSpec.publicQuery({
-        name: "list",
-        args: () => FnArgs,
-        returns: () => FnReturns,
-      }),
-    );
+    const expectedRef = Ref.make("notes", list);
 
     expect(Ref.getConvexFunctionName(actualRef)).toStrictEqual(
       Ref.getConvexFunctionName(expectedRef),
@@ -49,7 +39,7 @@ describe("make", () => {
         .addFunction(
           FunctionSpec.publicQuery({
             name: "list",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Array(Schema.String),
           }),
         ),
@@ -60,7 +50,7 @@ describe("make", () => {
   });
 
   it("filters internal refs to only internal functions", () => {
-    const FnArgs = Schema.Struct({});
+    const FnArgs = {};
     const FnReturns = Schema.String;
 
     const spec = Spec.make().add(
@@ -86,8 +76,8 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "internal",
-        typeof FnArgs.Type,
-        typeof FnReturns.Type
+        typeof FnArgs,
+        typeof FnReturns
       >
     >();
 
@@ -96,7 +86,7 @@ describe("make", () => {
   });
 
   it("filters out groups with no matching functions", () => {
-    const FnArgs = Schema.Struct({});
+    const FnArgs = {};
     const FnReturns = Schema.String;
 
     const spec = Spec.make()
@@ -125,8 +115,8 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "internal",
-        typeof FnArgs.Type,
-        typeof FnReturns.Type
+        typeof FnArgs,
+        typeof FnReturns
       >
     >();
 
@@ -135,7 +125,7 @@ describe("make", () => {
   });
 
   it("filters public refs to only public functions", () => {
-    const FnArgs = Schema.Struct({});
+    const FnArgs = {};
     const FnReturns = Schema.String;
 
     const spec = Spec.make().add(
@@ -161,8 +151,8 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "public",
-        typeof FnArgs.Type,
-        typeof FnReturns.Type
+        typeof FnArgs,
+        typeof FnReturns
       >
     >();
 
@@ -258,8 +248,8 @@ describe("make", () => {
     type ConvexQueryArgs = { cursor: string };
     type ConvexQueryReturns = string[];
 
-    const ConfectQueryArgs = Schema.Struct({ limit: Schema.Finite });
-    type ConfectQueryArgs = typeof ConfectQueryArgs.Type;
+    const ConfectQueryArgs = { limit: Schema.Finite };
+    type ConfectQueryArgs = Schema.Struct.Type<typeof ConfectQueryArgs>;
 
     const ConfectQueryReturns = Schema.Array(Schema.String);
     type ConfectQueryReturns = typeof ConfectQueryReturns.Type;
@@ -289,8 +279,8 @@ describe("make", () => {
       Ref.ConfectRef<
         RuntimeAndFunctionType.ConvexQuery,
         "public",
-        ConfectQueryArgs,
-        ConfectQueryReturns
+        typeof ConfectQueryArgs,
+        typeof ConfectQueryReturns
       >
     >();
 
@@ -323,7 +313,7 @@ describe("middleware error unions", () => {
         .addFunction(
           FunctionSpec.publicMutation({
             name: "update",
-            args: () => Schema.Struct({}),
+            args: () => ({}),
             returns: () => Schema.Null,
           }),
         )

--- a/packages/core/test/Spec.test.ts
+++ b/packages/core/test/Spec.test.ts
@@ -15,13 +15,11 @@ describe("isSpec", () => {
 });
 
 it("infers refs from addAt-assembled spec", () => {
-  const FnArgs = {};
   const FnReturns = Schema.Array(Schema.String);
 
   const notes = GroupSpec.make().addFunction(
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => FnArgs,
       returns: () => FnReturns,
     }),
   );
@@ -29,7 +27,6 @@ it("infers refs from addAt-assembled spec", () => {
   const databaseReader = GroupSpec.make().addFunction(
     FunctionSpec.publicQuery({
       name: "listNotes",
-      args: () => FnArgs,
       returns: () => FnReturns,
     }),
   );
@@ -48,13 +45,11 @@ it("infers refs from addAt-assembled spec", () => {
 });
 
 it("places a Node group alongside Convex groups, with no `node` namespace", () => {
-  const FnArgs = {};
   const FnReturns = Schema.Null;
 
   const notes = GroupSpec.make().addFunction(
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => FnArgs,
       returns: () => Schema.Array(Schema.String),
     }),
   );
@@ -64,7 +59,6 @@ it("places a Node group alongside Convex groups, with no `node` namespace", () =
   const email = GroupSpec.makeNode().addFunction(
     FunctionSpec.publicNodeAction({
       name: "send",
-      args: () => FnArgs,
       returns: () => FnReturns,
     }),
   );

--- a/packages/core/test/Spec.test.ts
+++ b/packages/core/test/Spec.test.ts
@@ -15,7 +15,7 @@ describe("isSpec", () => {
 });
 
 it("infers refs from addAt-assembled spec", () => {
-  const FnArgs = Schema.Struct({});
+  const FnArgs = {};
   const FnReturns = Schema.Array(Schema.String);
 
   const notes = GroupSpec.make().addFunction(
@@ -48,7 +48,7 @@ it("infers refs from addAt-assembled spec", () => {
 });
 
 it("places a Node group alongside Convex groups, with no `node` namespace", () => {
-  const FnArgs = Schema.Struct({});
+  const FnArgs = {};
   const FnReturns = Schema.Null;
 
   const notes = GroupSpec.make().addFunction(

--- a/packages/js/test/HttpClient.test.ts
+++ b/packages/js/test/HttpClient.test.ts
@@ -32,7 +32,6 @@ const noArgsQueryRef = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -50,7 +49,6 @@ const noArgsMutationRef = Ref.make(
   "tasks",
   FunctionSpec.publicMutation({
     name: "cleanup",
-    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -68,7 +66,6 @@ const noArgsActionRef = Ref.make(
   "random",
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );

--- a/packages/js/test/HttpClient.test.ts
+++ b/packages/js/test/HttpClient.test.ts
@@ -32,7 +32,7 @@ const noArgsQueryRef = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -41,7 +41,7 @@ const argsQueryRef = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "get",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -50,7 +50,7 @@ const noArgsMutationRef = Ref.make(
   "tasks",
   FunctionSpec.publicMutation({
     name: "cleanup",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -59,7 +59,7 @@ const argsMutationRef = Ref.make(
   "notes",
   FunctionSpec.publicMutation({
     name: "insert",
-    args: () => Schema.Struct({ text: Schema.String }),
+    args: () => ({ text: Schema.String }),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -68,7 +68,7 @@ const noArgsActionRef = Ref.make(
   "random",
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -77,7 +77,7 @@ const argsActionRef = Ref.make(
   "email",
   FunctionSpec.publicAction({
     name: "send",
-    args: () => Schema.Struct({ to: Schema.String }),
+    args: () => ({ to: Schema.String }),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -154,7 +154,7 @@ const queryWithError = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "getOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Struct({ text: Schema.String }),
     error: () => NotFound,
   }),
@@ -164,7 +164,7 @@ const mutationWithError = Ref.make(
   "notes",
   FunctionSpec.publicMutation({
     name: "deleteOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NotFound,
   }),
@@ -174,7 +174,7 @@ const actionWithError = Ref.make(
   "tasks",
   FunctionSpec.publicAction({
     name: "runOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NotFound,
   }),

--- a/packages/js/test/WebSocketClient.test.ts
+++ b/packages/js/test/WebSocketClient.test.ts
@@ -51,7 +51,7 @@ const noArgsQueryRef = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -60,7 +60,7 @@ const argsQueryRef = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "get",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -69,7 +69,7 @@ const noArgsMutationRef = Ref.make(
   "tasks",
   FunctionSpec.publicMutation({
     name: "cleanup",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -78,7 +78,7 @@ const argsMutationRef = Ref.make(
   "notes",
   FunctionSpec.publicMutation({
     name: "insert",
-    args: () => Schema.Struct({ text: Schema.String }),
+    args: () => ({ text: Schema.String }),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -87,7 +87,7 @@ const noArgsActionRef = Ref.make(
   "random",
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -96,7 +96,7 @@ const argsActionRef = Ref.make(
   "email",
   FunctionSpec.publicAction({
     name: "send",
-    args: () => Schema.Struct({ to: Schema.String }),
+    args: () => ({ to: Schema.String }),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -332,7 +332,7 @@ const queryWithError = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "getOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Struct({ text: Schema.String }),
     error: () => NotFound,
   }),
@@ -342,7 +342,7 @@ const mutationWithError = Ref.make(
   "notes",
   FunctionSpec.publicMutation({
     name: "deleteOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NotFound,
   }),
@@ -352,7 +352,7 @@ const actionWithError = Ref.make(
   "tasks",
   FunctionSpec.publicAction({
     name: "runOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NotFound,
   }),

--- a/packages/js/test/WebSocketClient.test.ts
+++ b/packages/js/test/WebSocketClient.test.ts
@@ -51,7 +51,6 @@ const noArgsQueryRef = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -69,7 +68,6 @@ const noArgsMutationRef = Ref.make(
   "tasks",
   FunctionSpec.publicMutation({
     name: "cleanup",
-    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );
@@ -87,7 +85,6 @@ const noArgsActionRef = Ref.make(
   "random",
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => ({}),
     returns: () => Schema.Struct({}),
   }),
 );

--- a/packages/react/test/index.test.ts
+++ b/packages/react/test/index.test.ts
@@ -56,7 +56,6 @@ const queryNoError = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => ({}),
     returns: () => Schema.Array(Schema.Struct({ text: Schema.String })),
   }),
 );
@@ -94,7 +93,6 @@ const actionNoError = Ref.make(
   "tasks",
   FunctionSpec.publicAction({
     name: "ping",
-    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/packages/react/test/index.test.ts
+++ b/packages/react/test/index.test.ts
@@ -46,7 +46,7 @@ const queryWithError = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "getOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Struct({ text: Schema.String }),
     error: () => NotFound,
   }),
@@ -56,7 +56,7 @@ const queryNoError = Ref.make(
   "notes",
   FunctionSpec.publicQuery({
     name: "list",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Array(Schema.Struct({ text: Schema.String })),
   }),
 );
@@ -65,7 +65,7 @@ const mutationWithError = Ref.make(
   "notes",
   FunctionSpec.publicMutation({
     name: "deleteOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NotFound,
   }),
@@ -75,7 +75,7 @@ const mutationNoError = Ref.make(
   "notes",
   FunctionSpec.publicMutation({
     name: "insert",
-    args: () => Schema.Struct({ text: Schema.String }),
+    args: () => ({ text: Schema.String }),
     returns: () => Schema.String,
   }),
 );
@@ -84,7 +84,7 @@ const actionWithError = Ref.make(
   "tasks",
   FunctionSpec.publicAction({
     name: "runOrFail",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NotFound,
   }),
@@ -94,7 +94,7 @@ const actionNoError = Ref.make(
   "tasks",
   FunctionSpec.publicAction({
     name: "ping",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.String,
   }),
 );
@@ -409,7 +409,7 @@ describe("usePaginatedQuery", () => {
     "notes",
     FunctionSpec.publicPaginatedQuery({
       name: "listPaginated",
-      args: () => Schema.Struct({ count: Schema.FiniteFromString }),
+      args: () => ({ count: Schema.FiniteFromString }),
       item: () => paginatedDoc,
     }),
   );

--- a/packages/server/src/RegisteredFunction.ts
+++ b/packages/server/src/RegisteredFunction.ts
@@ -75,38 +75,37 @@ type ConfectRegisteredFunction<
 
 export type ConvexRegisteredFunction<
   FunctionSpec_ extends FunctionSpec.AnyWithProps,
-> = FunctionSpec_ extends {
-  functionProvenance: {
-    _tag: "Convex";
-    "~args": infer Args_ extends DefaultFunctionArgs;
-    "~returns": infer Returns_;
-  };
-}
-  ? RuntimeAndFunctionType.GetFunctionType<
-      FunctionSpec_["runtimeAndFunctionType"]
-    > extends "query"
-    ? RegisteredQuery<
-        FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
-        Args_,
-        Returns_
-      >
-    : RuntimeAndFunctionType.GetFunctionType<
-          FunctionSpec_["runtimeAndFunctionType"]
-        > extends "mutation"
-      ? RegisteredMutation<
+> = FunctionSpec_ extends FunctionSpec.AnyWithProps
+  ? FunctionSpec.GetFunctionProvenance<FunctionSpec_> extends FunctionProvenance.Convex<
+      infer Args_ extends DefaultFunctionArgs,
+      infer Returns_
+    >
+    ? RuntimeAndFunctionType.GetFunctionType<
+        FunctionSpec_["runtimeAndFunctionType"]
+      > extends "query"
+      ? RegisteredQuery<
           FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
           Args_,
           Returns_
         >
       : RuntimeAndFunctionType.GetFunctionType<
             FunctionSpec_["runtimeAndFunctionType"]
-          > extends "action"
-        ? RegisteredAction<
+          > extends "mutation"
+        ? RegisteredMutation<
             FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
             Args_,
             Returns_
           >
-        : never
+        : RuntimeAndFunctionType.GetFunctionType<
+              FunctionSpec_["runtimeAndFunctionType"]
+            > extends "action"
+          ? RegisteredAction<
+              FunctionSpec.GetFunctionVisibility<FunctionSpec_>,
+              Args_,
+              Returns_
+            >
+          : never
+    : never
   : never;
 
 export type RegisteredFunction<

--- a/packages/server/test/CronJob.test.ts
+++ b/packages/server/test/CronJob.test.ts
@@ -10,7 +10,7 @@ const makeMutationRef = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalMutation({
       name,
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -20,7 +20,7 @@ const makeMutationRefWithArgs = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalMutation({
       name,
-      args: () => Schema.Struct({ email: Schema.String }),
+      args: () => ({ email: Schema.String }),
       returns: () => Schema.Void,
     }),
   );

--- a/packages/server/test/CronJob.test.ts
+++ b/packages/server/test/CronJob.test.ts
@@ -10,7 +10,6 @@ const makeMutationRef = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalMutation({
       name,
-      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );

--- a/packages/server/test/CronJobs.test.ts
+++ b/packages/server/test/CronJobs.test.ts
@@ -12,7 +12,6 @@ const makeMutationRef = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalMutation({
       name,
-      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -22,7 +21,6 @@ const makeActionRef = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalAction({
       name,
-      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );

--- a/packages/server/test/CronJobs.test.ts
+++ b/packages/server/test/CronJobs.test.ts
@@ -12,7 +12,7 @@ const makeMutationRef = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalMutation({
       name,
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -22,7 +22,7 @@ const makeActionRef = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalAction({
       name,
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Void,
     }),
   );
@@ -32,7 +32,7 @@ const makeMutationRefWithArgs = (functionNamespace: string, name: string) =>
     functionNamespace,
     FunctionSpec.internalMutation({
       name,
-      args: () => Schema.Struct({ email: Schema.String }),
+      args: () => ({ email: Schema.String }),
       returns: () => Schema.Void,
     }),
   );

--- a/packages/server/test/FunctionImpl.test.ts
+++ b/packages/server/test/FunctionImpl.test.ts
@@ -11,7 +11,6 @@ import * as Schema from "effect/Schema";
 const fnSpec = <const Name extends string>(name: Name) =>
   FunctionSpec.publicQuery({
     name,
-    args: () => ({}),
     returns: () => Schema.Null,
   });
 

--- a/packages/server/test/FunctionImpl.test.ts
+++ b/packages/server/test/FunctionImpl.test.ts
@@ -11,7 +11,7 @@ import * as Schema from "effect/Schema";
 const fnSpec = <const Name extends string>(name: Name) =>
   FunctionSpec.publicQuery({
     name,
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Null,
   });
 

--- a/packages/server/test/MiddlewareImpl.test.ts
+++ b/packages/server/test/MiddlewareImpl.test.ts
@@ -22,7 +22,6 @@ import ProvideViewer, {
 
 const viewerName = FunctionSpec.publicQuery({
   name: "viewerName",
-  args: () => ({}),
   returns: () => Schema.String,
 });
 
@@ -276,7 +275,6 @@ describe("registry key namespacing", () => {
 
     const clashFunction = FunctionSpec.publicQuery({
       name: "clash",
-      args: () => ({}),
       returns: () => Schema.String,
     });
 

--- a/packages/server/test/MiddlewareImpl.test.ts
+++ b/packages/server/test/MiddlewareImpl.test.ts
@@ -22,7 +22,7 @@ import ProvideViewer, {
 
 const viewerName = FunctionSpec.publicQuery({
   name: "viewerName",
-  args: () => Schema.Struct({}),
+  args: () => ({}),
   returns: () => Schema.String,
 });
 
@@ -276,7 +276,7 @@ describe("registry key namespacing", () => {
 
     const clashFunction = FunctionSpec.publicQuery({
       name: "clash",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     });
 

--- a/packages/server/test/local-backend/fixtures/confect/groups/cacheStubbed.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/cacheStubbed.spec.ts
@@ -5,35 +5,35 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectNoTime",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithClock",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithRawDateNow",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithSpan",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithLog",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/cacheStubbed.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/cacheStubbed.spec.ts
@@ -5,35 +5,30 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectNoTime",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithClock",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithRawDateNow",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithSpan",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "confectWithLog",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -5,14 +5,12 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "manyOpsQuery",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "manyOpsMutation",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -5,14 +5,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "manyOpsQuery",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "manyOpsMutation",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/storage.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/storage.spec.ts
@@ -5,14 +5,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "generateUploadUrl",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getUrl",
-      args: () => Schema.Struct({ storageId: GenericId.GenericId("_storage") }),
+      args: () => ({ storageId: GenericId.GenericId("_storage") }),
       returns: () => Schema.String,
     }),
   );

--- a/packages/server/test/local-backend/fixtures/confect/groups/storage.spec.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/storage.spec.ts
@@ -5,7 +5,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "generateUploadUrl",
-      args: () => ({}),
       returns: () => Schema.String,
     }),
   )

--- a/packages/server/test/mock-backend/fixtures/confect/databaseReader.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/databaseReader.spec.ts
@@ -12,14 +12,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getNote",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => notes.Doc,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "listNotes",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Array(notes.Doc),
     }),
   )
@@ -32,14 +32,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicPaginatedQuery({
       name: "paginateNotesWithFilter",
-      args: () => Schema.Struct({ tag: Schema.String }),
+      args: () => ({ tag: Schema.String }),
       item: () => notes.Doc,
     }),
   )
   .addFunction(
     FunctionSpec.publicPaginatedQuery({
       name: "paginateNotesOrFail",
-      args: () => Schema.Struct({ shouldFail: Schema.Boolean }),
+      args: () => ({ shouldFail: Schema.Boolean }),
       item: () => notes.Doc,
       error: () => PaginationDenied,
     }),

--- a/packages/server/test/mock-backend/fixtures/confect/databaseReader.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/databaseReader.spec.ts
@@ -19,7 +19,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "listNotes",
-      args: () => ({}),
       returns: () => Schema.Array(notes.Doc),
     }),
   )

--- a/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.spec.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "echo",
-    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/aliasImporter.spec.ts
@@ -4,7 +4,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "echo",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.spec.ts
@@ -4,7 +4,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "now",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/cjsImporter.spec.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "now",
-    args: () => ({}),
     returns: () => Schema.String,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/middleware.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/middleware.spec.ts
@@ -10,21 +10,21 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "viewerName",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "viewerNameMutation",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "viewerNameAction",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
@@ -33,7 +33,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "firstNoteForViewer",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
       error: () => NoNotes,
     }),
@@ -41,7 +41,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "shoutName",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.String,
     }).middleware(RequireLongName),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/middleware.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/middleware.spec.ts
@@ -10,21 +10,18 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "viewerName",
-      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "viewerNameMutation",
-      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "viewerNameAction",
-      args: () => ({}),
       returns: () => Schema.String,
     }),
   )
@@ -33,7 +30,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "firstNoteForViewer",
-      args: () => ({}),
       returns: () => Schema.String,
       error: () => NoNotes,
     }),
@@ -41,7 +37,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "shoutName",
-      args: () => ({}),
       returns: () => Schema.String,
     }).middleware(RequireLongName),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/middlewareHelpers.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/middlewareHelpers.spec.ts
@@ -9,7 +9,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.internalQuery({
     name: "firstUsername",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.NullOr(Schema.String),
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/middlewareHelpers.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/middlewareHelpers.spec.ts
@@ -9,7 +9,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.internalQuery({
     name: "firstUsername",
-    args: () => ({}),
     returns: () => Schema.NullOr(Schema.String),
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/middlewareOrder.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/middlewareOrder.spec.ts
@@ -12,18 +12,17 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "record",
-      args: () =>
-        Schema.Struct({
-          blocked: Schema.Boolean,
-          blockedAtFunction: Schema.Boolean,
-        }),
+      args: () => ({
+        blocked: Schema.Boolean,
+        blockedAtFunction: Schema.Boolean,
+      }),
       returns: () => Schema.Null,
     }).middleware(RecordFunctionLevel),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "recordPlain",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Null,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/middlewareOrder.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/middlewareOrder.spec.ts
@@ -22,7 +22,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "recordPlain",
-      args: () => ({}),
       returns: () => Schema.Null,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/notes.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/notes.spec.ts
@@ -14,7 +14,6 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => ({}),
       returns: () => Schema.Array(notes.Doc),
     }),
   )
@@ -28,14 +27,12 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getFirst",
-      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.internalQuery({
       name: "internalGetFirst",
-      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/notes.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/notes.spec.ts
@@ -7,35 +7,35 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "insert",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Id("notes"),
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "list",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Array(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "delete_",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => Schema.Null,
     }),
   )
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getFirst",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   )
   .addFunction(
     FunctionSpec.internalQuery({
       name: "internalGetFirst",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.OptionFromNullOr(notes.Doc),
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random.spec.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => ({}),
     returns: () => Schema.Finite,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random.spec.ts
@@ -4,7 +4,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicAction({
     name: "getNumber",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Finite,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
@@ -4,7 +4,7 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "count",
-    args: () => Schema.Struct({}),
+    args: () => ({}),
     returns: () => Schema.Finite,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/random/stats.spec.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export default GroupSpec.make().addFunction(
   FunctionSpec.publicQuery({
     name: "count",
-    args: () => ({}),
     returns: () => Schema.Finite,
   }),
 );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/runners.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/runners.spec.ts
@@ -6,21 +6,21 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicAction({
       name: "insertNoteViaRunner",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Id("notes"),
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "getNumberViaRunner",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "countNotesViaRunner",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/runners.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/runners.spec.ts
@@ -13,14 +13,12 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicAction({
       name: "getNumberViaRunner",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "countNotesViaRunner",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -5,14 +5,12 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "manyOpsQuery",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "manyOpsMutation",
-      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.spec.ts
@@ -5,14 +5,14 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "manyOpsQuery",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   )
   .addFunction(
     FunctionSpec.publicMutation({
       name: "manyOpsMutation",
-      args: () => Schema.Struct({}),
+      args: () => ({}),
       returns: () => Schema.Finite,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/groups/typedErrors.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/typedErrors.spec.ts
@@ -33,7 +33,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "getNoteOrFail",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => notes.Doc,
       error: () => NotFound,
     }),
@@ -41,11 +41,10 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "deleteNoteOrFail",
-      args: () =>
-        Schema.Struct({
-          noteId: Id("notes"),
-          asAdmin: Schema.Boolean,
-        }),
+      args: () => ({
+        noteId: Id("notes"),
+        asAdmin: Schema.Boolean,
+      }),
       returns: () => Schema.Null,
       error: () => NoteError,
     }),
@@ -53,10 +52,9 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicAction({
       name: "failingAction",
-      args: () =>
-        Schema.Struct({
-          kind: Schema.Literals(["notFound", "forbidden"]),
-        }),
+      args: () => ({
+        kind: Schema.Literals(["notFound", "forbidden"]),
+      }),
       returns: () => Schema.Null,
       error: () => NoteError,
     }),
@@ -64,7 +62,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicMutation({
       name: "insertThenFail",
-      args: () => Schema.Struct({ text: Schema.String }),
+      args: () => ({ text: Schema.String }),
       returns: () => Schema.Null,
       error: () => NotFound,
     }),
@@ -72,35 +70,33 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicQuery({
       name: "tryGetNote",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => TryGetResult,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "tryDeleteNote",
-      args: () =>
-        Schema.Struct({
-          noteId: Id("notes"),
-          asAdmin: Schema.Boolean,
-        }),
+      args: () => ({
+        noteId: Id("notes"),
+        asAdmin: Schema.Boolean,
+      }),
       returns: () => TryDeleteResult,
     }),
   )
   .addFunction(
     FunctionSpec.publicAction({
       name: "tryFailingAction",
-      args: () =>
-        Schema.Struct({
-          kind: Schema.Literals(["notFound", "forbidden"]),
-        }),
+      args: () => ({
+        kind: Schema.Literals(["notFound", "forbidden"]),
+      }),
       returns: () => TryFailingActionResult,
     }),
   )
   .addFunction(
     FunctionSpec.internalQuery({
       name: "internalGetNoteOrFail",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => notes.Doc,
       error: () => NotFound,
     }),
@@ -108,7 +104,7 @@ export default GroupSpec.make()
   .addFunction(
     FunctionSpec.publicAction({
       name: "tryInternalGetNote",
-      args: () => Schema.Struct({ noteId: Id("notes") }),
+      args: () => ({ noteId: Id("notes") }),
       returns: () => TryGetResult,
     }),
   );

--- a/packages/server/test/mock-backend/fixtures/confect/typedErrorsNode.spec.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/typedErrorsNode.spec.ts
@@ -9,7 +9,7 @@ export class NodeNotFound extends Schema.TaggedError<NodeNotFound>()(
 export default GroupSpec.makeNode().addFunction(
   FunctionSpec.publicNodeAction({
     name: "failingNodeAction",
-    args: () => Schema.Struct({ id: Schema.String }),
+    args: () => ({ id: Schema.String }),
     returns: () => Schema.Null,
     error: () => NodeNotFound,
   }),


### PR DESCRIPTION
Stacked on #594 and intended as the second PR in the stack (before #584).

- declare Confect function args as lazy `Schema.Struct` field maps
- derive decoded/encoded args and concrete ref schemas from those fields
- keep Convex-provenance args constrained to `DefaultFunctionArgs`
- preserve schema laziness and paginated provenance composition
- migrate examples, docs, fixtures, and tests

Validation:
- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm circular`
- `pnpm --filter @confect/core test`
- full `pnpm test` passes all relevant tests; the existing macOS `/var` vs `/private/var` assertion in `packages/cli/test/Bundler.test.ts` remains environment-dependent