### PR TITLE
Fix DatabaseWriter.patch to accept undefined for optional fields

### DIFF
--- a/.changeset/patch-undefined-optional-fields.md
+++ b/.changeset/patch-undefined-optional-fields.md
@@ -1,0 +1,7 @@
+---
+"@confect/server": patch
+---
+
+Fix `DatabaseWriter`'s `patch` rejecting `undefined` for optional fields under `exactOptionalPropertyTypes`.
+
+Setting an optional field to `undefined` in a patch removes it from the document, but the argument was typed as a plain `Partial` of the document, so `writer.table("notes").patch(id, { tag: undefined })` was a type error in projects with `exactOptionalPropertyTypes` enabled. Optional fields now accept `undefined`; required fields still don't, since removing one would leave a document the table's schema rejects.

--- a/.changeset/patch-undefined-optional-fields.md
+++ b/.changeset/patch-undefined-optional-fields.md
@@ -4,4 +4,4 @@
 
 Fix `DatabaseWriter`'s `patch` rejecting `undefined` for optional fields under `exactOptionalPropertyTypes`.
 
-Setting an optional field to `undefined` in a patch removes it from the document, but the argument was typed as a plain `Partial` of the document, so `writer.table("notes").patch(id, { tag: undefined })` was a type error in projects with `exactOptionalPropertyTypes` enabled. Optional fields now accept `undefined`; required fields still don't, since removing one would leave a document the table's schema rejects.
+Setting an optional field to `undefined` in a patch unsets it, but the argument was typed as a plain `Partial` of the document, so `writer.table("notes").patch(id, { tag: undefined })` was a type error in projects with `exactOptionalPropertyTypes` enabled. Optional fields now accept `undefined`; required fields still don't, since unsetting one would leave a document the table's schema rejects.

--- a/.changeset/patch-undefined-optional-fields.md
+++ b/.changeset/patch-undefined-optional-fields.md
@@ -4,4 +4,4 @@
 
 Fix `DatabaseWriter`'s `patch` rejecting `undefined` for optional fields under `exactOptionalPropertyTypes`.
 
-Setting an optional field to `undefined` in a patch unsets it, but the argument was typed as a plain `Partial` of the document, so `writer.table("notes").patch(id, { tag: undefined })` was a type error in projects with `exactOptionalPropertyTypes` enabled. Optional fields now accept `undefined`; required fields still don't, since unsetting one would leave a document the table's schema rejects.
+Setting an optional field to `undefined` in a patch unsets it, but the argument was typed as a plain `Partial` of the document, so `writer.table("notes").patch(id, { tag: undefined })` was a type error in projects with `exactOptionalPropertyTypes` enabled. Optional fields now accept `undefined`; fields whose type does not already include `undefined` are unchanged.

