### PR TITLE
Stream-first querying: pin pages in Foldkit's paginator

### DIFF
--- a/.changeset/foldkit-pinned-pages.md
+++ b/.changeset/foldkit-pinned-pages.md
@@ -1,0 +1,7 @@
+---
+"@confect/foldkit": minor
+---
+
+`PaginatedQuery.next` now pins the page it leaves to the range it displayed, so `PaginatedQuery.prev` reloads exactly that range — from the page's cursor to its continuation cursor — rather than the first `initialNumItems` documents after its cursor. Going back and forward no longer skips or repeats documents when the data has changed in between.
+
+This also makes the machine work with paginated queries built on `QueryStream.paginate`, which have no query journal to remember page ranges.

--- a/apps/docs/clients/foldkit.mdx
+++ b/apps/docs/clients/foldkit.mdx
@@ -480,6 +480,15 @@ earlier identical session. Options use Convex's names: `initialNumItems` is
 required, while `maximumRowsRead` and `maximumBytesRead` are optional positive
 integers.
 
+When you navigate forward, the page you leave is pinned to the range it
+displayed — from its cursor to its continuation cursor — so going back reloads
+exactly that range, however the data has moved since. This is what keeps
+consecutive pages gap-free and duplicate-free for
+[stream-paginated queries](/server/database/streams#paginate), which have no
+query journal to remember page ranges. The page currently on screen is a live
+window of `initialNumItems` documents from its cursor, so it stays full as
+documents are inserted and deleted.
+
 <Note>
   Convex may signal that a page has grown too large by recommending or requiring
   a page split. The machine handles the full protocol transparently: the current

--- a/packages/foldkit/src/PaginatedQuery.ts
+++ b/packages/foldkit/src/PaginatedQuery.ts
@@ -543,7 +543,17 @@ export const reset = <Item_, UserArgs_, Error_>(
   phase: pendingPhase(phaseData(state.phase), "Reset"),
 });
 
-/** Navigate to the next page, retaining the current page while it loads. */
+/**
+ * Navigate to the next page, retaining the current page while it loads.
+ *
+ * The page being left is pushed onto the stack *pinned* to the range it
+ * displayed — its cursor to its continuation cursor — so `prev` reloads
+ * exactly that range rather than the first `initialNumItems` documents
+ * after its cursor, however the data has moved meanwhile. Convex's own
+ * pagination keeps that range in its query journal; stream-paginated
+ * queries have no journal, so the pin is what keeps consecutive pages
+ * gap-free and duplicate-free for them.
+ */
 export const next = <Item_, UserArgs_, Error_>(
   state: Active<Item_, UserArgs_, Error_>,
 ): Option.Option<Active<Item_, UserArgs_, Error_>> =>
@@ -553,24 +563,25 @@ export const next = <Item_, UserArgs_, Error_>(
       Match.value(data.isDone).pipe(
         Match.withReturnType<Option.Option<Active<Item_, UserArgs_, Error_>>>(),
         Match.when(true, () => Option.none()),
-        Match.when(false, () =>
-          Option.some({
+        Match.when(false, () => {
+          const end = Option.getOrElse(
+            data.descriptor.endCursor,
+            () => data.continueCursor,
+          );
+          return Option.some({
             ...state,
             requestId: state.requestId + 1,
-            current: {
-              cursor: Option.getOrElse(
-                data.descriptor.endCursor,
-                () => data.continueCursor,
-              ),
-              endCursor: Option.none(),
-            },
-            prevStack: [...state.prevStack, data.descriptor],
+            current: { cursor: end, endCursor: Option.none() },
+            prevStack: [
+              ...state.prevStack,
+              { cursor: data.descriptor.cursor, endCursor: Option.some(end) },
+            ],
             phase: Phase.Refreshing<Item_, Error_>({
               data,
               direction: "Next",
             }),
-          }),
-        ),
+          });
+        }),
         Match.exhaustive,
       ),
     ),

