### PR TITLE
Fix the Streams docs icon

### DIFF
--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -1,5 +1,5 @@
 ---
-icon: "waves"
+icon: "waves-horizontal"
 title: "Streams"
 description: "Compose, merge, join, and paginate index queries as Effect streams."
 ---


### PR DESCRIPTION
Replace `waves` with Lucide's current `waves-horizontal` icon name. The old SVG URL returns 404, leaving the Streams navigation icon blank.

Verified with `mintlify validate`, Oxfmt, and the local docs preview: the wave icon renders beside Streams.

![Screenshot](https://api.capy.ai/pr-assets/8-94suBx2a1pazojiuOagsdncI35qZOTKfbihXCXVkA)