### PR TITLE
Fix Bundler path assertion on macOS

### DIFF
--- a/packages/cli/test/Bundler.test.ts
+++ b/packages/cli/test/Bundler.test.ts
@@ -249,9 +249,16 @@ layer(BundlerLayer)("importersOfPackage", (it) => {
       const bundled = yield* Bundler.bundle(entry);
 
       // The import resolved to an absolute path inside `pkg/dist`, yet the
-      // package is still found by name.
+      // package is still found by name. Canonicalize the returned path because
+      // macOS exposes the same temporary directory through both `/var` and
+      // `/private/var`.
+      const importers = Bundler.importersOfPackage(
+        bundled,
+        "@scope/lib",
+        () => true,
+      );
       expect(
-        Bundler.importersOfPackage(bundled, "@scope/lib", () => true),
+        yield* Effect.forEach(importers, (importer) => fs.realPath(importer)),
       ).toStrictEqual([yield* fs.realPath(entry)]);
     }).pipe(Effect.scoped),
   );


### PR DESCRIPTION
The Bundler workspace-package regression test compared an absolute metafile path with a canonical realpath. macOS exposes temporary directories through both `/var` and `/private/var`, making those strings differ even though they identify the same file.

Canonicalizing the returned importer before comparison keeps the test focused on filesystem identity without changing `importersOfPackage`'s absolute-path contract.

Verification:

- `pnpm exec vitest run --project @confect/cli packages/cli/test/Bundler.test.ts`
- `pnpm test` — 1,422 tests passed, no type errors
- `pnpm check`

No changeset is included because this only makes an existing test portable; published behavior is unchanged.
