### PR TITLE
Upgrade the pnpm and bun runtime pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-bun = "1.3.14"
+bun = "1.4.0"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node", "pnpm"]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "effect"
   ],
   "license": "ISC",
-  "packageManager": "pnpm@11.18.0",
+  "packageManager": "pnpm@11.25.0",
   "scripts": {
     "build": "vp run --cache --filter \"@confect/*\" build",
     "check": "vp check",


### PR DESCRIPTION
Routine sweep of the version pins that live outside every `package.json` dependency map, where nothing surfaces the drift: no lockfile records them, so Dependabot and `syncpack` both look straight past them and they only move when someone goes looking.

## Pins that moved

| Pin | Where | From | To | Notes |
| --- | --- | --- | --- | --- |
| pnpm | `package.json` → `packageManager` | 11.18.0 | 11.25.0 | [release notes](https://github.com/pnpm/pnpm/releases) |
| bun | `mise.toml` → `[tools]` | 1.3.14 | 1.4.0 | [release notes](https://bun.com/blog/bun-v1.4) |

**pnpm 11.18.0 → 11.25.0.** Seven minors inside the 11 line. `pnpm-lock.yaml` is unchanged at `lockfileVersion: 9.0` and a reinstall is byte-identical. 11.25.0 turns dependency cycles into `ERR_PNPM_TASK_CYCLE`, which the checked-in `.npmrc` (`ignore-workspace-cycles=true`) already downgrades to a warning, and deprecates workspace-scoped registry auth settings, which this workspace doesn't use. Install emits no new warnings.

**bun 1.3.14 → 1.4.0.** Still inside the 1.x line, and 1.3.14 was the end of the 1.3 series. bun's only job in this repo is running the three `.claude/hooks/*.ts` Claude Code hooks under `mise exec`; all three were run against 1.4.0 and exit clean. Nothing published, built, or tested touches bun — `@effect/platform-bun` is a library dependency, not this runtime.

## Consumers these pins reach

Both bumps reach every consumer that resolves them — no CI action needs editing:

- `.github/actions/{confect,docs,example}-setup` resolve Node through `node-version-file: ".node-version"` and pnpm through `pnpm/action-setup@v6` with **no `version:` input**, which falls back to the `packageManager` field. So the pnpm bump lands in CI without touching the actions.
- `.github/workflows/packages.yml` and `release.yml` read the same `.node-version` file directly.
- `mise` reads both files via `idiomatic_version_file_enable_tools = ["node", "pnpm"]`. `mise ls` after the change confirms it resolves pnpm 11.25.0 from `package.json` and Node 22.23.2 from `.node-version`.

No consumer is left behind by these two bumps.

## Node 24 deliberately deferred

`.node-version` is the floating major `22`, so there is no in-line bump available — the only move is the jump to the current active LTS (24.20.0). **It was tried end to end and it works**: `mise` on Node 24.20.0, a frozen-lockfile reinstall, then `pnpm check`, `pnpm build`, `pnpm typecheck`, and `pnpm test` (1112 passed, no type errors) all green. The [24.0.0 removals](https://nodejs.org/en/blog/release/v24.0.0) land nowhere in this tree — no `url.parse`, `SlowBuffer`, `tls.createSecurePair`, or `dirent.path`, and `scripts/auditPrereleaseSync.test.mjs` is the one `node:test` consumer with flat `test()` calls, so the subtest-promise change doesn't reach it.

What holds it back is **coverage, not compatibility**. Every workflow resolves Node from this single file, so moving it to 24 would leave the `>=22` floor that all six published packages declare in `engines` untested anywhere in CI, while `@types/node` stays pinned to the 22 line one routine over. That couples `.node-version`, `engines`, and `@types/node` into a single support-policy call — the same reasoning that held `@types/node` back in e9fcfa4 — so it belongs to a deliberate, changeset-recorded decision rather than to this sweep. Flipping it is a one-line change on top of this branch whenever you want it.

## No changeset

`engines` is untouched and nothing here is visible to consumers of `@confect/*`.

## Verification

Run locally under the new pins: `pnpm install`, `pnpm check`, `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm build`, `pnpm test` (1112 passed, 13 skipped, no type errors), `pnpm circular`, `pnpm check:pack-contents`, `pnpm test:server:mock-backend`, and `pnpm test:server:local-backend` (6 passed).

One caveat worth naming: the local-backend suite fails on its **first** cold run in a fresh container — `convex dev` exits before printing its ready line while the backend is still initializing — and passes on every run after. It does the same on an unmodified checkout, so it is environmental rather than anything these pins caused. The Windows jobs and the docs/example app workflows can't run in this container and are left to CI here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtYmgXkqckDG2MVAYmWWZF)_