### PR TITLE
Sync `main` into the v10 prerelease line

### DIFF
--- a/.changeset/support-convex-1-45.md
+++ b/.changeset/support-convex-1-45.md
@@ -1,0 +1,7 @@
+---
+"@confect/cli": patch
+"@confect/react": patch
+"@confect/server": patch
+---
+
+Validate `@confect/cli`, `@confect/react`, and `@confect/server` against `convex@1.45.0`.

--- a/.changeset/support-convex-1-45.md
+++ b/.changeset/support-convex-1-45.md
@@ -1,7 +1,0 @@
----
-"@confect/cli": patch
-"@confect/react": patch
-"@confect/server": patch
----
-
-Validate `@confect/cli`, `@confect/react`, and `@confect/server` against `convex@1.45.0`.

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -8,7 +8,7 @@
     "@confect/server": "workspace:*",
     "@convex-dev/workpool": "0.4.9",
     "@effect/platform": "0.97.1",
-    "convex": "1.44.0",
+    "convex": "1.45.0",
     "convex-helpers": "0.1.123",
     "effect": "3.22.1",
     "react": "19.2.8",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "@effect/vitest": "0.30.0",
     "@types/node": "22.20.1",
     "@vitest/coverage-v8": "4.1.10",
-    "convex": "1.44.0",
+    "convex": "1.45.0",
     "effect": "3.22.1",
     "tsdown": "0.22.14",
     "typescript": "7.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,7 @@
     "@types/node": "22.20.1",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
-    "convex": "1.44.0",
+    "convex": "1.45.0",
     "effect": "3.22.1",
     "happy-dom": "20.11.2",
     "react": "19.2.8",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
     "@types/node": "22.20.1",
     "@vitest/coverage-v8": "4.1.10",
     "confect-bench-harness": "workspace:*",
-    "convex-test": "0.0.55",
+    "convex-test": "0.0.56",
     "dotenv": "17.4.2",
     "effect": "3.22.1",
     "tsdown": "0.22.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  convex: 1.44.0
+  convex: 1.45.0
   effect: 3.22.1
   '@effect/platform-node-shared': 0.61.1
   '@effect/typeclass': 0.41.0
@@ -116,16 +116,16 @@ importers:
         version: link:../../packages/server
       '@convex-dev/workpool':
         specifier: 0.4.9
-        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.44.0(react@19.2.8))(react@19.2.8)
+        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.45.0(react@19.2.8))(react@19.2.8)
       '@effect/platform':
         specifier: 0.97.1
         version: 0.97.1(effect@3.22.1)
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
       convex-helpers:
         specifier: 0.1.123
-        version: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
+        version: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -199,7 +199,7 @@ importers:
     devDependencies:
       '@convex-dev/workpool':
         specifier: 0.4.9
-        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.44.0(react@19.2.8))(react@19.2.8)
+        version: 0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.45.0(react@19.2.8))(react@19.2.8)
       '@effect/tsgo':
         specifier: 0.36.5
         version: 0.36.5
@@ -213,8 +213,8 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -240,8 +240,8 @@ importers:
   packages/core:
     dependencies:
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
     devDependencies:
       '@effect/vitest':
         specifier: 0.30.0
@@ -277,8 +277,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
     devDependencies:
       '@effect/vitest':
         specifier: 0.30.0
