### PR TITLE
Drop the Convex 1.45.0 changeset

### DIFF
--- a/.changeset/support-convex-1-45.md
+++ b/.changeset/support-convex-1-45.md
@@ -1,7 +1,0 @@
----
-"@confect/cli": patch
-"@confect/react": patch
-"@confect/server": patch
----
-
-Validate `@confect/cli`, `@confect/react`, and `@confect/server` against `convex@1.45.0`.


### PR DESCRIPTION
Removes `.changeset/support-convex-1-45.md`, which the Convex 1.45.0 upgrade (#612) added.

## Why

The upgrade moved only dev-only pins and the `pnpm-workspace.yaml` override. Nothing on the published surface changed:

| Package | Where `convex` lives | Published range |
|---|---|---|
| `@confect/cli` | devDependency `1.45.0` — no dependency or peer on `convex` at all | — |
| `@confect/react` | devDependency `1.45.0` | peer stays `^1.36.0` |
| `@confect/server` | `convex-test` devDependency `0.0.56` | peer stays `^1.32.0` |
| `apps/example` | private app | n/a |

The upgrade's own commit message says as much: *"Existing peer ranges remain unchanged because the supported floor did not move."*

That leaves the `create-changeset` skill's user-visible delta list empty — no export consumers call changed, no observable behavior changed, no authored artifact changed, and no dependency or peer range on a published package changed. The skill's rule for that case is explicit: *"Empty list, no published package behavior touched → no changeset (internal refactors, tests, tooling, comments)."* It's the same reason `upgrade-internal-deps` ships dev-only bumps with no changeset, while `upgrade-published-deps` requires one.

As written, the entry would have told consumers that a version they cannot observe from the published surface moved — and asked them to take no action.

## Consequence

This was the only pending changeset, so merging it leaves `.changeset/` with just `config.json`. The open **Version Packages** PR (#615) will close itself once the changesets action re-runs, and no release is outstanding until the next user-facing change lands. That's reversible — the next changeset reopens it.

The `1.45.0` pins themselves are untouched; only the changelog entry goes away.

## Related

The prerelease sync PR (#617) carries this same changeset, since it rode along with the upgrade commit into `v10`. It's deliberately left as-is there rather than diverged — once this merges, the entry drops off that line on the next `main` → `v10` sync.

## Verification

The only change is deleting a `.changeset/*.md` file, so no source, build, or test surface is affected; CI on this PR is the check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HziAC8br3rbzdW2zTX7XDU)_