### PR TITLE
Stream-first querying: empty, leftJoin, and effect concurrency

### DIFF
--- a/.changeset/stream-empty-left-join-concurrency.md
+++ b/.changeset/stream-empty-left-join-concurrency.md
@@ -1,0 +1,9 @@
+---
+"@confect/server": minor
+---
+
+Add three operations to `QueryStream`:
+
+- `QueryStream.empty` builds a query stream with no documents but a known order key and direction, so a merge over a dynamic list of streams has something to return when the list is empty: `QueryStream.empty<NotesDoc>()(["_creationTime"], "desc")`.
+- `QueryStream.leftJoin` is `flatMap` that keeps outer documents whose inner stream is empty, emitting `onEmpty(outer)` in their place — SQL's `LEFT JOIN` to `flatMap`'s inner join. The placeholder paginates like any element.
+- `QueryStream.filterEffect` and `QueryStream.mapEffect` accept `{ concurrency }` to run several documents' effects at once. Elements are still emitted in stream order, so the result remains a query stream.

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -675,6 +675,49 @@ export type Any = QueryStream<any, any, any, any, any>;
 export const isQueryStream = (u: unknown): u is Any =>
   Predicate.hasProperty(u, TypeId);
 
+/**
+ * An empty query stream with the given order key and direction — the
+ * `merge` input for a dynamic list of streams that may turn out empty.
+ *
+ * - As a stream: `Stream.empty` that still knows its order key, so it
+ *   merges with, and paginates like, any stream of that key.
+ * - In SQL: the empty relation — `SELECT ... WHERE false` with the same
+ *   `ORDER BY`.
+ *
+ * Nothing can infer the document type from no documents, so it is supplied
+ * as a type argument in a first, otherwise empty call:
+ * `QueryStream.empty<NotesDoc>()(["text", "_creationTime"], "desc")`. The
+ * key is the type-level order key of the streams it will be merged with
+ * (the index fields that still vary, tiebreaker included).
+ */
+export const empty =
+  <Doc>(): {
+    <const Key extends ReadonlyArray<string>>(
+      key: Key,
+    ): QueryStream<Doc, Types.Mutable<Key>, never, never, "asc">;
+    <const Key extends ReadonlyArray<string>, Direction extends OrderDirection>(
+      key: Key,
+      order: Direction,
+    ): QueryStream<Doc, Types.Mutable<Key>, never, never, Direction>;
+  } =>
+  (key: ReadonlyArray<string>, order: OrderDirection = "asc") => {
+    const keyFields = withIdTiebreaker(key);
+    const tiebreakers = appendedTiebreaker(key, keyFields);
+    // `any` in the key and direction slots: the overloads above assign the
+    // literal types the caller supplied.
+    const make = (): QueryStream<Doc, any, never, never, any> =>
+      new QueryStream(
+        order,
+        keyFields,
+        Stream.empty,
+        undefined,
+        // Narrowing nothing is nothing.
+        () => make(),
+        tiebreakers,
+      );
+    return make();
+  };
+
 // -----------------------------------------------------------------------------
 // Constructors
 // -----------------------------------------------------------------------------