@@ -324,8 +324,8 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -363,8 +363,8 @@ importers:
         specifier: ^0.108.1
         version: 0.108.1(@effect/cluster@0.60.2(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(@effect/rpc@0.76.2(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(@effect/platform@0.97.1(effect@3.22.1))(effect@3.22.1))(effect@3.22.1)
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
     devDependencies:
       '@effect/cluster':
         specifier: 0.60.2
@@ -400,8 +400,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/bench-harness
       convex-test:
-        specifier: 0.0.55
-        version: 0.0.55(convex@1.44.0(react@19.2.8))
+        specifier: 0.0.56
+        version: 0.0.56(convex@1.45.0(react@19.2.8))
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -439,8 +439,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -458,8 +458,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
       effect:
         specifier: 3.22.1
         version: 3.22.1
@@ -483,11 +483,11 @@ importers:
         specifier: workspace:^
         version: link:../server
       convex:
-        specifier: 1.44.0
-        version: 1.44.0(react@19.2.8)
+        specifier: 1.45.0
+        version: 1.45.0(react@19.2.8)
       convex-test:
         specifier: '>=0.0.50 <0.1.0'
-        version: 0.0.50(convex@1.44.0(react@19.2.8))
+        version: 0.0.50(convex@1.45.0(react@19.2.8))
     devDependencies:
       '@types/node':
         specifier: 22.20.1
@@ -679,13 +679,13 @@ packages:
   '@convex-dev/batch-worker@0.2.0':
     resolution: {integrity: sha512-dn0L/5jqufXHzgzAhWqjGBmDGXbwRA0S6YVV5Z66y4pMXZ+YL3M4aHCk9iBInPp5zOtEPgVbfo/BYMxhLxVP+w==}
     peerDependencies:
-      convex: 1.44.0
+      convex: 1.45.0
       react: 19.2.8
 
   '@convex-dev/workpool@0.4.9':
     resolution: {integrity: sha512-2EauCO+fXqhBE0qN3aC2G/CA8Udc1nDiSha2uwdJi5SaElz6HmuM3Rv60AeQ3snMZ8PdHugKKlVeEFvAhSaokQ==}
     peerDependencies:
-      convex: 1.44.0
+      convex: 1.45.0
       convex-helpers: ^0.1.94
 
   '@effect/cli@0.77.0':
@@ -4112,7 +4112,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@standard-schema/spec': ^1.0.0
-      convex: 1.44.0
+      convex: 1.45.0
       hono: ^4.0.5
       react: 19.2.8
       typescript: ^5.5 || ^6.0.0 || ^7.0.0
@@ -4132,16 +4132,16 @@ packages:
   convex-test@0.0.50:
     resolution: {integrity: sha512-rMNfrgcKJGToYDqNns2n1AO9KUP1NyC/AF9ldYEuWwTfRbgC9RQiHjlZsZQ/sOjLIVPUyKKIjoI/fNJUzy1urw==}
     peerDependencies:
-      convex: 1.44.0
+      convex: 1.45.0
 
-  convex-test@0.0.55:
-    resolution: {integrity: sha512-ablJ6vR3WUpyTaYrrRQf8yxInGrhHyqBEQsCFzloda3G0MDEu2RMKNGUkvlBXYWPiiEP0UIKPS7gZuLbqGnvQw==}
+  convex-test@0.0.56:
+    resolution: {integrity: sha512-dLYXlQjKFoGqvjAmPzyLgb2HsYI7iLo1iuNTU2DZmSrMRLWosYk94erjSU67GG5ovfP6+MjX8RJO+ebhmL6QYA==}
     peerDependencies:
-      convex: 1.44.0
+      convex: 1.45.0
 
-  convex@1.44.0:
-    resolution: {integrity: sha512-84bBa1ufSX4qohXdycXuQl2c2kAmfVpTCpypcmIgxpS5rUBgv5qjhArYugTkJVbljMs5SH2mW30bjJo+SQwe1w==}
-    engines: {node: '>=18.0.0', npm: '>=7.0.0'}
+  convex@1.45.0:
+    resolution: {integrity: sha512-AV3B56Ptu/14d76g3urBJ50dwpiZa6uJaLT84OWox5aCwZIJiuAamdjv3lLHDzs8vv5kC31anEZohhUe3qJ2bA==}
+    engines: {node: '>=20.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
       '@auth0/auth0-react': ^2.0.1
@@ -7699,16 +7699,16 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@convex-dev/batch-worker@0.2.0(convex@1.44.0(react@19.2.8))(react@19.2.8)':
+  '@convex-dev/batch-worker@0.2.0(convex@1.45.0(react@19.2.8))(react@19.2.8)':
     dependencies:
-      convex: 1.44.0(react@19.2.8)
+      convex: 1.45.0(react@19.2.8)
       react: 19.2.8
 
-  '@convex-dev/workpool@0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.44.0(react@19.2.8))(react@19.2.8)':
+  '@convex-dev/workpool@0.4.9(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6))(convex@1.45.0(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@convex-dev/batch-worker': 0.2.0(convex@1.44.0(react@19.2.8))(react@19.2.8)
-      convex: 1.44.0(react@19.2.8)
-      convex-helpers: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
+      '@convex-dev/batch-worker': 0.2.0(convex@1.45.0(react@19.2.8))(react@19.2.8)
+      convex: 1.45.0(react@19.2.8)
+      convex-helpers: 0.1.123(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6)
     transitivePeerDependencies:
       - react
 
@@ -10591,24 +10591,24 @@ snapshots:
 
   convert-to-spaces@2.0.1: {}
 
-  convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.44.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6):
+  convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@1.45.0(react@19.2.8))(react@19.2.8)(typescript@7.0.2)(zod@4.3.6):
     dependencies:
-      convex: 1.44.0(react@19.2.8)
+      convex: 1.45.0(react@19.2.8)
     optionalDependencies:
       '@standard-schema/spec': 1.1.0
       react: 19.2.8
       typescript: 7.0.2
       zod: 4.3.6
 
-  convex-test@0.0.50(convex@1.44.0(react@19.2.8)):
+  convex-test@0.0.50(convex@1.45.0(react@19.2.8)):
     dependencies:
-      convex: 1.44.0(react@19.2.8)
+      convex: 1.45.0(react@19.2.8)
 
-  convex-test@0.0.55(convex@1.44.0(react@19.2.8)):
+  convex-test@0.0.56(convex@1.45.0(react@19.2.8)):
     dependencies:
-      convex: 1.44.0(react@19.2.8)
+      convex: 1.45.0(react@19.2.8)
 
-  convex@1.44.0(react@19.2.8):
+  convex@1.45.0(react@19.2.8):
     dependencies:
       esbuild: 0.27.0
       prettier: 3.9.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ allowBuilds:
   sharp: true
 
 overrides:
-  convex: 1.44.0
+  convex: 1.45.0
   effect: 3.22.1
   "@effect/platform-node-shared": 0.61.1
   "@effect/typeclass": 0.41.0


### PR DESCRIPTION
Merges `origin/main` into the `v10` prerelease line so the eventual `v10` → `main` merge stays small. These are real `git merge`s, so the commits carry `main`'s tip as a second parent.

## What the merge changes

The only content `main` carries that `v10` didn't already have is the Convex 1.45.0 upgrade:

- `convex` `1.44.0` → `1.45.0` in the `pnpm-workspace.yaml` `overrides` entry and in the exact pins in `apps/example`, `@confect/cli`, `@confect/react`, and `@confect/foldkit`.
- `convex-test` `0.0.55` → `0.0.56` in `@confect/server`.

`@confect/foldkit` exists only on this branch, so `main`'s bump could not reach its pin. It's bumped here too, otherwise Syncpack sees two Convex versions across the workspace and the `overrides` entry silently forces 1.45.0 anyway.

## Conflicts and how they were resolved

Conflicts landed in `apps/example/package.json`, `packages/cli/package.json`, `packages/react/package.json`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml`. `main` is still on Effect v3, so its Effect entries never apply here — each conflict took `main`'s Convex value and kept this branch's Effect v4 pins:

- `effect` stays `4.0.0-rc.112` rather than reverting to `3.22.1`.
- `@effect/platform` stays absent from `apps/example` — v4 folds the platform surface into `effect` itself, and this branch removed the separate dependency.
- The `@effect/platform-node-shared` and `@effect/typeclass` `overrides` entries stay absent — those are v3-line pins this branch dropped.

`pnpm-lock.yaml` was not hand-merged; it was taken from this branch and regenerated with `pnpm install`. `pnpm why effect` confirms `4.0.0-rc.112` resolves everywhere and the lockfile resolves `convex@1.45.0`.

The later merges brought in the updated base (`v10` gained the macOS Bundler path fix from #620) and the current `main`, and both applied cleanly.

## Changesets

**None on this branch.** The Convex upgrade originally arrived carrying `.changeset/support-convex-1-45.md`, but #618 has since removed that changeset from `main` — the bump moved only devDependency pins, and the published `convex` peer ranges (`^1.36.0` on `@confect/react`, `^1.32.0` on `@confect/server`) never moved. Merging the current `main` deletes the file here too, so the prerelease line no longer carries an entry `main` deliberately dropped.

No sync changeset is needed either: no stable `## 9.x.y` heading is present in `main`'s `@confect/*` changelogs but missing from this branch's copies, so nothing released on `main` was absorbed.

## Migrations

None. The Convex bump compiles against the branch's current Effect v4 pin with no source changes, so this PR is green at the current pin on its own.

## Verification

Re-run after the base and `main` merges:

- `pnpm build` — green
- `pnpm check` (format + lint) — 461 files formatted, no lint errors
- `pnpm typecheck` — clean
- `pnpm test` — 108 files, 1422 tests passed, no type errors
- `pnpm test:server:mock-backend` — 28 files, 241 tests passed
- `pnpm test:server:local-backend` — 3 files, 9 tests passed
- `pnpm codegen:server:mock-backend` and `codegen:server:local-backend` re-run earlier; `git status` clean, so the Convex bump left the codegen fixtures unchanged

## Note on the Effect release candidate

No bump was needed this run. The branch is already pinned to `4.0.0-rc.112`, which is what `npm view effect@rc version` currently reports, so there's no stacked bump PR.