### PR TITLE
Narrow invalid cursor detection

### DIFF
--- a/packages/core/src/PaginationError.ts
+++ b/packages/core/src/PaginationError.ts
@@ -33,41 +33,39 @@ const isInvalidCursorData = (value: unknown): value is InvalidCursorData =>
   "paginationError" in value &&
   value.paginationError === "InvalidCursor";
 
-/**
- * Recognizes the structured Convex system error and the message-only fallback
- * used by Convex's own pagination clients.
- */
-export const fromUnknown = (error: unknown): Option.Option<InvalidCursor> =>
+const fromErrorMessage = (
+  error: globalThis.Error,
+): Option.Option<InvalidCursor> =>
+  error.message.includes("InvalidCursor")
+    ? Option.some(new InvalidCursor({ cause: error }))
+    : Option.none();
+
+/** Recognizes an invalid-cursor error emitted by a Convex query. */
+export const fromConvexQueryError = (
+  error: unknown,
+): Option.Option<InvalidCursor> =>
   Match.value(error).pipe(
-    Match.when(Match.instanceOf(InvalidCursor), (invalidCursor) =>
-      Option.some(invalidCursor),
-    ),
     Match.when(isConvexError, (convexError) =>
       Match.value(isInvalidCursorData(convexError.data)).pipe(
         Match.when(true, () =>
           Option.some(new InvalidCursor({ cause: error })),
         ),
-        Match.when(false, () =>
-          Match.value(convexError.message.includes("InvalidCursor")).pipe(
-            Match.when(true, () =>
-              Option.some(new InvalidCursor({ cause: error })),
-            ),
-            Match.when(false, () => Option.none<InvalidCursor>()),
-            Match.exhaustive,
-          ),
-        ),
+        Match.when(false, () => fromErrorMessage(convexError)),
         Match.exhaustive,
       ),
     ),
-    Match.when(isInvalidCursorData, () =>
-      Option.some(new InvalidCursor({ cause: error })),
-    ),
-    Match.when(Match.instanceOf(globalThis.Error), (cause) =>
-      Match.value(cause.message.includes("InvalidCursor")).pipe(
-        Match.when(true, () => Option.some(new InvalidCursor({ cause }))),
-        Match.when(false, () => Option.none<InvalidCursor>()),
-        Match.exhaustive,
-      ),
+    Match.when(Match.instanceOf(globalThis.Error), fromErrorMessage),
+    Match.when(Match.any, () => Option.none<InvalidCursor>()),
+    Match.exhaustive,
+  );
+
+/** Recognizes the error data attached to Convex's invalid-cursor error. */
+export const fromConvexErrorData = (
+  errorData: unknown,
+): Option.Option<InvalidCursor> =>
+  Match.value(errorData).pipe(
+    Match.when(isInvalidCursorData, (cause) =>
+      Option.some(new InvalidCursor({ cause })),
     ),
     Match.when(Match.any, () => Option.none<InvalidCursor>()),
     Match.exhaustive,

--- a/packages/core/test/PaginationError.test.ts
+++ b/packages/core/test/PaginationError.test.ts
@@ -31,18 +31,14 @@ describe("PaginationError", () => {
       isConvexSystemError: true,
       paginationError: "InvalidCursor",
     } as const;
-    const error = Option.getOrThrow(
-      PaginationError.fromConvexErrorData(cause),
-    );
+    const error = Option.getOrThrow(PaginationError.fromConvexErrorData(cause));
 
     expect(error.cause).toBe(cause);
   });
 
   it("rejects unrelated errors", () => {
     expect(
-      Option.isNone(
-        PaginationError.fromConvexQueryError(new Error("offline")),
-      ),
+      Option.isNone(PaginationError.fromConvexQueryError(new Error("offline"))),
     ).toBe(true);
     expect(
       Option.isNone(

--- a/packages/core/test/PaginationError.test.ts
+++ b/packages/core/test/PaginationError.test.ts
@@ -9,7 +9,9 @@ describe("PaginationError", () => {
       isConvexSystemError: true,
       paginationError: "InvalidCursor",
     });
-    const error = Option.getOrThrow(PaginationError.fromUnknown(cause));
+    const error = Option.getOrThrow(
+      PaginationError.fromConvexQueryError(cause),
+    );
 
     expect(error).toBeInstanceOf(PaginationError.InvalidCursor);
     expect(error.cause).toBe(cause);
@@ -17,20 +19,55 @@ describe("PaginationError", () => {
 
   it("recognizes Convex's message-only fallback", () => {
     const cause = new Error("InvalidCursor: cursor has expired");
-    const error = Option.getOrThrow(PaginationError.fromUnknown(cause));
+    const error = Option.getOrThrow(
+      PaginationError.fromConvexQueryError(cause),
+    );
 
     expect(error.cause).toBe(cause);
   });
 
-  it("recognizes an already normalized error", () => {
-    const error = new PaginationError.InvalidCursor({ cause: "expired" });
+  it("recognizes Convex's structured invalid-cursor error data", () => {
+    const cause = {
+      isConvexSystemError: true,
+      paginationError: "InvalidCursor",
+    } as const;
+    const error = Option.getOrThrow(
+      PaginationError.fromConvexErrorData(cause),
+    );
 
-    expect(Option.getOrThrow(PaginationError.fromUnknown(error))).toBe(error);
+    expect(error.cause).toBe(cause);
   });
 
   it("rejects unrelated errors", () => {
     expect(
-      Option.isNone(PaginationError.fromUnknown(new Error("offline"))),
+      Option.isNone(
+        PaginationError.fromConvexQueryError(new Error("offline")),
+      ),
+    ).toBe(true);
+    expect(
+      Option.isNone(
+        PaginationError.fromConvexQueryError(
+          new ConvexError({ _tag: "NotFound" }),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      Option.isNone(PaginationError.fromConvexQueryError("InvalidCursor")),
+    ).toBe(true);
+    expect(
+      Option.isNone(
+        PaginationError.fromConvexErrorData({
+          isConvexSystemError: true,
+          paginationError: "InvalidPage",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      Option.isNone(
+        PaginationError.fromConvexErrorData(
+          new Error("InvalidCursor: not server error data"),
+        ),
+      ),
     ).toBe(true);
   });
 });

--- a/packages/foldkit/src/Subscription.ts
+++ b/packages/foldkit/src/Subscription.ts
@@ -27,12 +27,10 @@ const paginatedError = <Query extends Ref.AnyConfectPublicPaginatedQuery>(
 ): PaginatedQuery.Error<Query> =>
   Match.value(error).pipe(
     Match.when(Schema.isSchemaError, (schemaError) => schemaError),
-    Match.when(
-      Match.instanceOf(Client.WebSocketClientError),
-      (clientError) =>
-        PaginationError.fromConvexQueryError(clientError.cause).pipe(
-          Option.getOrElse(() => clientError),
-        ),
+    Match.when(Match.instanceOf(Client.WebSocketClientError), (clientError) =>
+      PaginationError.fromConvexQueryError(clientError.cause).pipe(
+        Option.getOrElse(() => clientError),
+      ),
     ),
     Match.when(Match.any, (functionError) =>
       PaginationError.fromConvexErrorData(functionError).pipe(

--- a/packages/foldkit/src/Subscription.ts
+++ b/packages/foldkit/src/Subscription.ts
@@ -24,36 +24,25 @@ export type Error<Query extends Ref.AnyConfectPublicQuery> =
 
 const paginatedError = <Query extends Ref.AnyConfectPublicPaginatedQuery>(
   error: Error<Query>,
-): PaginatedQuery.Error<Query> => {
-  const invalidCursor = PaginationError.fromUnknown(error).pipe(
-    Option.orElse(() =>
-      Match.value(error).pipe(
-        Match.withReturnType<Option.Option<PaginationError.InvalidCursor>>(),
-        Match.when(Match.instanceOf(Client.WebSocketClientError), ({ cause }) =>
-          PaginationError.fromUnknown(cause),
+): PaginatedQuery.Error<Query> =>
+  Match.value(error).pipe(
+    Match.when(Schema.isSchemaError, (schemaError) => schemaError),
+    Match.when(
+      Match.instanceOf(Client.WebSocketClientError),
+      (clientError) =>
+        PaginationError.fromConvexQueryError(clientError.cause).pipe(
+          Option.getOrElse(() => clientError),
         ),
-        Match.when(Match.any, () => Option.none()),
-        Match.exhaustive,
-      ),
     ),
-  );
-
-  return Option.match(invalidCursor, {
-    onSome: (invalidCursorError) => invalidCursorError,
-    onNone: () =>
-      Match.value(error).pipe(
-        Match.when(Schema.isSchemaError, (schemaError) => schemaError),
-        Match.when(
-          Match.instanceOf(Client.WebSocketClientError),
-          (clientError) => clientError,
-        ),
-        Match.when(Match.any, (functionError) =>
+    Match.when(Match.any, (functionError) =>
+      PaginationError.fromConvexErrorData(functionError).pipe(
+        Option.getOrElse(() =>
           PaginatedQuery.FunctionError({ error: functionError }),
         ),
-        Match.exhaustive,
-      ) as PaginatedQuery.Error<Query>,
-  });
-};
+      ),
+    ),
+    Match.exhaustive,
+  ) as PaginatedQuery.Error<Query>;
 
 /**
  * The dependency record of a `reactiveQuery` entry. `None` means the

--- a/packages/foldkit/test/Subscription.test.ts
+++ b/packages/foldkit/test/Subscription.test.ts
@@ -504,12 +504,15 @@ layer(StubLayer)("Subscription.paginatedQuery", (it) => {
     );
 
     it.effect(
-      "normalizes invalid cursors and carries codec errors directly",
+      "normalizes invalid cursors and carries infrastructure errors directly",
       () =>
         Effect.gen(function* () {
           const cause = new ConvexError({
             isConvexSystemError: true,
             paginationError: "InvalidCursor",
+          });
+          const transportError = new Client.WebSocketClientError({
+            cause: new Error("offline"),
           });
           const decoded = Schema.decodeUnknownResult(Schema.Finite)("bad");
           if (Result.isSuccess(decoded)) {
@@ -517,6 +520,7 @@ layer(StubLayer)("Subscription.paginatedQuery", (it) => {
           }
           reactiveQueryResults = Stream.make(
             Result.fail(new Client.WebSocketClientError({ cause })),
+            Result.fail(transportError),
             Result.fail(decoded.failure),
           );
           const entry = makePaginatedEntry();
@@ -532,6 +536,9 @@ layer(StubLayer)("Subscription.paginatedQuery", (it) => {
             Result.fail(new PaginationError.InvalidCursor({ cause })),
           );
           expect(messages[1]!.settlement.result).toEqual(
+            Result.fail(transportError),
+          );
+          expect(messages[2]!.settlement.result).toEqual(
             Result.fail(decoded.failure),
           );
         }),


### PR DESCRIPTION
## Summary

- detect invalid cursors only at the Convex query-error and decoded error-data boundaries
- match the structured Convex system error while retaining Convex’s query-message fallback
- leave unrelated transport and schema errors unchanged

## Testing

- pnpm --filter @confect/core typecheck
- pnpm --filter @confect/foldkit typecheck
- pnpm --filter @confect/core test -- PaginationError.test.ts
- pnpm --filter @confect/foldkit test -- Subscription.test.ts