@@ -1158,21 +1201,38 @@ const transformEffect = <
 >(
   self: QueryStream<Doc, Key, E, R, Direction>,
   f: (doc: Doc) => Effect.Effect<Option.Option<Doc2>, E2, R2>,
+  options: EffectOptions | undefined,
 ): QueryStream<Doc2, Key, E | E2, R | R2, Direction> =>
   new QueryStream(
     self.order,
     self.keyFields,
-    Stream.mapEffect(self.annotated, ([doc, key]) =>
-      Option.match(doc, {
-        onNone: () => Effect.succeed([Option.none<Doc2>(), key] as const),
-        onSome: (value) =>
-          Effect.map(f(value), (mapped) => [mapped, key] as const),
-      }),
+    Stream.mapEffect(
+      self.annotated,
+      ([doc, key]) =>
+        Option.match(doc, {
+          onNone: () => Effect.succeed([Option.none<Doc2>(), key] as const),
+          onSome: (value) =>
+            Effect.map(f(value), (mapped) => [mapped, key] as const),
+        }),
+      // Order is preserved at any concurrency: elements are emitted in
+      // input order however their effects finish.
+      { concurrency: options?.concurrency },
     ),
     undefined,
-    (keyBounds) => transformEffect(narrowByKeyBounds(self, keyBounds), f),
+    (keyBounds) =>
+      transformEffect(narrowByKeyBounds(self, keyBounds), f, options),
     self.tiebreakers,
   );
+
+/** Options for the effectful transforms (`filterEffect`, `mapEffect`). */
+export interface EffectOptions {
+  /**
+   * How many documents' effects may run at once (`"unbounded"` for all).
+   * Elements are emitted in stream order regardless, so the result stays
+   * a query stream with the same order key. Defaults to one at a time.
+   */
+  readonly concurrency?: number | "unbounded" | undefined;
+}
 
 /**
  * Filter with a pure predicate — `Stream.filter` that keeps the stream
@@ -1214,6 +1274,7 @@ export const filter = dual<
 export const filterEffect = dual<
   <Doc, E2, R2>(
     predicate: (doc: Doc) => Effect.Effect<boolean, E2, R2>,
+    options?: EffectOptions,
   ) => <
     Key extends ReadonlyArray<string>,
     E,
@@ -1233,13 +1294,19 @@ export const filterEffect = dual<
   >(
     self: QueryStream<Doc, Key, E, R, Direction>,
     predicate: (doc: Doc) => Effect.Effect<boolean, E2, R2>,
+    options?: EffectOptions,
   ) => QueryStream<Doc, Key, E | E2, R | R2, Direction>
->(2, (self, predicate) =>
-  transformEffect(self, (doc) =>
-    Effect.map(predicate(doc), (keep) =>
-      keep ? Option.some(doc) : Option.none(),
+>(
+  (args) => isQueryStream(args[0]),
+  (self, predicate, options) =>
+    transformEffect(
+      self,
+      (doc) =>
+        Effect.map(predicate(doc), (keep) =>
+          keep ? Option.some(doc) : Option.none(),
+        ),
+      options,
     ),
-  ),
 );
 
 /**
@@ -1280,6 +1347,7 @@ export const map = dual<
 export const mapEffect = dual<
   <Doc, Doc2, E2, R2>(
     f: (doc: Doc) => Effect.Effect<Doc2, E2, R2>,
+    options?: EffectOptions,
   ) => <
     Key extends ReadonlyArray<string>,
     E,
@@ -1300,9 +1368,12 @@ export const mapEffect = dual<
   >(
     self: QueryStream<Doc, Key, E, R, Direction>,
     f: (doc: Doc) => Effect.Effect<Doc2, E2, R2>,
+    options?: EffectOptions,
   ) => QueryStream<Doc2, Key, E | E2, R | R2, Direction>
->(2, (self, f) =>
-  transformEffect(self, (doc) => Effect.map(f(doc), Option.some)),
+>(
+  (args) => isQueryStream(args[0]),
+  (self, f, options) =>
+    transformEffect(self, (doc) => Effect.map(f(doc), Option.some), options),
 );
 
 /**
@@ -1381,6 +1452,83 @@ export const flatMap = dual<
     f,
     innerKeyFields,
     appendedTiebreaker(options.innerKey, innerKeyFields),
+    undefined,
+    {},
+  );
+});
+
+/**
+ * A left join: `flatMap` that keeps outer documents whose inner stream is
+ * empty, emitting `onEmpty(outer)` in their place.
+ *
+ * - As a stream: `flatMap` whose empty inner streams are replaced by one
+ *   element, so every outer document contributes at least one.
+ * - In SQL: `LEFT JOIN LATERAL` — an outer row with no inner rows still
+ *   appears once, with `onEmpty` standing in for the `NULL` inner columns.
+ *
+ * The placeholder takes the position an empty inner stream's marker would
+ * (the outer key followed by `null`s), so it sorts first within its outer
+ * document and pagination resumes past it like any element. Outer
+ * documents filtered out upstream stay absent. Everything else — the
+ * `innerKey` check, the direction rules, narrowing — is `flatMap`'s.
+ */
+export const leftJoin = dual<
+  <
+    Doc,
+    Doc2,
+    Doc3,
+    InnerKey extends ReadonlyArray<string>,
+    E2,
+    R2,
+    Direction extends OrderDirection,
+  >(
+    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
+    options: {
+      readonly innerKey: NoInfer<InnerKey>;
+      readonly onEmpty: (doc: Doc) => Doc3;
+    },
+  ) => <Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R, Direction>,
+  ) => QueryStream<
+    Doc2 | Doc3,
+    readonly [...Key, ...InnerKey],
+    E | E2,
+    R | R2,
+    Direction
+  >,
+  <
+    Doc,
+    Key extends ReadonlyArray<string>,
+    E,
+    R,
+    Doc2,
+    Doc3,
+    InnerKey extends ReadonlyArray<string>,
+    E2,
+    R2,
+    Direction extends OrderDirection,
+  >(
+    self: QueryStream<Doc, Key, E, R, Direction>,
+    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, NoInfer<Direction>>,
+    options: {
+      readonly innerKey: NoInfer<InnerKey>;
+      readonly onEmpty: (doc: Doc) => Doc3;
+    },
+  ) => QueryStream<
+    Doc2 | Doc3,
+    readonly [...Key, ...InnerKey],
+    E | E2,
+    R | R2,
+    Direction
+  >
+>(3, (self, f, options) => {
+  const innerKeyFields = withIdTiebreaker(options.innerKey);
+  return makeFlatMap(
+    self,
+    f,
+    innerKeyFields,
+    appendedTiebreaker(options.innerKey, innerKeyFields),
+    options.onEmpty,
     {},
   );
 });
