### PR TITLE
Stream-first querying: reverse

### DIFF
--- a/.changeset/stream-reverse.md
+++ b/.changeset/stream-reverse.md
@@ -1,0 +1,7 @@
+---
+"@confect/server": minor
+---
+
+Add `QueryStream.reverse`, which runs a composed query stream in the opposite direction. Every leaf is rebuilt with the other order, so the reversed stream reads from the index in that direction rather than collecting and reversing, and it stays a query stream: it merges and paginates like any other. The typical use is bidirectional pagination, loading a feed's earlier pages with the reverse of the stream that loads its later ones.
+
+Merges, `filter`/`map` and their effectful forms, `flatMap`/`leftJoin` (inner streams included), `orderBy`, and `empty` all reverse. A `distinct` stream throws when reversed, because the other direction would keep a different document per group; apply `distinct` to the reversed input instead.

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -84,6 +84,15 @@ export type OrderKey = ReadonlyArray<Value | undefined>;
  */
 export type OrderDirection = "asc" | "desc";
 
+/** The opposite of a direction; a runtime-chosen direction stays the union. */
+export type Flip<Direction extends OrderDirection> = Direction extends "asc"
+  ? "desc"
+  : "asc";
+
+const flipDirection = <Direction extends OrderDirection>(
+  direction: Direction,
+): Flip<Direction> => (direction === "asc" ? "desc" : "asc") as Flip<Direction>;
+
 /**
  * An element of the annotated stream: the decoded document (`None` when the
  * element was read but filtered out — it still advances cursors) paired with
@@ -627,6 +636,14 @@ export class QueryStream<
       Array.dropRight(keyFields, 1),
       keyFields,
     ),
+    /**
+     * How this stream runs in the opposite direction: leaves rebuild their
+     * Convex queries with the other `order`, and derived streams reverse
+     * their inputs and re-apply their combinator. Absent where reversing
+     * would change the result (`distinct`) or isn't possible (externally
+     * constructed streams); `reverse` then throws.
+     */
+    readonly reverseWith?: () => QueryStream<Doc, Key, E, R, Flip<Direction>>,
   ) {}
 
   toStream(): Stream.Stream<Doc, E, R> {
@@ -705,17 +722,20 @@ export const empty =
     const tiebreakers = appendedTiebreaker(key, keyFields);
     // `any` in the key and direction slots: the overloads above assign the
     // literal types the caller supplied.
-    const make = (): QueryStream<Doc, any, never, never, any> =>
+    const make = (
+      direction: OrderDirection,
+    ): QueryStream<Doc, any, never, never, any> =>
       new QueryStream(
-        order,
+        direction,
         keyFields,
         Stream.empty,
         undefined,
-        // Narrowing nothing is nothing.
-        () => make(),
+        // Narrowing nothing is nothing, and so is reversing it.
+        () => make(direction),
         tiebreakers,
+        () => make(flipDirection(direction)),
       );
-    return make();
+    return make(order);
   };
 
 // -----------------------------------------------------------------------------
@@ -947,6 +967,12 @@ const makeLeaf = <Doc, Direction extends OrderDirection>(
         }),
       }),
     tiebreakers,
+    // Bounds live in ascending key space, so the reversed leaf keeps them.
+    () =>
+      makeLeaf(
+        { ...reflection, order: flipDirection(reflection.order) },
+        bounds,
+      ),
   );
 };
 
@@ -1155,6 +1181,11 @@ const mergeUnchecked = <
         ),
       ]),
     head.tiebreakers,
+    () =>
+      mergeUnchecked([
+        reverse(head),
+        ...Array.map(Array.tailNonEmpty(streams), (stream) => reverse(stream)),
+      ]),
   );
 };
 
@@ -1186,6 +1217,7 @@ const transform = <
     undefined,
     (keyBounds) => transform(narrowByKeyBounds(self, keyBounds), f),
     self.tiebreakers,
+    () => transform(reverse(self), f),
   );
 
 /** The effectful {@link transform}. */
@@ -1222,6 +1254,7 @@ const transformEffect = <
     (keyBounds) =>
       transformEffect(narrowByKeyBounds(self, keyBounds), f, options),
     self.tiebreakers,
+    () => transformEffect(reverse(self), f, options),
   );
 
 /** Options for the effectful transforms (`filterEffect`, `mapEffect`). */
@@ -1745,6 +1778,17 @@ const makeFlatMap = <
       );
     },
     tiebreakers,