--- a/packages/foldkit/test/PaginatedQuery.test.ts
+++ b/packages/foldkit/test/PaginatedQuery.test.ts
@@ -325,7 +325,9 @@ describe("PaginatedQuery", () => {
       ) as Active;
       const returning = Option.getOrThrow(PaginatedQuery.prev(pageTwo));
 
-      expect(returning.current).toEqual(firstPageRequest.descriptor);
+      // Returning targets page one's pinned range under a new request id;
+      // a late outcome for the original, unpinned request is ignored.
+      expect(returning.current).toEqual(descriptor(null, "c1"));
       expect(returning.requestId).not.toBe(firstPageRequest.requestId);
       expect(
         PaginatedQuery.settle(returning, {
@@ -350,7 +352,8 @@ describe("PaginatedQuery", () => {
       const phase = getPhase(state, "Refreshing");
 
       expect(state.current).toEqual(descriptor("c1"));
-      expect(state.prevStack).toEqual([descriptor(null)]);
+      // The page left behind is pinned to the range it displayed.
+      expect(state.prevStack).toEqual([descriptor(null, "c1")]);
       expect(phase.direction).toBe("Next");
       expect(phase.data.number).toBe(1);
       expect(PaginatedQuery.targetPageNumber(state)).toBe(2);
@@ -366,9 +369,37 @@ describe("PaginatedQuery", () => {
       ) as Active;
       const state = Option.getOrThrow(PaginatedQuery.prev(pageTwo));
 
-      expect(state.current).toEqual(descriptor(null));
+      expect(state.current).toEqual(descriptor(null, "c1"));
       expect(state.prevStack).toEqual([]);
       expect(getPhase(state, "Refreshing").direction).toBe("Previous");
+    });
+
+    it("reloads a pinned range on prev and continues past it on next", () => {
+      const loadingTwo = Option.getOrThrow(
+        PaginatedQuery.next(loadedPageOne()),
+      );
+      const pageTwo = PaginatedQuery.settle(
+        loadingTwo,
+        success(loadingTwo, [{ text: "c" }], { continueCursor: "c2" }),
+      ) as Active;
+      const loadingOne = Option.getOrThrow(PaginatedQuery.prev(pageTwo));
+      // Page one reloads its pinned range, which may hold more or fewer
+      // documents than it did — but never a different range.
+      const pageOne = PaginatedQuery.settle(
+        loadingOne,
+        success(loadingOne, [{ text: "a" }, { text: "a2" }, { text: "b" }], {
+          continueCursor: "c1",
+        }),
+      ) as Active;
+      expect(getPhase(pageOne, "Success").data.descriptor).toEqual(
+        descriptor(null, "c1"),
+      );
+
+      // Going forward again starts page two at the pin, not at whatever
+      // continuation cursor the reloaded page reports.
+      const forward = Option.getOrThrow(PaginatedQuery.next(pageOne));
+      expect(forward.current).toEqual(descriptor("c1"));
+      expect(forward.prevStack).toEqual([descriptor(null, "c1")]);
     });
 
     it("first returns to page one without replacing the session", () => {
@@ -416,7 +447,7 @@ describe("PaginatedQuery", () => {
         success(loadingTwo, [], { isDone: true }),
       ) as Active;
 
-      expect(state.current).toEqual(descriptor(null));
+      expect(state.current).toEqual(descriptor(null, "c1"));
       expect(state.prevStack).toEqual([]);
       expect(getPhase(state, "Refreshing").direction).toBe("Previous");
     });


### PR DESCRIPTION
**Stack 7/8** — [1: QueryStream core (#597)] · [2: push-down narrow (#598)] · [3: combinators (#599)] · [4: React hook (#600)] · [5: example feed (#601)] · [6: maximumBytesRead (#636)] ← **Foldkit pinning** · [8: docs (#634)]

Builds on #636. Makes `@confect/foldkit`'s `PaginatedQuery` machine correct on stream-paginated queries, which have no query journal to remember page ranges.

## What's in this layer

- **`PaginatedQuery.next` pins the page it leaves.** The departing page's descriptor is pushed onto the back stack with `endCursor` set to the range the page displayed (its cursor to its continuation cursor, or an existing split pin), so `prev` reloads exactly that range and a later `next` continues from the pin. Previously the stack held the bare cursor, so going back refetched the first `initialNumItems` documents after it — a different range once documents had been inserted or deleted, with pages overlapping or skipping. Convex's native pagination masked this via the journal; `QueryStream.paginate` ignores the journal id, so on streams the drift was unavoidable.
- The live page stays a window of `initialNumItems` from its cursor: a single-page navigator reads better full, and pinning it on load would cost a second subscription per page.
- Everything else the machine already did with the protocol (`maximumRowsRead`/`maximumBytesRead`, `SplitRequired`/`SplitRecommended`, `InvalidCursor` reset) is unchanged — this stack's byte budget in #636 needed no Foldkit change, since the machine forwarded the option already.
- Docs: the Foldkit page explains the pinning and its relation to stream queries. A `@confect/foldkit` minor changeset describes the navigation change, which applies to native paginated queries too.

## Verification

- Machine tests: `next` pushes the pinned descriptor, `prev` targets it, retreat from an empty terminal page lands on it, a late outcome for the original unpinned request is ignored, and a new test walks next → prev (range reloads with a different item count) → next (continues from the pin, not the reloaded page's continuation cursor).
- `pnpm check` and the full `pnpm test` run are green at this commit and at the stack tip.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m)_