@@ -1442,14 +1590,17 @@ const makeFlatMap = <
   E2,
   R2,
   Direction extends OrderDirection,
+  Doc3 = never,
 >(
   self: QueryStream<Doc, Key, E, R, Direction>,
   f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
   innerKeyFields: ReadonlyArray<string>,
   innerTiebreakers: ReadonlyArray<number>,
+  /** Present for a left join: what an outer document with no inner rows emits. */
+  onEmpty: ((doc: Doc) => Doc3) | undefined,
   refinements: InnerRefinements,
 ): QueryStream<
-  Doc2,
+  Doc2 | Doc3,
   readonly [...Key, ...InnerKey],
   E | E2,
   R | R2,
@@ -1505,34 +1656,44 @@ const makeFlatMap = <
         : Option.none(),
   });
 
+  // The single element an outer document contributes when it has no inner
+  // elements: filtered (cursor accounting only), or — for a left join — the
+  // `onEmpty` placeholder. Either sits at the outer key followed by `null`s,
+  // and is emitted only if that position is within the inner bounds.
   const markerStream = (
     outerKey: OrderKey,
     innerBounds: KeyBounds,
-  ): Stream.Stream<Element<Doc2>> =>
+    doc: Option.Option<Doc2 | Doc3>,
+  ): Stream.Stream<Element<Doc2 | Doc3>> =>
     admittedByLower(innerBounds.lower)(nullPadding) &&
     admittedByUpper(innerBounds.upper)(nullPadding)
-      ? Stream.succeed([
-          Option.none<Doc2>(),
-          Array.appendAll(outerKey, nullPadding),
-        ] as const)
+      ? Stream.succeed([doc, Array.appendAll(outerKey, nullPadding)] as const)
       : Stream.empty;
 
   const annotated: Stream.Stream<
-    Element<Doc2>,
+    Element<Doc2 | Doc3>,
     E | E2,
     R | R2
   > = self.annotated.pipe(
     Stream.flatMap(([outerDoc, outerKey]) => {
       const innerBounds = innerBoundsFor(outerKey);
       return Option.match(outerDoc, {
-        onNone: () => markerStream(outerKey, innerBounds),
+        onNone: () => markerStream(outerKey, innerBounds, Option.none()),
         onSome: (doc) =>
           narrowByKeyBounds(validated(f(doc)), innerBounds).annotated.pipe(
             Stream.map(
               ([innerDoc, innerKey]) =>
                 [innerDoc, Array.appendAll(outerKey, innerKey)] as const,
             ),
-            Stream.orElseIfEmpty(() => markerStream(outerKey, innerBounds)),
+            Stream.orElseIfEmpty(() =>
+              markerStream(
+                outerKey,
+                innerBounds,
+                onEmpty === undefined
+                  ? Option.none()
+                  : Option.some(onEmpty(doc)),
+              ),
+            ),
           ),
       });
     }),
@@ -1576,6 +1737,7 @@ const makeFlatMap = <
         f,
         innerKeyFields,
         innerTiebreakers,
+        onEmpty,
         {
           lower: combineLowerRefinements(refinements.lower, lower.refinement),
           upper: combineUpperRefinements(refinements.upper, upper.refinement),

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -1,6 +1,7 @@
 import { type Document, QueryStream } from "@confect/server";
 import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { assertEquals } from "@effect/vitest/utils";
+import * as Array from "effect/Array";
 import * as Context from "effect/Context";
 import { getDocumentSize, type Value } from "convex/values";
 import * as Effect from "effect/Effect";
@@ -166,6 +167,52 @@ describe("QueryStream", () => {
               .stream("by_text", (q) => q.eq("text", "apple")),
           );
           expect(exactly).toEqual(["apple"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("empty merges with, and paginates like, streams of its key", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["a", "b"]);
+
+          const reader = yield* DatabaseReader;
+          const notes = reader.table("notes").stream("by_text");
+          type Note =
+            typeof notes extends Stream.Stream<infer A, any, any> ? A : never;
+          const nothing = QueryStream.empty<Note>()(["text", "_creationTime"]);
+
+          expect(
+            yield* collectTexts(QueryStream.merge([nothing, notes])),
+          ).toEqual(["a", "b"]);
+          const page = yield* QueryStream.paginate(nothing, {
+            numItems: 5,
+            cursor: null,
+          });
+          expect(page.page).toEqual([]);
+          assertEquals(page.isDone, true);
+
+          // The case it exists for: a merge over a list that may be empty.
+          const only = (texts: ReadonlyArray<string>) =>
+            Array.match(texts, {
+              onEmpty: () => nothing,
+              onNonEmpty: (some) =>
+                QueryStream.merge(
+                  Array.map(some, (text) =>
+                    reader
+                      .table("notes")
+                      .stream("by_text", (q) =>
+                        q.gte("text", text).lte("text", text),
+                      ),
+                  ),
+                ),
+            });
+          expect(yield* collectTexts(only([]))).toEqual([]);
+          expect(yield* collectTexts(only(["b", "a"]))).toEqual(["a", "b"]);
         }),
       );
     }).pipe(Effect.provide(TestConfect.layer)),
