### PR TITLE
Replace deprecated toMatchTypeOf test matchers

### DIFF
--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -45,15 +45,15 @@ describe("make", () => {
     expectTypeOf<FunctionSpec.Args<FunctionSpec.AnyConfect>>().toBeAny();
     expectTypeOf<FunctionSpec.Returns<FunctionSpec.AnyConfect>>().toBeAny();
     expectTypeOf<FunctionSpec.Error<FunctionSpec.AnyConfect>>().toBeAny();
-    expectTypeOf<
-      FunctionSpec.ArgsSchema<FunctionSpec.AnyConfect>
-    >().toExtend<Schema.Codec<any, any>>();
+    expectTypeOf<FunctionSpec.ArgsSchema<FunctionSpec.AnyConfect>>().toExtend<
+      Schema.Codec<any, any>
+    >();
     expectTypeOf<
       FunctionSpec.ReturnsSchema<FunctionSpec.AnyConfect>
     >().toExtend<Schema.Codec<any, any>>();
-    expectTypeOf<
-      FunctionSpec.ErrorSchema<FunctionSpec.AnyConfect>
-    >().toExtend<Schema.Codec<any, any>>();
+    expectTypeOf<FunctionSpec.ErrorSchema<FunctionSpec.AnyConfect>>().toExtend<
+      Schema.Codec<any, any>
+    >();
   });
 
   it("extracts no error schema when none is declared", () => {

--- a/packages/core/test/FunctionSpec.test.ts
+++ b/packages/core/test/FunctionSpec.test.ts
@@ -47,13 +47,13 @@ describe("make", () => {
     expectTypeOf<FunctionSpec.Error<FunctionSpec.AnyConfect>>().toBeAny();
     expectTypeOf<
       FunctionSpec.ArgsSchema<FunctionSpec.AnyConfect>
-    >().toMatchTypeOf<Schema.Codec<any, any>>();
+    >().toExtend<Schema.Codec<any, any>>();
     expectTypeOf<
       FunctionSpec.ReturnsSchema<FunctionSpec.AnyConfect>
-    >().toMatchTypeOf<Schema.Codec<any, any>>();
+    >().toExtend<Schema.Codec<any, any>>();
     expectTypeOf<
       FunctionSpec.ErrorSchema<FunctionSpec.AnyConfect>
-    >().toMatchTypeOf<Schema.Codec<any, any>>();
+    >().toExtend<Schema.Codec<any, any>>();
   });
 
   it("extracts no error schema when none is declared", () => {

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -127,7 +127,7 @@ describe("FunctionReference", () => {
     expectTypeOf<Ref.Args<Ref.AnyConfect>>().toBeAny();
     expectTypeOf<Ref.Returns<Ref.AnyConfect>>().toBeAny();
     expectTypeOf<Ref.Error<Ref.AnyConfect>>().toBeAny();
-    expectTypeOf<Ref.ArgsSchema<Ref.AnyConfect>>().toMatchTypeOf<
+    expectTypeOf<Ref.ArgsSchema<Ref.AnyConfect>>().toExtend<
       Schema.Codec<any, any>
     >();
   });

--- a/packages/core/test/Spec.test.ts
+++ b/packages/core/test/Spec.test.ts
@@ -75,5 +75,5 @@ it("places a Node group alongside Convex groups, with no `node` namespace", () =
 
   type PublicRefs = Refs.Refs<typeof spec, RefMod.AnyPublic>;
   expectTypeOf<keyof PublicRefs>().toEqualTypeOf<"notes" | "email">();
-  expectTypeOf<PublicRefs["email"]["send"]>().toMatchTypeOf<RefMod.AnyAction>();
+  expectTypeOf<PublicRefs["email"]["send"]>().toExtend<RefMod.AnyAction>();
 });


### PR DESCRIPTION
## Summary

- replace deprecated `toMatchTypeOf` assertions with `toExtend`
- preserve the existing type compatibility checks

## Testing

- `pnpm --filter @confect/core test`