--- a/apps/docs/server/database/writing.mdx
+++ b/apps/docs/server/database/writing.mdx
@@ -35,7 +35,7 @@ writer.table("notes").insert({
 
 ### Patch
 
-Shallow merge the provided object with the existing document. New fields are added. Existing fields are overwritten. Fields set to `undefined` are removed.
+Shallow merge the provided object with the existing document. New fields are added. Existing fields are overwritten. Optional fields set to `undefined` are removed; required fields can't be removed this way, and passing `undefined` for one is a type error.
 
 ```ts
 writer.table("notes").patch(noteId, {

--- a/apps/docs/server/database/writing.mdx
+++ b/apps/docs/server/database/writing.mdx
@@ -35,7 +35,7 @@ writer.table("notes").insert({
 
 ### Patch
 
-Shallow merge the provided object with the existing document. New fields are added. Existing fields are overwritten. Optional fields set to `undefined` are removed; required fields can't be removed this way, and passing `undefined` for one is a type error.
+Shallow merge the provided object with the existing document. New fields are added. Existing fields are overwritten. Optional fields set to `undefined` are unset.
 
 ```ts
 writer.table("notes").patch(noteId, {

--- a/apps/docs/server/database/writing.mdx
+++ b/apps/docs/server/database/writing.mdx
@@ -14,7 +14,6 @@ Effect.gen(function* () {
   const writer = yield* DatabaseWriter;
 
   return yield* writer.table("notes").insert({
-    title: "My first note",
     text: "This is my first note",
   });
 });
@@ -28,8 +27,8 @@ Insert a new document.
 
 ```ts
 writer.table("notes").insert({
-  title: "My first note",
   text: "This is my first note",
+  tag: "drafts",
 });
 ```
 
@@ -39,9 +38,9 @@ Shallow merge the provided object with the existing document. New fields are add
 
 ```ts
 writer.table("notes").patch(noteId, {
-  title: "Patched title",
-  author: "John Doe",
-  text: undefined,
+  text: "Patched text",
+  author: { role: "user", name: "John Doe" },
+  tag: undefined,
 });
 ```
 
@@ -51,7 +50,6 @@ Replace the entire document.
 
 ```ts
 writer.table("notes").replace(noteId, {
-  title: "Replaced title",
   text: "I'm replacing the whole document",
 });
 ```

--- a/packages/server/src/DatabaseWriter.ts
+++ b/packages/server/src/DatabaseWriter.ts
@@ -19,6 +19,19 @@ import * as QueryInitializer from "./QueryInitializer";
 import type * as Table from "./Table";
 import type * as TableInfo from "./TableInfo";
 
+/**
+ * The argument accepted by `patch`: like `Partial<Doc>`, but the fields that
+ * are already optional also accept `undefined`, since setting a field to
+ * `undefined` removes it from the document. `Partial` alone would reject that
+ * under `exactOptionalPropertyTypes`. Required fields stay required, because
+ * removing one would produce a document the table's schema no longer accepts.
+ */
+export type PatchValue<Doc> = Doc extends unknown
+  ? {
+      [K in keyof Doc]?: undefined extends Doc[K] ? Doc[K] | undefined : Doc[K];
+    }
+  : never;
+
 export interface DatabaseWriterTableAccessor<
   DataModel_ extends DataModel.AnyWithProps,
   TableName extends DataModel.TableNames<DataModel_>,
@@ -29,7 +42,7 @@ export interface DatabaseWriterTableAccessor<
   ) => Effect.Effect<GenericId<TableName>, Document.DocumentEncodeError>;
   readonly patch: (
     id: GenericId<TableName>,
-    patchedValues: Partial<Document.WithoutSystemFields<Doc>>,
+    patchedValues: PatchValue<Document.WithoutSystemFields<Doc>>,
   ) => Effect.Effect<
     void,
     | QueryInitializer.GetByIdFailure
@@ -122,7 +135,7 @@ export const make = <DatabaseSchema_ extends DatabaseSchema.AnyWithProps>(
 
     const patch = (
       id: GenericId<TableName>,
-      patchedValues: Partial<
+      patchedValues: PatchValue<
         Document.WithoutSystemFields<DocumentByName_<DataModel_, TableName>>
       >,
     ) =>

--- a/packages/server/src/DatabaseWriter.ts
+++ b/packages/server/src/DatabaseWriter.ts
@@ -22,9 +22,7 @@ import type * as TableInfo from "./TableInfo";
 /**
  * The argument accepted by `patch`: like `Partial<Doc>`, but the fields that
  * are already optional also accept `undefined`, since setting a field to
- * `undefined` removes it from the document. `Partial` alone would reject that
- * under `exactOptionalPropertyTypes`. Required fields stay required, because
- * removing one would produce a document the table's schema no longer accepts.
+ * `undefined` removes it from the document.
  */
 export type PatchValue<Doc> = Doc extends unknown
   ? {

--- a/packages/server/src/DatabaseWriter.ts
+++ b/packages/server/src/DatabaseWriter.ts
@@ -22,7 +22,7 @@ import type * as TableInfo from "./TableInfo";
 /**
  * The argument accepted by `patch`: like `Partial<Doc>`, but the fields that
  * are already optional also accept `undefined`, since setting a field to
- * `undefined` removes it from the document.
+ * `undefined` unsets it.
  */
 export type PatchValue<Doc> = Doc extends unknown
   ? {

--- a/packages/server/src/DatabaseWriter.ts
+++ b/packages/server/src/DatabaseWriter.ts
@@ -24,11 +24,9 @@ import type * as TableInfo from "./TableInfo";
  * are already optional also accept `undefined`, since setting a field to
  * `undefined` unsets it.
  */
-export type PatchValue<Doc> = Doc extends unknown
-  ? {
-      [K in keyof Doc]?: undefined extends Doc[K] ? Doc[K] | undefined : Doc[K];
-    }
-  : never;
+export type PatchValue<Doc> = {
+  [K in keyof Doc]?: undefined extends Doc[K] ? Doc[K] | undefined : Doc[K];
+};
 
 export interface DatabaseWriterTableAccessor<
   DataModel_ extends DataModel.AnyWithProps,

--- a/packages/server/test/mock-backend/integration.test.ts
+++ b/packages/server/test/mock-backend/integration.test.ts
@@ -67,7 +67,7 @@ describe("DatabaseReader", () => {
 });
 
 describe("DatabaseWriter", () => {
-  it.effect("patch removes optional fields set to undefined", () =>
+  it.effect("patch unsets optional fields set to undefined", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
 

--- a/packages/server/test/mock-backend/integration.test.ts
+++ b/packages/server/test/mock-backend/integration.test.ts
@@ -97,14 +97,14 @@ describe("DatabaseWriter", () => {
     }).pipe(Effect.provide(TestConfect.layer())),
   );
 
-  it("patch only accepts undefined for optional fields", () => {
+  it("patch accepts undefined only where the field type allows it", () => {
     const patchNote = (writer: DatabaseWriter) => writer.table("notes").patch;
     type Patch = Parameters<ReturnType<typeof patchNote>>[1];
 
-    expectTypeOf<{ tag: undefined }>().toMatchTypeOf<Patch>();
-    expectTypeOf<{ author: undefined }>().toMatchTypeOf<Patch>();
-    expectTypeOf<{ text: undefined }>().not.toMatchTypeOf<Patch>();
-    expectTypeOf<{ text: string }>().toMatchTypeOf<Patch>();
+    expectTypeOf<{ tag: undefined }>().toExtend<Patch>();
+    expectTypeOf<{ author: undefined }>().toExtend<Patch>();
+    expectTypeOf<{ text: undefined }>().not.toExtend<Patch>();
+    expectTypeOf<{ text: string }>().toExtend<Patch>();
   });
 });
 

--- a/packages/server/test/mock-backend/integration.test.ts
+++ b/packages/server/test/mock-backend/integration.test.ts
@@ -66,6 +66,48 @@ describe("DatabaseReader", () => {
   );
 });
 
+describe("DatabaseWriter", () => {
+  it.effect("patch removes optional fields set to undefined", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      const noteId = yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+
+          const id = yield* writer
+            .table("notes")
+            .insert({ text: "original", tag: "draft" });
+
+          yield* writer
+            .table("notes")
+            .patch(id, { text: "patched", tag: undefined });
+
+          return id;
+        }),
+        Id("notes"),
+      );
+
+      const note = yield* c.query(refs.public.databaseReader.getNote, {
+        noteId,
+      });
+
+      assertEquals(note.text, "patched");
+      assert.isFalse(Object.hasOwn(note, "tag"));
+    }).pipe(Effect.provide(TestConfect.layer())),
+  );
+
+  it("patch only accepts undefined for optional fields", () => {
+    const patchNote = (writer: DatabaseWriter) => writer.table("notes").patch;
+    type Patch = Parameters<ReturnType<typeof patchNote>>[1];
+
+    expectTypeOf<{ tag: undefined }>().toMatchTypeOf<Patch>();
+    expectTypeOf<{ author: undefined }>().toMatchTypeOf<Patch>();
+    expectTypeOf<{ text: undefined }>().not.toMatchTypeOf<Patch>();
+    expectTypeOf<{ text: string }>().toMatchTypeOf<Patch>();
+  });
+});
+
 describe("MutationRunner", () => {
   it.effect("insertNoteViaRunner", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fixed `DatabaseWriter`'s `patch` method to properly accept `undefined` for optional fields under `exactOptionalPropertyTypes`, while still rejecting `undefined` for required fields.

## Changes

- **Type definition**: Introduced `PatchValue<Doc>` type that allows `undefined` only for fields that are already optional in the document schema. Required fields remain required and cannot be set to `undefined`.
- **API update**: Changed `patch` method signature to use `PatchValue` instead of plain `Partial`, enabling type-safe removal of optional fields.
- **Tests**: Added comprehensive test coverage including:
  - Integration test verifying that patching with `undefined` actually removes optional fields from documents
  - Type-level tests ensuring `undefined` is accepted for optional fields but rejected for required fields
- **Documentation**: Updated the patch section in the writing guide to clarify the behavior with optional vs. required fields.
- **Changeset**: Added entry documenting the fix for projects with `exactOptionalPropertyTypes` enabled.

## Implementation Details

The `PatchValue` type uses a conditional type to inspect each field: if a field's type already includes `undefined` (indicating it's optional), the patch value accepts either the field's type or `undefined`; otherwise, it only accepts the field's type. This ensures that `writer.table("notes").patch(id, { tag: undefined })` is valid when `tag` is optional, but `{ text: undefined }` is rejected when `text` is required.

https://claude.ai/code/session_018nMDZbtJaQewyiPCV1CPeq