### PR TITLE
Refresh Confect's feature overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Confect is a framework that deeply integrates Effect with Convex. It's more than
 - Define your Convex database schema using Effect schemas.
 - Write Convex function args and returns validators using Effect's schema library.
 - Use Confect functions to automatically decode and encode your data according to your Effect schema definitions for end-to-end rich types, from client to function to database (and back).
-- Use Effect's HTTP API modules to define your HTTP API(s). Includes interactive OpenAPI documentation powered by [Scalar](https://github.com/scalar/scalar).
+- Add reusable, type-safe middleware to function groups or individual functions to provide Effect services and run logic around handlers.
+- Declare typed errors on functions and middleware using Effect schemas, then handle the decoded errors at every call site.
+- Use Effect's native HTTP API modules to define your HTTP API.
 - Access Convex platform capabilities via Effect services.
 
 Want to learn more? Read the [docs](https://confect.dev)!


### PR DESCRIPTION
The README feature overview did not mention Confect's middleware or end-to-end typed error support, making both capabilities easy to miss. It also described the HTTP integration in terms that no longer matched the native Effect API support.

This presents middleware and typed errors as separate features so the latter is clearly shared by functions and middleware, and aligns the HTTP summary with the current implementation.

## Verification

- `pnpm oxfmt --write README.md`
- `git diff --check -- README.md`