@@ -727,6 +774,113 @@ describe("QueryStream", () => {
             ["a2"],
             ["b1"],
           ]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("leftJoin keeps outer documents that have no inner rows", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          for (const [text, tag] of [
+            ["b", "b1"],
+            ["a", "a1"],
+            ["a", "a2"],
+            ["x0", "none"],
+            ["x1", "a"],
+            ["x2", "b"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const outer = reader
+            .table("notes")
+            .stream("by_text", (q) => q.gte("text", "x"));
+          type Note =
+            typeof outer extends Stream.Stream<infer A, any, any> ? A : never;
+          const inner = (note: Note) =>
+            reader
+              .table("notes")
+              .stream("by_text", (q) => q.eq("text", note.tag ?? ""));
+
+          // "x0" has no inner rows: the placeholder stands in for them, in
+          // the position its inner rows would have had, and pagination
+          // steps past it like any element.
+          const joined = outer.pipe(
+            QueryStream.leftJoin(inner, {
+              innerKey: ["_creationTime"],
+              onEmpty: (note) => ({ tag: `none for ${note.text}` }),
+            }),
+          );
+          const pages = yield* paginateAll(joined, 1);
+          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+            ["none for x0"],
+            ["a1"],
+            ["a2"],
+            ["b1"],
+          ]);
+
+          // An outer document filtered out upstream contributes no
+          // placeholder.
+          const withoutX0 = outer.pipe(
+            QueryStream.filter((note) => note.text !== "x0"),
+            QueryStream.leftJoin(inner, {
+              innerKey: ["_creationTime"],
+              onEmpty: (note) => ({ tag: `none for ${note.text}` }),
+            }),
+          );
+          expect(
+            yield* Stream.runCollect(withoutX0).pipe(
+              Effect.map((docs) => docs.map((doc) => doc.tag)),
+            ),
+          ).toEqual(["a1", "a2", "b1"]);
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
+  it.effect("effectful transforms keep stream order at any concurrency", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          yield* insertNotes(["c", "a", "b"]);
+
+          const reader = yield* DatabaseReader;
+          const notes = reader.table("notes").stream("by_text");
+          // The first element's effect finishes last.
+          const slowForA = (text: string) =>
+            Effect.succeed(text.toUpperCase()).pipe(
+              Effect.delay(text === "a" ? "30 millis" : "1 millis"),
+            );
+
+          const shouted = notes.pipe(
+            QueryStream.mapEffect((note) => slowForA(note.text), {
+              concurrency: "unbounded",
+            }),
+          );
+          expect(yield* Stream.runCollect(shouted)).toEqual(["A", "B", "C"]);
+
+          const withoutB = QueryStream.filterEffect(
+            notes,
+            (note) => Effect.map(slowForA(note.text), (text) => text !== "B"),
+            { concurrency: 2 },
+          );
+          expect(yield* collectTexts(withoutB)).toEqual(["a", "c"]);
+
+          // Still a query stream: it paginates.
+          const page = yield* QueryStream.paginate(shouted, {
+            numItems: 2,
+            cursor: null,
+          });
+          expect(page.page).toEqual(["A", "B"]);
         }),
       );
     }).pipe(Effect.provide(TestConfect.layer)),
