### PR TITLE
Stream-first querying: enforce maximumBytesRead

### DIFF
--- a/.changeset/stream-maximum-bytes-read.md
+++ b/.changeset/stream-maximum-bytes-read.md
@@ -1,0 +1,18 @@
+---
+"@confect/server": minor
+"@confect/react": minor
+---
+
+Enforce `maximumBytesRead` in `QueryStream.paginate`, and accept it as an option of `useStreamPaginatedQuery`.
+
+`QueryStream.paginate` now charges the estimated size of every document its index queries read, filtered or not, against `paginationOpts.maximumBytesRead`; when the budget is hit the page returns what it has so far with `pageStatus: "SplitRequired"` and a `splitCursor`, just as `maximumRowsRead` does. Previously the option was accepted and ignored.
+
+`useStreamPaginatedQuery` forwards a `maximumBytesRead` option to every page alongside `maximumRowsRead`, and splits a page the server truncates for exceeding it.
+
+```ts
+const { results, status, loadMore } = useStreamPaginatedQuery(
+  refs.public.notes.feed,
+  {},
+  { initialNumItems: 10, maximumBytesRead: 512 * 1024 },
+);
+```

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -481,7 +481,8 @@ recommendation:
   improvement over `convex-helpers`' full index keys: equality-pinned values
   never leak into cursors, and merged streams with different pins share a
   cursor space by construction.
-- No `orderBy` (re-keying) yet; no `maximumBytesRead` accounting; NaN
+- `maximumBytesRead` is charged Convex's `getDocumentSize` estimate per document
+  read (as `convex-helpers` does), not the backend's exact byte accounting; NaN
   ordering subtleties are skipped.
 
 ## 8. Open questions

--- a/packages/react/src/StreamPagination.ts
+++ b/packages/react/src/StreamPagination.ts
@@ -33,21 +33,34 @@ export interface PageRequest {
   /** Present once the page is pinned to a fixed range. */
   readonly endCursor?: string;
   /**
-   * Per-page read budget, forwarded to the server so a scan-heavy page
+   * Per-page read budgets, forwarded to the server so a scan-heavy page
    * fails over to `SplitRequired` instead of exceeding query limits.
    */
   readonly maximumRowsRead?: number;
+  readonly maximumBytesRead?: number;
+}
+
+/** The per-page read budgets every growing page is requested with. */
+export interface ReadBudget {
+  readonly maximumRowsRead?: number | undefined;
+  readonly maximumBytesRead?: number | undefined;
 }
 
 /** A fresh growing-page request (no `endCursor`). */
 const growingRequest = (
   numItems: number,
   cursor: string | null,
-  maximumRowsRead: number | undefined,
-): PageRequest =>
-  maximumRowsRead === undefined
-    ? { numItems, cursor }
-    : { numItems, cursor, maximumRowsRead };
+  budget: ReadBudget,
+): PageRequest => ({
+  numItems,
+  cursor,
+  ...(budget.maximumRowsRead === undefined
+    ? {}
+    : { maximumRowsRead: budget.maximumRowsRead }),
+  ...(budget.maximumBytesRead === undefined
+    ? {}
+    : { maximumBytesRead: budget.maximumBytesRead }),
+});
 
 export interface State {
   readonly nextPageKey: number;
@@ -74,14 +87,11 @@ export const empty: State = {
 /** One growing (unpinned) page from the start of the stream. */
 export const initial = (
   initialNumItems: number,
-  maximumRowsRead?: number,
+  budget: ReadBudget = {},
 ): State => ({
   nextPageKey: 1,
   pageKeys: ["0"],
-  pages: Record.singleton(
-    "0",
-    growingRequest(initialNumItems, null, maximumRowsRead),
-  ),
+  pages: Record.singleton("0", growingRequest(initialNumItems, null, budget)),
   ongoingSplits: Record.empty(),
 });
 
@@ -123,7 +133,7 @@ export const loadMore =
   (
     continueCursor: string,
     numItems: number,
-    maximumRowsRead?: number,
+    budget: ReadBudget = {},
   ): ((state: State) => State) =>
   (state) =>
     pipe(
@@ -145,7 +155,7 @@ export const loadMore =
               pages: Record.set(
                 state.pages,
                 nextKey,
-                growingRequest(numItems, continueCursor, maximumRowsRead),
+                growingRequest(numItems, continueCursor, budget),
               ),
               ongoingSplits: state.ongoingSplits,
             };
@@ -160,7 +170,7 @@ export const loadMore =
               Record.set(pinnedKey, { ...lastPage, endCursor: continueCursor }),
               Record.set(
                 nextKey,
-                growingRequest(numItems, continueCursor, maximumRowsRead),
+                growingRequest(numItems, continueCursor, budget),
               ),
             ),
             ongoingSplits: Record.set(state.ongoingSplits, lastKey, [

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -366,12 +366,14 @@ export const useStreamPaginatedQuery = <
   options: {
     readonly initialNumItems: number;
     /**
-     * Per-page read budget forwarded as `paginationOpts.maximumRowsRead`:
-     * a page that would scan more rows than this returns truncated with
+     * Per-page read budgets forwarded as `paginationOpts.maximumRowsRead`
+     * and `paginationOpts.maximumBytesRead`: a page that would scan more
+     * rows, or read more bytes, than these returns truncated with
      * `SplitRequired` (and the hook splits it) instead of exceeding
      * Convex's query limits on a filter-heavy stream.
      */
     readonly maximumRowsRead?: number;
+    readonly maximumBytesRead?: number;
   },
 ): PaginatedQueryResult.PaginatedQueryResult<
   PaginatedQueryItem<Query>,
@@ -414,22 +416,21 @@ export const useStreamPaginatedQuery = <
         encodedArgsKey,
         options.initialNumItems,
         options.maximumRowsRead ?? null,
+        options.maximumBytesRead ?? null,
       ]),
     [
       functionReference,
       encodedArgsKey,
       options.initialNumItems,
       options.maximumRowsRead,
+      options.maximumBytesRead,
     ],
   );
 
   const freshState = () =>
     skipped
       ? StreamPagination.empty
