### PR TITLE
Stream-first querying: docs

### DIFF
--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -191,6 +191,51 @@ Without an `error` schema, the `Failure` variant is excluded from the type entir
 
 <Note>`usePaginatedQuery` requires `convex` 1.36.0 or newer.</Note>
 
+## `useStreamPaginatedQuery`
+
+Loads data reactively from a paginated query whose handler paginates a [query stream](/server/database/streams#paginating-a-stream) with `QueryStream.paginate`. Those pages are not tracked by Convex's query journal, which `usePaginatedQuery` relies on to keep pages consistent as data changes, so this hook maintains that guarantee itself: every loaded page is pinned to a fixed index range by echoing its `continueCursor` back as the next subscription's `endCursor`. Adjacent pages always meet exactly, a document is never shown twice or lost between pages, and a page that outgrows `initialNumItems` is split in two.
+
+The call shape and the result are the same as `usePaginatedQuery`: args are encoded with the spec's user-args schema, pages are decoded with its `item` schema, `"skip"` disables the query, and the result is a `PaginatedQueryResult<Item, E>` with a `Failure` variant when the spec declares an `error` schema.
+
+```tsx
+import { PaginatedQueryResult, useStreamPaginatedQuery } from "@confect/react";
+import refs from "../confect/_generated/refs";
+
+const Feed = () => {
+  const feed = useStreamPaginatedQuery(
+    refs.public.notes.feed,
+    {},
+    { initialNumItems: 10 },
+  );
+
+  return (
+    <div>
+      <ul>
+        {feed.results.map((note) => (
+          <li key={note._id}>{note.text}</li>
+        ))}
+      </ul>
+      {feed.isLoading && <p>Loading…</p>}
+      {PaginatedQueryResult.isCanLoadMore(feed) && (
+        <button type="button" onClick={() => feed.loadMore(10)}>
+          Load more
+        </button>
+      )}
+    </div>
+  );
+};
+```
+
+The options accept an additional `maximumRowsRead`, a per-page read budget forwarded to the server. On a stream that filters out most of what it reads, a page that would otherwise scan past Convex's query limits returns truncated with `SplitRequired` instead, and the hook splits it.
+
+When a stored cursor stops matching the query — the server fails a page with `paginationError: "InvalidCursor"`, for example after an index change is deployed — the hook restarts pagination from the first page rather than failing.
+
+<Note>
+  `useStreamPaginatedQuery` also works with paginated queries that use the
+  built-in `paginate`, since it only relies on the `endCursor` protocol field.
+  It subscribes to one query per loaded page.
+</Note>
+
 ## `useMutation`
 
 Returns a function that encodes args using the spec's `args` schema, calls the Convex mutation, and decodes the result using the spec's `returns` schema. The returned promise's shape depends on whether the spec declares an `error` schema.

--- a/apps/docs/clients/react.mdx
+++ b/apps/docs/clients/react.mdx
@@ -226,7 +226,7 @@ const Feed = () => {
 };
 ```
 
-The options accept an additional `maximumRowsRead`, a per-page read budget forwarded to the server. On a stream that filters out most of what it reads, a page that would otherwise scan past Convex's query limits returns truncated with `SplitRequired` instead, and the hook splits it.
+The options also accept `maximumRowsRead` and `maximumBytesRead`, per-page read budgets forwarded to the server. On a stream that filters out most of what it reads, a page that would otherwise scan past Convex's query limits returns truncated with `SplitRequired` instead, and the hook splits it.
 
 When a stored cursor stops matching the query — the server fails a page with `paginationError: "InvalidCursor"`, for example after an index change is deployed — the hook restarts pagination from the first page rather than failing.
 

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -63,6 +63,7 @@
             "pages": [
               "server/database/schema",
               "server/database/reading",
+              "server/database/streams",
               "server/database/writing",
               "server/database/system-tables",
               "server/database/determinism"

--- a/apps/docs/server/database/reading.mdx
+++ b/apps/docs/server/database/reading.mdx
@@ -129,6 +129,8 @@ Get a `Stream` of documents matching the query.
 reader.table("notes").index("by_creation_time").stream();
 ```
 
+To merge, join, or paginate several queries together, use a [query stream](/server/database/streams) instead — `reader.table("notes").stream("by_creation_time")` — which stays paginable after composition.
+
 ### Accessing the current time
 
 Reading real time inside a query handler affects how aggressively Convex caches the result. See [Determinism](/server/database/determinism) for how Confect keeps queries cacheable by default and how to opt in to real time via Effect's `Clock` service.

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -289,7 +289,7 @@ A cursor that is malformed, or that was issued by a stream with a different orde
 
 ### On the client
 
-Pages of a stream-paginated query are not tracked by Convex's query journal, so [`usePaginatedQuery`](/clients/react#usepaginatedquery) can't keep them gap-free as data changes. Use [`useStreamPaginatedQuery`](/clients/react#usestreampaginatedquery) instead, which pins each loaded page with `endCursor` and splits pages that outgrow their size.
+Pages of a stream-paginated query are not tracked by Convex's query journal, so [`usePaginatedQuery`](/clients/react#usepaginatedquery) can't keep them gap-free as data changes. Use [`useStreamPaginatedQuery`](/clients/react#usestreampaginatedquery) instead, which pins each loaded page with `endCursor` and splits pages that outgrow their size. Foldkit's [`PaginatedQuery`](/clients/foldkit#paginated-queries) machine works with stream-paginated queries as is: it pins each page it navigates away from, so going back reloads the same range.
 
 ## Limitations
 

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -1,0 +1,282 @@
+---
+icon: "waves"
+title: "Streams"
+description: "Compose, merge, join, and paginate index queries as Effect streams."
+---
+
+<Warning>
+  Stream querying is a prototype on the `v10` prerelease line. The API is usable
+  end to end, but its surface may still change between prereleases.
+</Warning>
+
+A **query stream** is an Effect [`Stream`](https://effect.website/docs/stream/introduction) of decoded documents in index order that also remembers how it is ordered. That extra knowledge is what lets streams be combined — merged, filtered, joined, deduplicated — and still be paginated with cursors afterwards, which a plain `Stream` cannot do.
+
+Create one with `stream` on a table, then compose it with the `QueryStream` module from `@confect/server`:
+
+```ts
+import { QueryStream } from "@confect/server";
+import * as Effect from "effect/Effect";
+import { DatabaseReader } from "./confect/_generated/services";
+
+Effect.gen(function* () {
+  const reader = yield* DatabaseReader;
+
+  const byRole = (role: "admin" | "user") =>
+    reader
+      .table("notes")
+      .stream("by_role", (q) => q.eq("author.role", role), "desc");
+
+  return yield* QueryStream.merge([byRole("admin"), byRole("user")]).pipe(
+    QueryStream.filterEffect((note) => Effect.succeed(note.tag !== "hidden")),
+    QueryStream.paginate(paginationOpts),
+  );
+});
+```
+
+<Note>
+  `reader.table("notes").stream(...)` is different from
+  `reader.table("notes").index(...).stream()` on the
+  [Reading](/server/database/reading#stream) page. The latter is a plain
+  `Stream` over one query; the former is a composable query stream.
+</Note>
+
+## Creating a stream
+
+`stream` takes an index name, an optional range callback, and an optional order (`"asc"` by default). It returns a `QueryStream` whose elements are decoded documents, in index order.
+
+```ts Every note, sorted by text
+reader.table("notes").stream("by_text");
+```
+
+```ts Every note, sorted by text, descending
+reader.table("notes").stream("by_text", "desc");
+```
+
+```ts Notes whose text is at least "b", sorted by text
+reader.table("notes").stream("by_text", (q) => q.gte("text", "b"));
+```
+
+```ts Notes whose text is exactly "apple", sorted by creation time
+reader.table("notes").stream("by_text", (q) => q.eq("text", "apple"));
+```
+
+### Range callbacks
+
+The range callback mirrors Convex's index range builder with one addition: it tracks which fields are still _varying_ after the range is applied.
+
+- `eq` pins the next index field to a value and consumes it — it no longer varies within the stream.
+- `gt`, `gte`, `lt`, and `lte` bound the next field without consuming it, and must come last (a lower bound may be followed by an upper bound on the same field).
+
+Fields must be used in the order the index declares them, and each method only offers the next unused field, so misuse is a type error.
+
+### Order keys
+
+The fields that still vary after pinning, followed by the implicit `_creationTime` tiebreaker, form the stream's **order key**. It is part of the stream's type: `reader.table("notes").stream("by_text")` is a `QueryStream<Doc, ["text", "_creationTime"]>`, while pinning the text with `eq` leaves `["_creationTime"]`.
+
+The order key determines which streams can be merged: two streams can only be merged when their order keys are the same, so a mismatch is caught at compile time.
+
+## Consuming a stream
+
+A query stream is a genuine `Stream`, so everything in Effect's `Stream` module applies:
+
+```ts
+import * as Stream from "effect/Stream";
+
+const firstTwoTexts =
+  yield *
+  reader
+    .table("notes")
+    .stream("by_text")
+    .pipe(
+      Stream.map((note) => note.text),
+      Stream.take(2),
+      Stream.runCollect,
+    );
+```
+
+Once you apply a plain `Stream` combinator the result is an ordinary `Stream`: it can be consumed, but it no longer knows its order key, so it can't be merged or paginated further. Use the `QueryStream` combinators below when you need to keep that ability.
+
+`QueryStream.unique` consumes a stream expected to hold at most one document, returning an `Option` and failing with `NotUniqueError` if there are two or more:
+
+```ts
+const note =
+  yield *
+  QueryStream.unique(
+    reader.table("notes").stream("by_text", (q) => q.eq("text", "apple")),
+  );
+```
+
+## Combining streams
+
+Each combinator below returns another query stream, so results stay mergeable and paginable.
+
+### Merge
+
+`QueryStream.merge` interleaves streams that share an order key into one ordered stream — the equivalent of SQL's `UNION ALL`. Merging is how you query over several index ranges at once, such as the notes by two roles in the example at the top of this page.
+
+```ts
+const events = QueryStream.merge([
+  reader.table("events").stream("by_kind", (q) => q.eq("kind", "meeting")),
+  reader.table("events").stream("by_kind", (q) => q.eq("kind", "reminder")),
+]);
+```
+
+All inputs must have the same order key and document type (type errors otherwise) and the same order direction (checked when the stream runs). Overlapping inputs are not deduplicated: a document matched by two inputs appears twice.
+
+### Filter and map
+
+`QueryStream.filterEffect` and `QueryStream.mapEffect` are the effectful `filter` and `map`, with one difference from their `Stream` counterparts: a document that is filtered out still counts as _read_, so cursors keep advancing past it and pagination stays correct.
+
+```ts
+reader
+  .table("notes")
+  .stream("by_creation_time", "desc")
+  .pipe(
+    QueryStream.filterEffect((note) => Effect.succeed(note.tag !== "hidden")),
+    QueryStream.mapEffect((note) =>
+      Effect.succeed({ id: note._id, text: note.text }),
+    ),
+  );
+```
+
+A mapper must not change what the documents are ordered by — the mapped stream keeps the original order key.
+
+### Join
+
+`QueryStream.flatMap` runs an inner stream for each document of an outer stream and concatenates the results, ordered by the outer key and then the inner key. Pass the inner streams' order key as `innerKey`; it is checked against the type of the stream the function returns.
+
+```ts
+// Every author's messages, grouped by author in author order, and by
+// creation time within each author.
+reader
+  .table("authors")
+  .stream("by_name")
+  .pipe(
+    QueryStream.flatMap(
+      (author) =>
+        reader
+          .table("messages")
+          .stream("by_author", (q) => q.eq("authorId", author._id)),
+      { innerKey: ["_creationTime"] },
+    ),
+  );
+```
+
+The result's order key is the concatenation `["name", "_creationTime", "_creationTime"]`. Outer documents whose inner stream is empty contribute nothing visible but still count as read.
+
+### Distinct
+
+`QueryStream.distinct` keeps the first document for each distinct value of a prefix of the order key. It runs as a loose index scan — after finding a group's first document it skips to the next group with a fresh index read instead of scanning the rest of the group.
+
+```ts
+// One note per distinct text.
+reader
+  .table("notes")
+  .stream("by_text")
+  .pipe(QueryStream.distinct(["text"]));
+```
+
+The fields must be a prefix of the stream's order key, which is enforced at the type level. Apply `filterEffect` _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
+
+### Rename the order key
+
+`QueryStream.orderBy` relabels a stream's order key positionally without changing how it is sorted. Use it to merge streams from different indexes or tables that sort by the same kind of value under different field names. Since merged streams must also share a document type, map each side to a common shape first:
+
+```ts
+interface TimelineEntry {
+  readonly kind: "message" | "call";
+  readonly at: number;
+}
+
+const timeline = QueryStream.merge([
+  reader
+    .table("messages")
+    .stream("by_sent") // order key: ["sentAt", "_creationTime"]
+    .pipe(
+      QueryStream.mapEffect((message) =>
+        Effect.succeed<TimelineEntry>({ kind: "message", at: message.sentAt }),
+      ),
+    ),
+  reader
+    .table("calls")
+    .stream("by_started") // order key: ["startedAt", "_creationTime"]
+    .pipe(
+      QueryStream.mapEffect((call) =>
+        Effect.succeed<TimelineEntry>({ kind: "call", at: call.startedAt }),
+      ),
+      QueryStream.orderBy(["sentAt", "_creationTime"]),
+    ),
+]);
+```
+
+The new key must have exactly as many fields as the old one, and the values under each position must be comparable — relabeling doesn't reorder anything. A `flatMap` result can't be relabeled (its runtime key carries tiebreakers its type omits); relabel its inputs instead.
+
+## Paginating a stream
+
+`QueryStream.paginate` consumes one page of any composed stream, using the same `paginationOpts` shape that Convex's built-in `paginate` does. A [paginated query](/server/functions#paginated-queries) handler forwards its decoded `paginationOpts`:
+
+```ts confect/notes.impl.ts
+import { FunctionImpl, QueryStream } from "@confect/server";
+import * as Effect from "effect/Effect";
+import { DatabaseReader } from "./_generated/services";
+import databaseSchema from "./_generated/schema";
+import notes from "./notes.spec";
+
+const feed = FunctionImpl.make(
+  databaseSchema,
+  notes,
+  "feed",
+  ({ paginationOpts }) =>
+    Effect.gen(function* () {
+      const reader = yield* DatabaseReader;
+
+      const byRole = (role: "admin" | "user") =>
+        reader
+          .table("notes")
+          .stream("by_role", (q) => q.eq("author.role", role), "desc");
+
+      return yield* QueryStream.merge([byRole("admin"), byRole("user")]).pipe(
+        QueryStream.filterEffect((note) =>
+          Effect.succeed(note.tag !== "hidden"),
+        ),
+        QueryStream.paginate(paginationOpts),
+      );
+    }).pipe(Effect.orDie),
+);
+```
+
+Resuming from a cursor doesn't re-read the pages before it: the cursor's position is pushed down into the underlying index queries, through every combinator above, so each page costs roughly one page of reads.
+
+### Pagination protocol
+
+`paginate` speaks Convex's pagination protocol, with the semantics of [`convex-helpers`' stream pagination](https://stack.convex.dev/merging-streams-of-convex-data):
+
+| Field                            | Meaning                                                                                                                                                                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `cursor`                         | Where the page starts, exclusive. `null` starts at the beginning of the stream.                                                                                                                                                |
+| `numItems`                       | How many documents to return, counting only documents that pass filters.                                                                                                                                                       |
+| `endCursor`                      | When present, the page runs exactly to this cursor (inclusive) and `numItems` is ignored. Pinning pages this way keeps adjacent pages gap-free as data changes. `QueryStream.END_CURSOR` pins a page to the end of the stream. |
+| `maximumRowsRead`                | A read budget counting every document read, filtered or not. When it is hit, the page returns what it has so far with `pageStatus: "SplitRequired"` and a `splitCursor` to split the page at.                                  |
+| `pageStatus: "SplitRecommended"` | Returned with a `splitCursor` when a pinned page has grown well past `numItems`, or any page had to scan a very large number of rows for its items, so reactive clients can subdivide it.                                      |
+| `isDone`                         | `true` only when the page reached the true end of the stream.                                                                                                                                                                  |
+
+A cursor that is malformed, or that was issued by a stream with a different order key (for example after an index change is deployed), fails the query with a `ConvexError` whose data is `{ paginationError: "InvalidCursor" }` — the signal `convex/react` and Confect's hooks treat as "restart pagination".
+
+<Warning>
+  Stream cursors contain the order-key **values** of the page boundary,
+  serialized as JSON, rather than an opaque token. Anyone who receives a page
+  can read those values and craft cursors for chosen keys within the stream's
+  range. Don't paginate publicly over a sensitive indexed field without pinning
+  it with `eq`.
+</Warning>
+
+### On the client
+
+Pages of a stream-paginated query are not tracked by Convex's query journal, so [`usePaginatedQuery`](/clients/react#usepaginatedquery) can't keep them gap-free as data changes. Use [`useStreamPaginatedQuery`](/clients/react#usestreampaginatedquery) instead, which pins each loaded page with `endCursor` and splits pages that outgrow their size.
+
+## Limitations
+
+- `maximumBytesRead` is accepted but not enforced.
+- `merge` checks that its inputs share an order direction at runtime, not in the type.
+- `orderBy` rejects `flatMap` results at runtime (see [Rename the order key](#rename-the-order-key)).
+- Cursors are not opaque (see the warning above).

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -273,6 +273,7 @@ Resuming from a cursor doesn't re-read the pages before it: the cursor's positio
 | `numItems`                       | How many documents to return, counting only documents that pass filters.                                                                                                                                                       |
 | `endCursor`                      | When present, the page runs exactly to this cursor (inclusive) and `numItems` is ignored. Pinning pages this way keeps adjacent pages gap-free as data changes. `QueryStream.END_CURSOR` pins a page to the end of the stream. |
 | `maximumRowsRead`                | A read budget counting every document read, filtered or not. When it is hit, the page returns what it has so far with `pageStatus: "SplitRequired"` and a `splitCursor` to split the page at.                                  |
+| `maximumBytesRead`               | The same budget in bytes, charging each document's estimated size as it is read. It applies to every document the stream's index queries read, whether or not it reaches the page.                                             |
 | `pageStatus: "SplitRecommended"` | Returned with a `splitCursor` when a pinned page has grown well past `numItems`, or any page had to scan a very large number of rows for its items, so reactive clients can subdivide it.                                      |
 | `isDone`                         | `true` only when the page reached the true end of the stream.                                                                                                                                                                  |
 
@@ -292,6 +293,5 @@ Pages of a stream-paginated query are not tracked by Convex's query journal, so 
 
 ## Limitations
 
-- `maximumBytesRead` is accepted but not enforced.
 - `merge` checks that its inputs share an order direction at runtime, not in the type.
 - Cursors are not opaque (see the warning above).

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -29,7 +29,7 @@ Effect.gen(function* () {
       .stream("by_role", (q) => q.eq("author.role", role), "desc");
 
   return yield* QueryStream.merge([byRole("admin"), byRole("user")]).pipe(
-    QueryStream.filterEffect((note) => Effect.succeed(note.tag !== "hidden")),
+    QueryStream.filter((note) => note.tag !== "hidden"),
     QueryStream.paginate(paginationOpts),
   );
 });
@@ -127,21 +127,35 @@ All inputs must have the same order key and document type (type errors otherwise
 
 ### Filter and map
 
-`QueryStream.filterEffect` and `QueryStream.mapEffect` are the effectful `filter` and `map` that keep the result a query stream. You can use `Stream.filter` and `Stream.map` on a query stream too, and they behave correctly — but, like any plain `Stream` combinator, they return an ordinary `Stream` that can no longer be merged or paginated (see [Consuming a stream](#consuming-a-stream)). The `QueryStream` versions preserve the order key, and a document that `filterEffect` rejects still counts as _read_, so cursors keep advancing past it and pagination stays correct.
+`QueryStream.filter` and `QueryStream.map` are the `filter` and `map` that keep the result a query stream. You can use `Stream.filter` and `Stream.map` on a query stream too, and they behave correctly — but, like any plain `Stream` combinator, they return an ordinary `Stream` that can no longer be merged or paginated (see [Consuming a stream](#consuming-a-stream)). The `QueryStream` versions preserve the order key, and a document that `filter` rejects still counts as _read_, so cursors keep advancing past it and pagination stays correct.
 
 ```ts
 reader
   .table("notes")
   .stream("by_creation_time", "desc")
   .pipe(
-    QueryStream.filterEffect((note) => Effect.succeed(note.tag !== "hidden")),
-    QueryStream.mapEffect((note) =>
-      Effect.succeed({ id: note._id, text: note.text }),
-    ),
+    QueryStream.filter((note) => note.tag !== "hidden"),
+    QueryStream.map((note) => ({ id: note._id, text: note.text })),
   );
 ```
 
 A mapper must not change what the documents are ordered by — the mapped stream keeps the original order key.
+
+When the predicate or mapper needs to run an effect — read another table, use a service, or fail with a typed error — use `QueryStream.filterEffect` and `QueryStream.mapEffect` instead. They behave the same way, and the effect's error and requirement types flow into the stream's:
+
+```ts
+reader
+  .table("messages")
+  .stream("by_creation_time", "desc")
+  .pipe(
+    QueryStream.filterEffect((message) =>
+      reader
+        .table("users")
+        .get(message.from)
+        .pipe(Effect.map((author) => !author.banned)),
+    ),
+  );
+```
 
 ### Join
 
@@ -178,7 +192,7 @@ reader
   .pipe(QueryStream.distinct(["text"]));
 ```
 
-The fields must be a prefix of the stream's order key, which is enforced at the type level. Apply `filterEffect` _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
+The fields must be a prefix of the stream's order key, which is enforced at the type level. Apply `filter` (or `filterEffect`) _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
 
 ### Rename the order key
 
@@ -195,17 +209,19 @@ const timeline = QueryStream.merge([
     .table("messages")
     .stream("by_sent") // order key: ["sentAt", "_creationTime"]
     .pipe(
-      QueryStream.mapEffect((message) =>
-        Effect.succeed<TimelineEntry>({ kind: "message", at: message.sentAt }),
-      ),
+      QueryStream.map((message): TimelineEntry => ({
+        kind: "message",
+        at: message.sentAt,
+      })),
     ),
   reader
     .table("calls")
     .stream("by_started") // order key: ["startedAt", "_creationTime"]
     .pipe(
-      QueryStream.mapEffect((call) =>
-        Effect.succeed<TimelineEntry>({ kind: "call", at: call.startedAt }),
-      ),
+      QueryStream.map((call): TimelineEntry => ({
+        kind: "call",
+        at: call.startedAt,
+      })),
       QueryStream.orderBy(["sentAt", "_creationTime"]),
     ),
 ]);
@@ -238,9 +254,7 @@ const feed = FunctionImpl.make(
           .stream("by_role", (q) => q.eq("author.role", role), "desc");
 
       return yield* QueryStream.merge([byRole("admin"), byRole("user")]).pipe(
-        QueryStream.filterEffect((note) =>
-          Effect.succeed(note.tag !== "hidden"),
-        ),
+        QueryStream.filter((note) => note.tag !== "hidden"),
         QueryStream.paginate(paginationOpts),
       );
     }).pipe(Effect.orDie),

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -192,7 +192,7 @@ reader
   .pipe(QueryStream.distinct(["text"]));
 ```
 
-The fields must be a prefix of the stream's order key, which is enforced at the type level. Apply `filter` (or `filterEffect`) _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
+The fields must be a prefix of the stream's order key, which is enforced at the type level. On a `flatMap` result, a prefix that reaches into the inner key groups by the outer document as well, since groups are runs of consecutive equal keys. Apply `filter` (or `filterEffect`) _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
 
 ### Rename the order key
 
@@ -227,7 +227,7 @@ const timeline = QueryStream.merge([
 ]);
 ```
 
-The new key must have exactly as many fields as the old one, and the values under each position must be comparable — relabeling doesn't reorder anything. A `flatMap` result can't be relabeled (its runtime key carries tiebreakers its type omits); relabel its inputs instead.
+The new key must have exactly as many fields as the old one, and the values under each position must be comparable — relabeling doesn't reorder anything. A `flatMap` result relabels by its combined key, outer fields first.
 
 ## Paginating a stream
 
@@ -294,5 +294,4 @@ Pages of a stream-paginated query are not tracked by Convex's query journal, so 
 
 - `maximumBytesRead` is accepted but not enforced.
 - `merge` checks that its inputs share an order direction at runtime, not in the type.
-- `orderBy` rejects `flatMap` results at runtime (see [Rename the order key](#rename-the-order-key)).
 - Cursors are not opaque (see the warning above).

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -9,9 +9,11 @@ description: "Compose, merge, join, and paginate index queries as Effect streams
   end to end, but its surface may still change between prereleases.
 </Warning>
 
-A **query stream** is an Effect [`Stream`](https://effect.website/docs/stream/introduction) of decoded documents in index order that also remembers how it is ordered. That extra knowledge is what lets streams be combined — merged, filtered, joined, deduplicated — and still be paginated with cursors afterwards, which a plain `Stream` cannot do.
+Query streams are an alternative querying API to the [`index`](/server/database/reading#standard-indexes) method, built around Effect's [`Stream`](https://effect.website/docs/stream/introduction). A **query stream** is a `Stream` of decoded documents in index order that also remembers how it is ordered. That extra knowledge is what lets streams be combined — merged, filtered, joined, deduplicated — and still be paginated with cursors afterwards, which a plain `Stream` cannot do.
 
-Create one with `stream` on a table, then compose it with the `QueryStream` module from `@confect/server`:
+Everything the `index` API does, a query stream does too: `collect`, `first`, and `take` are `Stream.runCollect`, `Stream.runHead`, and `Stream.take`, and `paginate` is `QueryStream.paginate`. What `index` can't do is combine queries, so once you're comfortable with streams you can use them for every standard-index query. (Search indexes stay with [`search`](/server/database/reading#search-indexes).)
+
+Create a stream with `stream` on a table, then compose it with the `QueryStream` module from `@confect/server`:
 
 ```ts
 import { QueryStream } from "@confect/server";
@@ -125,7 +127,7 @@ All inputs must have the same order key and document type (type errors otherwise
 
 ### Filter and map
 
-`QueryStream.filterEffect` and `QueryStream.mapEffect` are the effectful `filter` and `map`, with one difference from their `Stream` counterparts: a document that is filtered out still counts as _read_, so cursors keep advancing past it and pagination stays correct.
+`QueryStream.filterEffect` and `QueryStream.mapEffect` are the effectful `filter` and `map` that keep the result a query stream. You can use `Stream.filter` and `Stream.map` on a query stream too, and they behave correctly — but, like any plain `Stream` combinator, they return an ordinary `Stream` that can no longer be merged or paginated (see [Consuming a stream](#consuming-a-stream)). The `QueryStream` versions preserve the order key, and a document that `filterEffect` rejects still counts as _read_, so cursors keep advancing past it and pagination stays correct.
 
 ```ts
 reader

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -5,8 +5,8 @@ description: "Compose, merge, join, and paginate index queries as Effect streams
 ---
 
 <Warning>
-  Stream querying is a prototype on the `v10` prerelease line. The API is usable
-  end to end, but its surface may still change between prereleases.
+  Stream querying is experimental. The API is usable end to end on the `v10`
+  prerelease line, but its surface may still change between prereleases.
 </Warning>
 
 Query streams are an alternative querying API to the [`index`](/server/database/reading#standard-indexes) method, built around Effect's [`Stream`](https://effect.website/docs/stream/introduction). A **query stream** is a `Stream` of decoded documents in index order that also remembers how it is ordered. That extra knowledge is what lets streams be combined — merged, filtered, joined, deduplicated — and still be paginated with cursors afterwards, which a plain `Stream` cannot do.


### PR DESCRIPTION
**Stack 8/8** — [1: QueryStream core (#597)] · [2: push-down narrow (#598)] · [3: combinators (#599)] · [4: React hook (#600)] · [5: example feed (#601)] · [6: maximumBytesRead (#636)] · [7: Foldkit pinning (#637)] ← **docs**

Builds on #637. Documents the experimental stream-first querying API on the docs site — no published-package changes, no changeset. Sits at the top of the stack so every documented feature lands before its page does.

## What's in this layer

- **New page `server/database/streams`** ("Streams", in the Database group after Reading): frames query streams as an alternative to the `index` API for standard-index queries (`collect`/`first`/`take`/`paginate` map to their stream forms) and how `table.stream(...)` differs from `.index(...).stream()`; creating streams with the typed range callback and what an order key is; consuming a stream with plain `Stream` combinators (and what that gives up); each `QueryStream` combinator — `merge`, `filter`/`map` (with `filterEffect`/`mapEffect` for effectful predicates and mappers), `flatMap`, `distinct`, `orderBy`, `unique` — with a short example and its constraints, including how `orderBy` and `distinct` treat a join's key; `paginate` in a paginated-query handler, the pagination protocol fields as a table (`cursor`, `numItems`, `endCursor`, `maximumRowsRead`, `maximumBytesRead`, `SplitRequired`/`SplitRecommended`, `isDone`), the `InvalidCursor` signal, and a warning that cursors carry order-key values; pointers to the React hook and to Foldkit's paginator; and the known limitations. The page opens with an experimental/prerelease warning.
- **`useStreamPaginatedQuery` section** on the React clients page, next to `usePaginatedQuery`: why it exists (no query journal for stream pages), what it guarantees (pinned, gap-free pages; splitting), same call shape/result as `usePaginatedQuery`, the `maximumRowsRead` and `maximumBytesRead` options, and invalid-cursor reset.
- A one-line pointer from the Reading page's `stream` method to the composable form, and the navigation entry in `docs.json`.

## Verification

- Every example was checked against the actual API (a probe confirmed `merge` requires a shared document type, so the `orderBy` example maps both sides to a common shape first).
- `pnpm check` green (Oxfmt formats the MDX fenced code).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m