@@ -1295,6 +1449,38 @@ describe("QueryStream types", () => {
       // @ts-expect-error — the new key must have as many fields as the old.
       const relabeledTooShort = QueryStream.orderBy(full, ["_creationTime"]);
       void relabeledTooShort;
+
+      // empty takes its document type explicitly and its key literally.
+      const nothing = QueryStream.empty<{ readonly text: string }>()([
+        "text",
+        "_creationTime",
+      ]);
+      expectTypeOf<KeyOf<typeof nothing>>().toEqualTypeOf<
+        ["text", "_creationTime"]
+      >();
+      expectTypeOf<DirectionOf<typeof nothing>>().toEqualTypeOf<"asc">();
+      const nothingDescending = QueryStream.empty<{ readonly text: string }>()(
+        ["text", "_creationTime"],
+        "desc",
+      );
+      expectTypeOf<
+        DirectionOf<typeof nothingDescending>
+      >().toEqualTypeOf<"desc">();
+
+      // leftJoin's elements are the inner documents or the placeholder.
+      const leftJoined = QueryStream.leftJoin(bounded, (_note) => pinned, {
+        innerKey: ["_creationTime"],
+        onEmpty: (note) => ({ missingFor: note.text }),
+      });
+      expectTypeOf<KeyOf<typeof leftJoined>>().toEqualTypeOf<
+        readonly ["text", "_creationTime", "_creationTime"]
+      >();
+      expectTypeOf<
+        typeof leftJoined extends Stream.Stream<infer A, any, any> ? A : never
+      >().toEqualTypeOf<
+        | (typeof pinned extends Stream.Stream<infer A, any, any> ? A : never)
+        | { missingFor: string }
+      >();
 
       // A flatMap result relabels by its type-level (tiebreaker-free) key.
       const relabeledJoin = QueryStream.orderBy(joined, ["a", "b", "c"]);


### PR DESCRIPTION
**Stack 1/3** — **empty, leftJoin, concurrency** · [2: reverse (#642)] · [3: docs (#640)]

Adds the three small operations identified while describing the API in stream and SQL terms. Code, tests, docstrings, and changeset only; the Streams page sections for these live in the docs PR at the top of the stack.

## What changed

- **`QueryStream.empty`** — a query stream with no documents but a known order key and direction. It exists for a merge over a dynamic list of streams that may be empty, since `merge` needs at least one input. Nothing can infer a document type from no documents, so the type comes first as a type argument and the key second: `QueryStream.empty<NotesDoc>()(["_creationTime"], "desc")`. Narrowing it is itself. As a stream: `Stream.empty` that still knows its key. In SQL: the empty relation with the same `ORDER BY`.
- **`QueryStream.leftJoin`** — `flatMap` that keeps outer documents whose inner stream is empty, emitting `onEmpty(outer)` in their place (`LEFT JOIN LATERAL`, with `onEmpty` standing in for the `NULL` inner columns). It reuses the join's existing empty-inner marker: the placeholder takes the marker's position (outer key followed by `null`s), so it sorts first within its outer document and pagination resumes past it like any element, and the same bounds check that suppresses a duplicate marker on resume suppresses a duplicate placeholder. Outer documents filtered out upstream stay absent. The result element type is `Doc2 | Doc3`; `makeFlatMap` gains an `onEmpty` parameter with a `Doc3 = never` default so plain `flatMap` is unchanged.
- **`{ concurrency }` on `filterEffect` and `mapEffect`** — forwarded to `Stream.mapEffect`, which emits in input order at any concurrency, so the result is the same query stream. The duals switch to an `isQueryStream`-based arity test to accept the optional third argument. Exported as `QueryStream.EffectOptions`.
- Changeset: `@confect/server` minor.

## Verification

- Mock-backend tests: `empty` merges with a leaf, paginates as done, and backs an `Array.match` over an empty and a non-empty list; `leftJoin` paginates one item per page through the placeholder (`["none for x0"], ["a1"], ["a2"], ["b1"]`) and emits no placeholder for an outer document filtered out upstream; `mapEffect` with unbounded concurrency and `filterEffect` with concurrency 2 keep stream order when the first element's effect finishes last, and the mapped stream still paginates.
- Type tests: `empty`'s key and direction, `leftJoin`'s concatenated key and `Doc2 | Doc3` element type.
- `pnpm check`, the stream suite, the full `pnpm test` run, and the type bench (within its baselines) are green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m