-      : StreamPagination.initial(
-          options.initialNumItems,
-          options.maximumRowsRead,
-        );
+      : StreamPagination.initial(options.initialNumItems, options);
 
   const [tracked, setTracked] = useState(() => ({
     resetKey,
@@ -575,11 +576,7 @@ export const useStreamPaginatedQuery = <
         if (!alreadyLoadingMore) {
           alreadyLoadingMore = true;
           applyTransitions([
-            StreamPagination.loadMore(
-              continueCursor,
-              numItems,
-              options.maximumRowsRead,
-            ),
+            StreamPagination.loadMore(continueCursor, numItems, options),
           ]);
         }
       },

--- a/packages/react/test/useStreamPaginatedQuery.test.ts
+++ b/packages/react/test/useStreamPaginatedQuery.test.ts
@@ -299,6 +299,44 @@ describe("useStreamPaginatedQuery", () => {
     ]);
   });
 
+  test("forwards read budgets to every growing page", () => {
+    const budget = { maximumRowsRead: 50, maximumBytesRead: 4096 };
+    respond(
+      { numItems: 2, cursor: null, ...budget },
+      {
+        page: [{ value: "1" }, { value: "2" }],
+        isDone: false,
+        continueCursor: "c0",
+      },
+    );
+    respond(
+      { numItems: 2, cursor: null, ...budget, endCursor: "c0" },
+      {
+        page: [{ value: "1" }, { value: "2" }],
+        isDone: false,
+        continueCursor: "c0",
+      },
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useStreamPaginatedQuery(list, {}, { initialNumItems: 2, ...budget }),
+    );
+    rerender();
+
+    // Every page carries the budgets: the first page, the pinned twin it
+    // is replaced by (a pinned range can still grow past a budget), and
+    // each page `loadMore` appends.
+    const canLoadMore = current(result);
+    assert(canLoadMore._tag === "CanLoadMore");
+    act(() => {
+      canLoadMore.loadMore(2);
+    });
+    expect(subscribedOpts()).toEqual([
+      { numItems: 2, cursor: null, ...budget, endCursor: "c0" },
+      { numItems: 2, cursor: "c0", ...budget },
+    ]);
+  });
+
   test("truncates before a page the server could not fetch in full", () => {
     respond(
       { numItems: 2, cursor: null },

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -16,7 +16,9 @@
  *
  * Known limitations (all called out in the design doc):
  *
- * - No `maximumBytesRead` accounting.
+ * - `maximumBytesRead` charges each document's estimated size (Convex's
+ *   `getDocumentSize`), as `convex-helpers` does — not the exact bytes the
+ *   backend bills; NaN ordering subtleties are skipped.
  * - Cursors serialize only the *remaining* (order-key) fields, not the full
  *   index key — equality-pinned values never leak into cursors.
  */
@@ -30,6 +32,7 @@ import {
   compareValues,
   ConvexError,
   convexToJson,
+  getDocumentSize,
   jsonToConvex,
   type Value,
 } from "convex/values";
@@ -38,6 +41,7 @@ import { pipeArguments, type Pipeable } from "effect/Pipeable";
 import * as Array from "effect/Array";
 import type * as Channel from "effect/Channel";
 import * as Chunk from "effect/Chunk";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Equivalence from "effect/Equivalence";
 import * as Filter from "effect/Filter";
@@ -791,7 +795,7 @@ const makeLeaf = <Doc>(
   const eqValues = Array.take(bounds.lower.key, reflection.spec.eqCount);
   const segments = splitRange(fullIndexFields, reflection.order, bounds);
 
-  const annotated = Stream.fromIterable(segments).pipe(
+  const encodedDocuments = Stream.fromIterable(segments).pipe(
     Stream.flatMap((segment) =>
       Stream.suspend(() =>
         Stream.fromAsyncIterable(
@@ -804,6 +808,25 @@ const makeLeaf = <Doc>(
       ),
     ),
     Stream.orDie,
+  );
+
+  // Under a byte-budgeted `paginate`, every document this leaf reads is
+  // charged to the budget's counter as it is read — before any filtering
+  // downstream, matching Convex's own `maximumBytesRead` semantics. With
+  // no counter provided (the default), nothing is measured.
+  const charged = Stream.unwrap(
+    Effect.map(Effect.service(BytesRead), (counter) =>
+      counter === undefined
+        ? encodedDocuments
+        : Stream.tap(encodedDocuments, (encoded) =>
+            Effect.sync(() => {
+              counter.bytes += getDocumentSize(encoded as GenericDocument);
+            }),
+          ),
+    ),
+  );
+
+  const annotated = charged.pipe(
     Stream.mapEffect((encoded) =>
       Effect.map(
         Document.decode(reflection.tableName, reflection.tableSchema)(encoded),
@@ -1831,6 +1854,23 @@ export type PaginateOptions = ConvexPaginationOptions;
  */
 export type PaginationResult<Doc> = ConvexPaginationResult<Doc>;
 
+/** The running total a byte-budgeted `paginate` shares with its leaves. */
+interface BytesCounter {
+  bytes: number;
+}
+
+/**
+ * The byte counter a `paginate` call with a `maximumBytesRead` budget
+ * provides to the leaf streams beneath it; each leaf adds the estimated
+ * size (`getDocumentSize` from `convex/values`, as `convex-helpers` does)
+ * of every document it reads. Absent by default, so a stream measures
+ * nothing unless it runs under a byte-budgeted `paginate`.
+ */
+const BytesRead = Context.Reference<BytesCounter | undefined>(
+  "@confect/server/QueryStream/BytesRead",
+  { defaultValue: () => undefined },
+);
+
 interface PaginateState<Doc> {
   readonly page: Chunk.Chunk<Doc>;
   readonly readKeys: Chunk.Chunk<OrderKey>;
@@ -1858,8 +1898,11 @@ const midpointCursor = (readKeys: Chunk.Chunk<OrderKey>): string =>
  * - `cursor` is exclusive, `endCursor` inclusive; when `endCursor` is set,
  *   `numItems` is ignored and the page runs to the end cursor — the
  *   reactive-adjacency guarantee that keeps concurrent pages gap-free.
- * - Filtered-out elements count as read (for `maximumRowsRead`) and advance
- *   the continue cursor.
+ * - Filtered-out elements count as read (for `maximumRowsRead` and
+ *   `maximumBytesRead`) and advance the continue cursor.
+ * - `maximumBytesRead` is charged the estimated size of every document
+ *   the stream's index queries read, whether or not it reaches the page;
+ *   hitting either budget ends the page with `SplitRequired`.
  */
 export const paginate = dual<
   (
@@ -1913,30 +1956,44 @@ export const paginate = dual<
       // With an endCursor the page runs to it, however many items that is.
       const maxRows = Option.isSome(endCursor) ? undefined : options.numItems;
       const maximumRowsRead = options.maximumRowsRead;
+      const maximumBytesRead = options.maximumBytesRead;
+      // A fresh counter per run, provided to the leaves only when there is
+      // a byte budget to charge against.
+      const bytesRead: BytesCounter = { bytes: 0 };
+      const withBytesBudget = <A, E2, R2>(
+        effect: Effect.Effect<A, E2, R2>,
+      ): Effect.Effect<A, E2, R2> =>
+        maximumBytesRead === undefined
+          ? effect
+          : Effect.provideService(effect, BytesRead, bytesRead);
 
-      return Stream.run(
-        narrowed.annotated,
-        Sink.fold(
-          initialPaginateState<Doc>,
-          (state) => !state.stopped,
-          (state, [doc, key]: Element<Doc>) => {
-            const readKeys = Chunk.append(state.readKeys, key);
-            const page = Option.match(doc, {
-              onNone: () => state.page,
-              onSome: (value) => Chunk.append(state.page, value),
-            });
-            const hitLimit =
-              maximumRowsRead !== undefined &&
-              Chunk.size(readKeys) >= maximumRowsRead;
-            return Effect.succeed<PaginateState<Doc>>({
-              page,
-              readKeys,
-              hitLimit,
-              stopped:
-                hitLimit ||
-                (maxRows !== undefined && Chunk.size(page) >= maxRows),
-            });
-          },
+      return withBytesBudget(
+        Stream.run(
+          narrowed.annotated,
+          Sink.fold(
+            initialPaginateState<Doc>,
+            (state) => !state.stopped,
+            (state, [doc, key]: Element<Doc>) => {
+              const readKeys = Chunk.append(state.readKeys, key);
+              const page = Option.match(doc, {
+                onNone: () => state.page,
+                onSome: (value) => Chunk.append(state.page, value),
+              });
+              const hitLimit =
+                (maximumRowsRead !== undefined &&
+                  Chunk.size(readKeys) >= maximumRowsRead) ||
+                (maximumBytesRead !== undefined &&
+                  bytesRead.bytes >= maximumBytesRead);
+              return Effect.succeed<PaginateState<Doc>>({
+                page,
+                readKeys,
+                hitLimit,
+                stopped:
+                  hitLimit ||
+                  (maxRows !== undefined && Chunk.size(page) >= maxRows),
+              });
+            },
+          ),
         ),
       ).pipe(
         Effect.map((state): PaginationResult<Doc> => {

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -2,6 +2,7 @@ import { type Document, QueryStream } from "@confect/server";
 import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { assertEquals } from "@effect/vitest/utils";
 import * as Context from "effect/Context";
+import { getDocumentSize, type Value } from "convex/values";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
@@ -362,6 +363,87 @@ describe("QueryStream", () => {
           assertEquals(result.isDone, false);
           assertEquals(result.pageStatus, "SplitRequired");
           expect(result.splitCursor).toBeDefined();
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("paginate reports SplitRequired when maximumBytesRead is hit", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          // Equal-sized documents, and a budget of two and a half of them,
+          // so a page admits exactly three.
+          yield* insertNotes(
+            ["a", "b", "c", "d", "e"].map((text) => text.padEnd(100, ".")),
+          );
+
+          const reader = yield* DatabaseReader;
+          const notes = reader.table("notes").stream("by_text");
+          const initials = (page: ReadonlyArray<{ text: string }>) =>
+            page.map((note) => note.text[0]);
+          const [first] = yield* Stream.runCollect(notes);
+          const maximumBytesRead =
+            2.5 * getDocumentSize(first as unknown as Record<string, Value>);
+
+          const page = yield* QueryStream.paginate(notes, {
+            numItems: 10,
+            cursor: null,
+            maximumBytesRead,
+          });
+          expect(initials(page.page)).toEqual(["a", "b", "c"]);
+          expect(page.pageStatus).toEqual("SplitRequired");
+          assertEquals(page.isDone, false);
+
+          // The budget is per call: resuming reads the rest.
+          const rest = yield* QueryStream.paginate(notes, {
+            numItems: 10,
+            cursor: page.continueCursor,
+            maximumBytesRead,
+          });
+          expect(initials(rest.page)).toEqual(["d", "e"]);
+          assertEquals(rest.isDone, true);
+
+          // Without a budget nothing is measured.
+          const whole = yield* QueryStream.paginate(notes, {
+            numItems: 10,
+            cursor: null,
+          });
+          expect(whole.page).toHaveLength(5);
+
+          // The budget reaches the leaves through combinators: a merge of
+          // two ranges (which pre-fetches from both) still stops early and
+          // covers every document across its pages.
+          const merged = QueryStream.merge([
+            reader.table("notes").stream("by_text", (q) => q.lt("text", "c")),
+            reader.table("notes").stream("by_text", (q) => q.gte("text", "c")),
+          ]);
+          const budgeted = (
+            cursor: string | null,
+            pages: ReadonlyArray<ReadonlyArray<string>>,
+          ): Effect.Effect<
+            ReadonlyArray<ReadonlyArray<string>>,
+            Document.DocumentDecodeError
+          > =>
+            QueryStream.paginate(merged, {
+              numItems: 10,
+              cursor,
+              maximumBytesRead,
+            }).pipe(
+              Effect.flatMap((result) =>
+                result.isDone
+                  ? Effect.succeed([...pages, initials(result.page)])
+                  : budgeted(result.continueCursor, [
+                      ...pages,
+                      initials(result.page),
+                    ]),
+              ),
+            );
+          const pages = yield* budgeted(null, []);
+          expect(pages.length).toBeGreaterThan(1);
+          expect(pages.flat()).toEqual(["a", "b", "c", "d", "e"]);
         }),
       );
     }).pipe(Effect.provide(TestConfect.layer)),


### PR DESCRIPTION
**Stack 6/8** — [1: QueryStream core (#597)] · [2: push-down narrow (#598)] · [3: combinators (#599)] · [4: React hook (#600)] · [5: example feed (#601)] ← **maximumBytesRead** · [7: Foldkit pinning (#637)] · [8: docs (#634)]

Builds on #601. Enforces the one pagination-protocol option the stack had accepted but ignored. (Replaces #635, which GitHub auto-marked as merged when the docs branch was moved above this one.)

## What's in this layer

- **Byte accounting in `QueryStream.paginate`**: when `paginationOpts.maximumBytesRead` is set, `paginate` provides a fiber-local byte counter (an Effect `Context.Reference`, absent by default) for the duration of the run, and every leaf charges the estimated size of each document it reads to it as the document comes off the index query — before any filtering, matching Convex's "bytes entering the pipeline" semantics, and using the same `getDocumentSize` estimate from `convex/values` that `convex-helpers` uses. Hitting the budget ends the page with `pageStatus: "SplitRequired"` and a `splitCursor`, exactly like `maximumRowsRead`.
- The counter reaches leaves through any combinator (merge, join, distinct's re-queries) without changing the annotated element shape, and a stream outside a byte-budgeted `paginate` measures nothing — the leaf reads the reference once per run and taps documents only when a counter is present.
- **`useStreamPaginatedQuery`** accepts `maximumBytesRead` alongside `maximumRowsRead`; the state machine's growing-page requests take a `ReadBudget` and every page (growing and pinned — a pinned range can still grow past a budget) carries both. Foldkit's paginator already forwarded the option, so it needed no change here.
- Changeset covers `@confect/server` and `@confect/react`. The docs for the budget live in the docs layer above.

## Verification

- Mock-backend test: equal-sized documents with a budget of two and a half of them yield a three-document `SplitRequired` page, resuming reads the rest, no budget reads everything, and a byte-budgeted merge of two ranges stops early yet covers every document across its pages (the counter reaches leaves through the k-way merge's pulls).
- Hook test: both budgets are forwarded on the first page, its pinned twin, and the page `loadMore` appends.
- `pnpm check`, the server stream suite, the React suite, and the full `pnpm test` run are green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m