+    // Refinements are key bounds, so they carry over; the inner streams
+    // are reversed alongside the outer one to keep the direction rule.
+    () =>
+      makeFlatMap(
+        reverse(self),
+        (doc) => reverse(f(doc)),
+        innerKeyFields,
+        innerTiebreakers,
+        onEmpty,
+        refinements,
+      ),
   );
 };
 
@@ -1889,6 +1933,7 @@ const orderByImpl = <
     // stream as-is.
     (bounds) => orderByImpl(narrowByKeyBounds(self, bounds), key),
     self.tiebreakers,
+    () => orderByImpl(reverse(self), key),
   );
 };
 
@@ -1969,6 +2014,41 @@ const makeDistinct = <
       ),
     self.tiebreakers,
   );
+};
+
+/**
+ * Run a stream in the opposite direction.
+ *
+ * - As a stream: the same composition with every leaf rebuilt in the
+ *   other `order` (the elements in reverse, but read that way from the
+ *   index rather than collected and reversed), so the result is still a
+ *   query stream — a paginated feed can load its earlier pages with it.
+ * - In SQL: flipping `ORDER BY ... ASC` to `DESC` (or back) on the whole
+ *   query.
+ *
+ * `merge`, the transforms, `flatMap`/`leftJoin`, `orderBy`, and `empty`
+ * reverse their inputs and re-apply themselves. A `distinct` stream can't
+ * be reversed: it keeps the *first* document of each group, and a reversed
+ * scan would keep the last, so `reverse` throws — reverse the input and
+ * apply `distinct` to that for the mirror query, or paginate the distinct
+ * stream in one direction only. Externally constructed streams (no
+ * `reverseWith`) throw too.
+ */
+export const reverse = <
+  Doc,
+  Key extends ReadonlyArray<string>,
+  E,
+  R,
+  Direction extends OrderDirection,
+>(
+  self: QueryStream<Doc, Key, E, R, Direction>,
+): QueryStream<Doc, Key, E, R, Flip<Direction>> => {
+  if (self.reverseWith === undefined) {
+    throw new Error(
+      "QueryStream.reverse: this stream cannot be reversed (a `distinct` stream keeps a different document per group in the other direction; apply `distinct` to the reversed input instead)",
+    );
+  }
+  return self.reverseWith();
 };
 
 /**

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -886,6 +886,90 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
+  it.effect("reverse runs a composition in the opposite direction", () =>
+    Effect.gen(function* () {
+      const c = yield* TestConfect.TestConfect;
+
+      yield* c.run(
+        Effect.gen(function* () {
+          const writer = yield* DatabaseWriter;
+          const reader = yield* DatabaseReader;
+
+          for (const [text, tag] of [
+            ["b", "b1"],
+            ["a", "a1"],
+            ["a", "a2"],
+            ["x0", "none"],
+            ["x1", "a"],
+            ["x2", "b"],
+          ] as const) {
+            yield* writer.table("notes").insert({ text, tag });
+          }
+
+          const notes = reader.table("notes").stream("by_text");
+          expect(yield* collectTexts(QueryStream.reverse(notes))).toEqual([
+            "x2",
+            "x1",
+            "x0",
+            "b",
+            "a",
+            "a",
+          ]);
+          // Reversing twice is the original direction.
+          expect(
+            yield* collectTexts(
+              QueryStream.reverse(QueryStream.reverse(notes)),
+            ),
+          ).toEqual(["a", "a", "b", "x0", "x1", "x2"]);
+
+          // Through a merge and the transforms.
+          const feed = QueryStream.merge([
+            reader.table("notes").stream("by_text", (q) => q.lt("text", "b")),
+            reader.table("notes").stream("by_text", (q) => q.gte("text", "b")),
+          ]).pipe(
+            QueryStream.filter((note) => note.text !== "x1"),
+            QueryStream.map((note) => note.text),
+          );
+          expect(yield* Stream.runCollect(QueryStream.reverse(feed))).toEqual([
+            "x2",
+            "x0",
+            "b",
+            "a",
+            "a",
+          ]);
+
+          // Through a join — the inner streams reverse with the outer — and
+          // on to pagination, with cursors still pushed down.
+          const joined = reader
+            .table("notes")
+            .stream("by_text", (q) => q.gte("text", "x"))
+            .pipe(
+              QueryStream.flatMap(
+                (note) =>
+                  reader
+                    .table("notes")
+                    .stream("by_text", (q) => q.eq("text", note.tag ?? "")),
+                { innerKey: ["_creationTime"] },
+              ),
+            );
+          const pages = yield* paginateAll(QueryStream.reverse(joined), 1);
+          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+            ["b1"],
+            ["a2"],
+            ["a1"],
+          ]);
+
+          // A distinct stream keeps a different document per group in the
+          // other direction, so it refuses.
+          const firstPerText = notes.pipe(QueryStream.distinct(["text"]));
+          expect(() => QueryStream.reverse(firstPerText)).toThrow(
+            /cannot be reversed/,
+          );
+        }),
+      );
+    }).pipe(Effect.provide(TestConfect.layer)),
+  );
+
   it.effect("distinct keeps the first document per group", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
@@ -1552,6 +1636,18 @@ describe("QueryStream types", () => {
       );
       expectTypeOf<
         DirectionOf<typeof dynamicInnerJoin>
+      >().toEqualTypeOf<QueryStream.OrderDirection>();
+
+      // reverse flips a known direction and keeps a runtime one as the
+      // union, leaving the key alone.
+      const reversed = QueryStream.reverse(full);
+      expectTypeOf<DirectionOf<typeof reversed>>().toEqualTypeOf<"desc">();
+      expectTypeOf<KeyOf<typeof reversed>>().toEqualTypeOf<
+        ["text", "_creationTime"]
+      >();
+      const reversedDynamic = QueryStream.reverse(dynamic);
+      expectTypeOf<
+        DirectionOf<typeof reversedDynamic>
       >().toEqualTypeOf<QueryStream.OrderDirection>();
     });
     void _typeChecks;


### PR DESCRIPTION
**Stack 2/3** — [1: empty, leftJoin, concurrency (#641)] ← **reverse** · [3: docs (#640)]

Stacked on #641. Adds `QueryStream.reverse`, kept separate so the `distinct` interaction gets its own look. Code, tests, docstring, and changeset only; the Streams page section lives in the docs PR at the top of the stack.

## What changed

- **`QueryStream.reverse`** runs a composed stream in the opposite direction. As a stream: the same composition with every leaf rebuilt in the other `order`, so the elements come out reversed but are read that way from the index rather than collected and reversed, and the result is still a query stream. In SQL: flipping `ORDER BY ... ASC` to `DESC` (or back) on the whole query. The type flips too (`Flip<Direction>`); a runtime-chosen direction stays the union. Its typical use is bidirectional pagination: the stream that loads a feed's later pages, reversed, loads its earlier ones.
- **Mechanism**: each stream carries a `reverseWith` strategy next to its `narrowWith`. Leaves rebuild their Convex query with the flipped order (their bounds live in ascending key space, so they carry over unchanged); `merge`, the transforms, `flatMap`/`leftJoin` (reversing the inner streams alongside the outer, which keeps the direction rule; the outer/inner refinements are key bounds and carry over), `orderBy`, and `empty` reverse their inputs and re-apply themselves. A reversed stream narrows and paginates through the same push-down as any other.
- **`distinct` deliberately has no strategy**: it keeps the *first* document of each group, and a reversed scan would keep the last, so `reverse` throws with a message pointing at applying `distinct` to the reversed input for the mirror query. Externally constructed streams (no `reverseWith`) throw too.
- Changeset: `@confect/server` minor.

## Design note for review

Reversing a distinct stream *could* be supported: in the reversed scan, each group's last element is the group's first in the original direction, which one extra forward read narrowed to the group prefix (`take(1)`) would fetch, giving two index reads per group with sound cursor semantics (the emitted key is the group's last key in the reversed order, so a cursor after it skips the whole group). I left that out of this PR because it doubles `distinct`'s cost only for reversed use and the throw is unambiguous; happy to add it if bidirectional paging over a distinct feed is a real need.

## Verification

- Mock-backend test: a reversed leaf lists in descending text order and reversing twice restores the original; a merge of two ranges with a filter and map reverses; a join reverses with its inner streams and paginates one item per page (`["b1"], ["a2"], ["a1"]`) with cursors pushed down; a distinct stream throws.
- Type tests: `reverse` of an `"asc"` stream is `"desc"` with the key unchanged; of a runtime-directed stream, the union.
- `pnpm check`, the stream suite, the full `pnpm test` run, and the type bench (within its baselines) are green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m