### PR TITLE
docs: put stream diagram names above their tracks

### DIFF
--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -74,10 +74,12 @@ A stream is drawn as a track, read left to right in **key order** — the way a 
 {/* stream-diagram: legend */}
 
 ```text
-by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+by_text
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 ```
 
+- The stream's name is printed above its track, and `╰` joins the two.
 - `─ n1 ─` is an element: the document `n1`. Its **key**, the values the stream is ordered by, is printed beneath it.
 - `─ (n6) ─` is an element that was read but filtered out. It emits nothing, but it still counts toward read budgets, and cursors still advance past it.
 - A blank stretch of track is key space the stream never read (skipped by a seek).
@@ -130,17 +132,21 @@ The four streams over the example data, with each element's key. A bound keeps a
 {/* stream-diagram: creating */}
 
 ```text
-by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+by_text
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-by_text desc  ─ n6 ──────── n4 ──────── n5 ──────── n2 ──────── n3 ──────── n1 ───────┤
-                [date,6]    [cherry,4]  [banana,5]  [banana,2]  [apple,3]   [apple,1]
+by_text desc
+╰─ n6 ──────── n4 ──────── n5 ──────── n2 ──────── n3 ──────── n1 ───────┤
+   [date,6]    [cherry,4]  [banana,5]  [banana,2]  [apple,3]   [apple,1]
 
-gte "banana"  ───────────────────────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                                        [banana,2]  [banana,5]  [cherry,4]  [date,6]
+gte "banana"
+╰───────────────────────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+                           [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-eq "apple"    ─ n1 ──────── n3 ───────┤
-                [1]         [3]
+eq "apple"
+╰─ n1 ──────── n3 ───────┤
+   [1]         [3]
 ```
 
 ### Range callbacks
@@ -167,7 +173,8 @@ In SQL terms, it is the empty relation, `SELECT ... WHERE false`, with the same 
 {/* stream-diagram: empty */}
 
 ```text
-nothing       ┤
+nothing
+╰┤
 ```
 
 Nothing can infer a document type from no documents, so the type comes first as a type argument and the key second. The key is the type-level order key of the streams it will be merged with, tiebreaker included; the [generated document types](/server/database/schema#document-types) name the document:
@@ -228,13 +235,16 @@ const cherry =
 {/* stream-diagram: unique */}
 
 ```text
-eq "cherry"   ─ n4 ───────┤   → Some(n4)
-                [4]
+eq "cherry"
+╰─ n4 ───────┤   → Some(n4)
+   [4]
 
-eq "apple"    ─ n1 ──────── n3 ───────┤   → NotUniqueError
-                [1]         [3]
+eq "apple"
+╰─ n1 ──────── n3 ───────┤   → NotUniqueError
+   [1]         [3]
 
-eq "fig"      ┤   → None
+eq "fig"
+╰┤   → None
 ```
 
 ## Combining streams
@@ -263,15 +273,18 @@ Pinning `author.role` leaves both streams with the order key `["_creationTime"]`
 {/* stream-diagram: merge */}
 
 ```text
-admin         ─ n1 ──────────────────────────────── n4 ──────── n5 ───────────────────┤
-                [1]                                 [4]         [5]
-user          ───────────── n2 ──────── n3 ──────────────────────────────── n6 ───────┤
-                            [2]         [3]                                 [6]
+admin
+╰─ n1 ──────────────────────────────── n4 ──────── n5 ───────────────────┤
+   [1]                                 [4]         [5]
+user
+╰───────────── n2 ──────── n3 ──────────────────────────────── n6 ───────┤
+               [2]         [3]                                 [6]
 
-              ╞═ merge([admin, user]) ═╡
+╞═ merge([admin, user]) ═╡
 
-merged        ─ n1 ──────── n2 ──────── n3 ──────── n4 ──────── n5 ──────── n6 ───────┤
-                [1]         [2]         [3]         [4]         [5]         [6]
+merged
+╰─ n1 ──────── n2 ──────── n3 ──────── n4 ──────── n5 ──────── n6 ───────┤
+   [1]         [2]         [3]         [4]         [5]         [6]
 ```
 
 All inputs must have the same order key, document type, and order direction, which are all type errors otherwise. The direction is `"asc"` when omitted and the given literal when passed one; the first input fixes it and each later input must match. A direction chosen at runtime types as `"asc" | "desc"`: such a stream can lead a merge (a known direction is assignable to it) but can't follow a known one, and a mismatch the types can't see makes `merge` throw when the streams are combined. Overlapping inputs are not deduplicated: a document matched by two inputs appears twice.
@@ -297,18 +310,21 @@ The hidden note is read, rejected, and kept in the cursor accounting; the mapped
 {/* stream-diagram: filter-map */}
 
 ```text
-by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+by_text
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-              ╞═ filter((note) => note.tag !== "hidden") ═╡
+╞═ filter((note) => note.tag !== "hidden") ═╡
 
-filtered      ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── (n6) ─────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+filtered
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── (n6) ─────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-              ╞═ map((note) => note.text) ═╡
+╞═ map((note) => note.text) ═╡
 
-mapped        ─ apple ───── apple ───── banana ──── banana ──── cherry ──── (n6) ─────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+mapped
+╰─ apple ───── apple ───── banana ──── banana ──── cherry ──── (n6) ─────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 ```
 
 A mapper must not change what the documents are ordered by — the mapped stream keeps the original order key.
@@ -374,16 +390,21 @@ Each admin note's comment stream runs in turn. The result's key is the outer key
 {/* stream-diagram: join */}
 
 ```text
-admin         ─ n1 ──────────────────── n4 ──────── n5 ───────┤
-                [1]                     [4]         [5]
-of n1         ─ c1 ──────── c2 ───────
-of n4                                 ─ c3 ───────
-of n5                                             ┤
+admin
+╰─ n1 ──────────────────── n4 ──────── n5 ───────┤
+   [1]                     [4]         [5]
+of n1
+╰─ c1 ──────── c2 ───────┤
+                        of n4
+                        ╰─ c3 ───────┤
+                                    of n5
+                                    ╰┤
 
-              ╞═ flatMap((note) => commentsOn(note), { innerKey: ["_creationTime"] }) ═╡
+╞═ flatMap((note) => commentsOn(note), { innerKey: ["_creationTime"] }) ═╡
 
-joined        ─ c1 ──────── c2 ──────── c3 ──────── (n5) ─────┤
-                [1,7]       [1,8]       [4,9]       [5,null]
+joined
+╰─ c1 ──────── c2 ──────── c3 ──────── (n5) ─────┤
+   [1,7]       [1,8]       [4,9]       [5,null]
 ```
 
 Pass the inner streams' order key as `innerKey`; it is checked against the type of the stream the function returns. Inner streams must run in the outer stream's direction: with `QueryStream.flatMap(outer, f, options)` the outer stream fixes it and a differing inner stream is a type error, while with `outer.pipe(QueryStream.flatMap(f, options))` the inner streams fix it. A mismatch the types can't see fails when the join runs.
@@ -421,16 +442,21 @@ The placeholder (`∅n5`, that is `onEmpty(n5)`) takes the position the filtered
 {/* stream-diagram: left-join */}
 
 ```text
-admin         ─ n1 ──────────────────── n4 ──────── n5 ───────┤
-                [1]                     [4]         [5]
-of n1         ─ c1 ──────── c2 ───────
-of n4                                 ─ c3 ───────
-of n5                                             ┤
+admin
+╰─ n1 ──────────────────── n4 ──────── n5 ───────┤
+   [1]                     [4]         [5]
+of n1
+╰─ c1 ──────── c2 ───────┤
+                        of n4
+                        ╰─ c3 ───────┤
+                                    of n5
+                                    ╰┤
 
-              ╞═ leftJoin((note) => commentsOn(note), { innerKey, onEmpty }) ═╡
+╞═ leftJoin((note) => commentsOn(note), { innerKey, onEmpty }) ═╡
 
-joined        ─ c1 ──────── c2 ──────── c3 ──────── ∅n5 ──────┤
-                [1,7]       [1,8]       [4,9]       [5,null]
+joined
+╰─ c1 ──────── c2 ──────── c3 ──────── ∅n5 ──────┤
+   [1,7]       [1,8]       [4,9]       [5,null]
 ```
 
 The elements are the inner stream's documents or the placeholders, so give both a common shape as above. Outer documents filtered out before the join stay absent. Everything else, including the `innerKey` check and the direction rules, is `flatMap`'s.
@@ -454,13 +480,15 @@ After `n1` is found, the stream seeks straight to the first key past `apple`; `n
 {/* stream-diagram: distinct */}
 
 ```text
-by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+by_text
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-              ╞═ distinct(["text"]) ═╡
+╞═ distinct(["text"]) ═╡
 
-distinct      ─ n1 ──────────────────── n2 ──────────────────── n4 ──────── n6 ───────┤
-                [apple,1]               [banana,2]              [cherry,4]  [date,6]
+distinct
+╰─ n1 ──────────────────── n2 ──────────────────── n4 ──────── n6 ───────┤
+   [apple,1]               [banana,2]              [cherry,4]  [date,6]
 ```
 
 The fields must be a prefix of the stream's order key, which is enforced at the type level. On a `flatMap` result, a prefix that reaches into the inner key groups by the outer document as well, since groups are runs of consecutive equal keys. A distinct stream can't be [reversed](#reverse), since the other direction would keep a different document per group. Apply `filter` (or `filterEffect`) _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
@@ -505,13 +533,15 @@ Relabeling changes the key's field names and nothing else:
 {/* stream-diagram: order-by */}
 
 ```text
-by_body       ─ c1 ──────── c2 ──────── c3 ───────┤
-                [great,7]   [meh,8]     [nice,9]     key: [body, _creationTime]
+by_body
+╰─ c1 ──────── c2 ──────── c3 ───────┤
+   [great,7]   [meh,8]     [nice,9]     key: [body, _creationTime]
 
-              ╞═ orderBy(["text", "_creationTime"]) ═╡
+╞═ orderBy(["text", "_creationTime"]) ═╡
 
-relabeled     ─ c1 ──────── c2 ──────── c3 ───────┤
-                [great,7]   [meh,8]     [nice,9]     key: [text, _creationTime]
+relabeled
+╰─ c1 ──────── c2 ──────── c3 ───────┤
+   [great,7]   [meh,8]     [nice,9]     key: [text, _creationTime]
 ```
 
 With matching key names, the two streams merge by their key values — here, alphabetically:
@@ -519,13 +549,16 @@ With matching key names, the two streams merge by their key values — here, alp
 {/* stream-diagram: order-by-merge */}
 
 ```text
-notes         ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────────────────────────────────────────┤
-relabeled     ───────────────────────────────────────────────────────────────────────── c1 ──────── c2 ──────── c3 ───────┤
+notes
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────────────────────────────────────────┤
+relabeled
+╰───────────────────────────────────────────────────────────────────────── c1 ──────── c2 ──────── c3 ───────┤
 
-              ╞═ merge([notes, relabeled]) ═╡
+╞═ merge([notes, relabeled]) ═╡
 
-merged        ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ──────── c1 ──────── c2 ──────── c3 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]    [great,7]   [meh,8]     [nice,9]
+merged
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ──────── c1 ──────── c2 ──────── c3 ───────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]    [great,7]   [meh,8]     [nice,9]
 ```
 
 The new key must have exactly as many fields as the old one, and the values under each position must be comparable — relabeling doesn't reorder anything. A `flatMap` result relabels by its combined key, outer fields first.
@@ -546,13 +579,15 @@ Reversing the merge reverses each of its inputs and merges them the other way:
 {/* stream-diagram: reverse */}
 
 ```text
-merged        ─ n1 ──────── n2 ──────── n3 ──────── n4 ──────── n5 ──────── n6 ───────┤
-                [1]         [2]         [3]         [4]         [5]         [6]
+merged
+╰─ n1 ──────── n2 ──────── n3 ──────── n4 ──────── n5 ──────── n6 ───────┤
+   [1]         [2]         [3]         [4]         [5]         [6]
 
-              ╞═ reverse ═╡
+╞═ reverse ═╡
 
-reversed      ─ n6 ──────── n5 ──────── n4 ──────── n3 ──────── n2 ──────── n1 ───────┤
-                [6]         [5]         [4]         [3]         [2]         [1]
+reversed
+╰─ n6 ──────── n5 ──────── n4 ──────── n3 ──────── n2 ──────── n1 ───────┤
+   [6]         [5]         [4]         [3]         [2]         [1]
 ```
 
 Merges, filters and maps, joins (their inner streams included), `orderBy`, and `empty` all reverse. A `distinct` stream can't: it keeps the first document of each group, and a reversed scan would keep the last, so `reverse` throws. For the mirror query, reverse the input and apply `distinct` to that.
@@ -575,14 +610,16 @@ The bounds become index-range predicates on the leaf, so the elements outside th
 {/* stream-diagram: narrow */}
 
 ```text
-by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
-                                                  ╎ after                 ╎ until
+by_text
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+                                     ╎ after                 ╎ until
 
-              ╞═ narrow({ after: [banana, 2], until: [cherry, 4] }) ═╡
+╞═ narrow({ after: [banana, 2], until: [cherry, 4] }) ═╡
 
-narrowed      ───────────────────────────────────── n5 ──────── n4 ───────┤
-                                                    [banana,5]  [cherry,4]
+narrowed
+╰───────────────────────────────────── n5 ──────── n4 ───────┤
+                                       [banana,5]  [cherry,4]
 ```
 
 Cursors are serialized keys: `QueryStream.deserializeCursor(page.continueCursor)` turns a page's cursor into an `after` bound.
@@ -598,20 +635,22 @@ Three pages of two over the filtered notes. Each page starts where the previous 
 {/* stream-diagram: paginate */}
 
 ```text
-filtered      ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── (n6) ─────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+filtered
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── (n6) ─────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-              ╞═ paginate({ numItems: 2, cursor: null }) ═╡
+╞═ paginate({ numItems: 2, cursor: null }) ═╡
 
-page 1        ─ n1 ──────── n3 ───────╎  continueCursor: [apple,3]
+page 1
+╰─ n1 ──────── n3 ───────╎  continueCursor: [apple,3]
 
-              ╞═ paginate({ numItems: 2, cursor: [apple,3] }) ═╡
+╞═ paginate({ numItems: 2, cursor: [apple,3] }) ═╡
 
-                                      ╎ n2 ──────── n5 ───────╎  continueCursor: [banana,5]
+                         ╎ n2 ──────── n5 ───────╎  continueCursor: [banana,5]
 
-              ╞═ paginate({ numItems: 2, cursor: [banana,5] }) ═╡
+╞═ paginate({ numItems: 2, cursor: [banana,5] }) ═╡
 
-                                                              ╎ n4 ──────── (n6) ─────┤  isDone: true
+                                                 ╎ n4 ──────── (n6) ─────┤  isDone: true
 ```
 
 With an `endCursor`, a page covers exactly the range between its two cursors, however many documents that range holds as data changes, which is how reactive clients keep adjacent pages gap-free:
@@ -619,12 +658,13 @@ With an `endCursor`, a page covers exactly the range between its two cursors, ho
 {/* stream-diagram: end-cursor */}
 
 ```text
-filtered      ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── (n6) ─────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+filtered
+╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── (n6) ─────┤
+   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
 
-              ╞═ paginate({ cursor: [apple,3], endCursor: [banana,5], numItems: 2 }) ═╡
+╞═ paginate({ cursor: [apple,3], endCursor: [banana,5], numItems: 2 }) ═╡
 
-                                      ╎ n2 ──────── n5 ───────╎  exactly this range, however many documents it holds
+                         ╎ n2 ──────── n5 ───────╎  exactly this range, however many documents it holds
 ```
 
 A [paginated query](/server/functions#paginated-queries) handler forwards its decoded `paginationOpts`:

--- a/scripts/streamDiagrams.test.ts
+++ b/scripts/streamDiagrams.test.ts
@@ -17,12 +17,24 @@ const block = (name: string): string =>
   `{/* stream-diagram: ${name} */}\n\`\`\`text\nstale\n\`\`\``;
 
 test("tracks and their keys share columns", () => {
-  const elements = track("by_text", ["n1", undefined, "n2"]);
-  const beneath = keys("", ["[apple,1]", undefined, "[banana,2]"]);
+  const [name, elements] = track("by_text", ["n1", undefined, "n2"]).split(
+    "\n",
+  );
+  const beneath = keys(["[apple,1]", undefined, "[banana,2]"]);
+  expect(name).toBe("by_text");
+  expect(elements?.startsWith("╰")).toBe(true);
   // Same width before the end marker, so keys sit beneath their elements.
-  expect(elements.length - 1).toBe(beneath.length);
-  expect(elements.indexOf("n2")).toBe(beneath.indexOf("[banana,2]"));
+  expect(elements?.length).toBe(beneath.length + 1);
+  expect(elements?.indexOf("n2")).toBe(beneath.indexOf("[banana,2]"));
   expect(cell("n1")).toHaveLength(cell("(n6)").length);
+});
+
+test("a track that starts later lines up with the outer track's columns", () => {
+  const [, outer] = track("admin", ["n1", undefined, "n4"]).split("\n");
+  const [name, inner] = track("of n4", ["c3"], "┤", 2).split("\n");
+  // The corner sits under the name, and the inner element under the outer one.
+  expect(inner?.indexOf("╰")).toBe(name?.indexOf("of n4"));
+  expect(inner?.indexOf("c3")).toBe(outer?.indexOf("n4"));
 });
 
 test("renders every marked block and leaves the rest of the page alone", () =>

--- a/scripts/streamDiagrams.ts
+++ b/scripts/streamDiagrams.ts
@@ -12,17 +12,20 @@ import * as Runtime from "effect/Runtime";
  *
  * A diagram is a set of tracks. A track is read left to right in key order
  * — the marble-diagram convention, with the index's ordering as the axis in
- * place of time. Every track in one diagram shares the same columns, so
- * elements that line up vertically hold the same position in the output's
- * order. Generating them keeps the notation consistent and the columns
- * aligned; the page marks each block with an MDX comment naming the
+ * place of time. Its name sits on the line above it, and the track curls up
+ * into the name (`╰`) rather than sitting beside it, so the diagram is no
+ * wider than its columns. Every track in one diagram shares the same
+ * columns, so elements that line up vertically hold the same position in
+ * the output's order. Generating them keeps the notation consistent and the
+ * columns aligned; the page marks each block with an MDX comment naming the
  * diagram (`stream-diagram: name`) and this script fills in the fenced
  * `text` block that follows.
  */
 
 const PAGE = "apps/docs/server/database/streams.mdx";
 const COLUMN_WIDTH = 12;
-const NAME_WIDTH = 14;
+/** Joins a track to the name printed above it. */
+const CORNER = "╰";
 
 export class StreamDiagramsError extends Data.TaggedError(
   "StreamDiagramsError",
@@ -46,44 +49,46 @@ const gap = "─".repeat(COLUMN_WIDTH);
 
 const keyCell = (key: string): string => `  ${key}`.padEnd(COLUMN_WIDTH);
 
-/** A track: a named stream, one cell per column, ending in `end`. */
+/**
+ * A track: a named stream, one cell per column, ending in `end`. The name
+ * is printed on the line above, and the track starts with the corner that
+ * joins it to the name. `start` shifts both right by that many columns —
+ * an inner stream of a join begins where its outer element is.
+ */
 export const track = (
   name: string,
   cells: ReadonlyArray<Cell>,
   end = "┤",
-): string =>
-  name.padEnd(NAME_WIDTH) +
-  cells.map((label) => (label === undefined ? gap : cell(label))).join("") +
-  end;
+  start = 0,
+): string => {
+  const indent = " ".repeat(COLUMN_WIDTH * start);
+  return (
+    indent +
+    name +
+    "\n" +
+    indent +
+    CORNER +
+    cells.map((label) => (label === undefined ? gap : cell(label))).join("") +
+    end
+  );
+};
 
 /** The keys printed beneath a track's elements. */
-export const keys = (name: string, values: ReadonlyArray<Cell>): string =>
-  name.padEnd(NAME_WIDTH) +
+export const keys = (values: ReadonlyArray<Cell>): string =>
+  " " +
   values
     .map((key) => (key === undefined ? " ".repeat(COLUMN_WIDTH) : keyCell(key)))
     .join("");
 
-/** A track that starts `start` columns in — an inner stream of a join. */
-const at = (
-  name: string,
-  start: number,
-  cells: ReadonlyArray<string>,
-  end = "┤",
-): string =>
-  name.padEnd(NAME_WIDTH) +
-  " ".repeat(COLUMN_WIDTH * start) +
-  cells.map(cell).join("") +
-  end;
-
 /** The operation between an input track and its output. */
-const op = (text: string): string => " ".repeat(NAME_WIDTH) + `╞═ ${text} ═╡`;
+const op = (text: string): string => `╞═ ${text} ═╡`;
 
 const lines = (...rows: ReadonlyArray<string>): string =>
   rows.map((row) => row.trimEnd()).join("\n");
 
 /** A cursor between two keys, drawn at the start of column `column`. */
 const cursorAt = (column: number): string =>
-  " ".repeat(NAME_WIDTH + COLUMN_WIDTH * column) + "╎";
+  " ".repeat(1 + COLUMN_WIDTH * column) + "╎";
 
 const BY_TEXT = ["n1", "n3", "n2", "n5", "n4", "n6"];
 const BY_TEXT_KEYS = [
@@ -97,14 +102,14 @@ const BY_TEXT_KEYS = [
 const FILTERED = ["n1", "n3", "n2", "n5", "n4", "(n6)"];
 
 export const diagrams: Readonly<Record<string, string>> = {
-  legend: lines(track("by_text", BY_TEXT), keys("", BY_TEXT_KEYS)),
+  legend: lines(track("by_text", BY_TEXT), keys(BY_TEXT_KEYS)),
 
   creating: lines(
     track("by_text", BY_TEXT),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     "",
     track("by_text desc", ["n6", "n4", "n5", "n2", "n3", "n1"]),
-    keys("", [
+    keys([
       "[date,6]",
       "[cherry,4]",
       "[banana,5]",
@@ -114,7 +119,7 @@ export const diagrams: Readonly<Record<string, string>> = {
     ]),
     "",
     track('gte "banana"', [undefined, undefined, "n2", "n5", "n4", "n6"]),
-    keys("", [
+    keys([
       undefined,
       undefined,
       "[banana,2]",
@@ -124,82 +129,82 @@ export const diagrams: Readonly<Record<string, string>> = {
     ]),
     "",
     track('eq "apple"', ["n1", "n3"]),
-    keys("", ["[1]", "[3]"]),
+    keys(["[1]", "[3]"]),
   ),
 
   empty: lines(track("nothing", [])),
 
   unique: lines(
     `${track('eq "cherry"', ["n4"])}   → Some(n4)`,
-    keys("", ["[4]"]),
+    keys(["[4]"]),
     "",
     `${track('eq "apple"', ["n1", "n3"])}   → NotUniqueError`,
-    keys("", ["[1]", "[3]"]),
+    keys(["[1]", "[3]"]),
     "",
     `${track('eq "fig"', [])}   → None`,
   ),
 
   merge: lines(
     track("admin", ["n1", undefined, undefined, "n4", "n5", undefined]),
-    keys("", ["[1]", undefined, undefined, "[4]", "[5]", undefined]),
+    keys(["[1]", undefined, undefined, "[4]", "[5]", undefined]),
     track("user", [undefined, "n2", "n3", undefined, undefined, "n6"]),
-    keys("", [undefined, "[2]", "[3]", undefined, undefined, "[6]"]),
+    keys([undefined, "[2]", "[3]", undefined, undefined, "[6]"]),
     "",
     op("merge([admin, user])"),
     "",
     track("merged", ["n1", "n2", "n3", "n4", "n5", "n6"]),
-    keys("", ["[1]", "[2]", "[3]", "[4]", "[5]", "[6]"]),
+    keys(["[1]", "[2]", "[3]", "[4]", "[5]", "[6]"]),
   ),
 
   "filter-map": lines(
     track("by_text", BY_TEXT),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     "",
     op('filter((note) => note.tag !== "hidden")'),
     "",
     track("filtered", FILTERED),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     "",
     op("map((note) => note.text)"),
     "",
     track("mapped", ["apple", "apple", "banana", "banana", "cherry", "(n6)"]),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
   ),
 
   join: lines(
     track("admin", ["n1", undefined, "n4", "n5"]),
-    keys("", ["[1]", undefined, "[4]", "[5]"]),
-    at("of n1", 0, ["c1", "c2"], ""),
-    at("of n4", 2, ["c3"], ""),
-    at("of n5", 3, []),
+    keys(["[1]", undefined, "[4]", "[5]"]),
+    track("of n1", ["c1", "c2"], "┤", 0),
+    track("of n4", ["c3"], "┤", 2),
+    track("of n5", [], "┤", 3),
     "",
     op('flatMap((note) => commentsOn(note), { innerKey: ["_creationTime"] })'),
     "",
     track("joined", ["c1", "c2", "c3", "(n5)"]),
-    keys("", ["[1,7]", "[1,8]", "[4,9]", "[5,null]"]),
+    keys(["[1,7]", "[1,8]", "[4,9]", "[5,null]"]),
   ),
 
   "left-join": lines(
     track("admin", ["n1", undefined, "n4", "n5"]),
-    keys("", ["[1]", undefined, "[4]", "[5]"]),
-    at("of n1", 0, ["c1", "c2"], ""),
-    at("of n4", 2, ["c3"], ""),
-    at("of n5", 3, []),
+    keys(["[1]", undefined, "[4]", "[5]"]),
+    track("of n1", ["c1", "c2"], "┤", 0),
+    track("of n4", ["c3"], "┤", 2),
+    track("of n5", [], "┤", 3),
     "",
     op("leftJoin((note) => commentsOn(note), { innerKey, onEmpty })"),
     "",
     track("joined", ["c1", "c2", "c3", "∅n5"]),
-    keys("", ["[1,7]", "[1,8]", "[4,9]", "[5,null]"]),
+    keys(["[1,7]", "[1,8]", "[4,9]", "[5,null]"]),
   ),
 
   distinct: lines(
     track("by_text", BY_TEXT),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     "",
     op('distinct(["text"])'),
     "",
     track("distinct", ["n1", undefined, "n2", undefined, "n4", "n6"]),
-    keys("", [
+    keys([
       "[apple,1]",
       undefined,
       "[banana,2]",
@@ -211,12 +216,12 @@ export const diagrams: Readonly<Record<string, string>> = {
 
   "order-by": lines(
     track("by_body", ["c1", "c2", "c3"]),
-    `${keys("", ["[great,7]", "[meh,8]", "[nice,9]"])}   key: [body, _creationTime]`,
+    `${keys(["[great,7]", "[meh,8]", "[nice,9]"])}   key: [body, _creationTime]`,
     "",
     op('orderBy(["text", "_creationTime"])'),
     "",
     track("relabeled", ["c1", "c2", "c3"]),
-    `${keys("", ["[great,7]", "[meh,8]", "[nice,9]"])}   key: [text, _creationTime]`,
+    `${keys(["[great,7]", "[meh,8]", "[nice,9]"])}   key: [text, _creationTime]`,
   ),
 
   "order-by-merge": lines(
@@ -236,33 +241,33 @@ export const diagrams: Readonly<Record<string, string>> = {
     op("merge([notes, relabeled])"),
     "",
     track("merged", [...BY_TEXT, "c1", "c2", "c3"]),
-    keys("", [...BY_TEXT_KEYS, "[great,7]", "[meh,8]", "[nice,9]"]),
+    keys([...BY_TEXT_KEYS, "[great,7]", "[meh,8]", "[nice,9]"]),
   ),
 
   reverse: lines(
     track("merged", ["n1", "n2", "n3", "n4", "n5", "n6"]),
-    keys("", ["[1]", "[2]", "[3]", "[4]", "[5]", "[6]"]),
+    keys(["[1]", "[2]", "[3]", "[4]", "[5]", "[6]"]),
     "",
     op("reverse"),
     "",
     track("reversed", ["n6", "n5", "n4", "n3", "n2", "n1"]),
-    keys("", ["[6]", "[5]", "[4]", "[3]", "[2]", "[1]"]),
+    keys(["[6]", "[5]", "[4]", "[3]", "[2]", "[1]"]),
   ),
 
   narrow: lines(
     track("by_text", BY_TEXT),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     `${cursorAt(3)} after${" ".repeat(COLUMN_WIDTH * 2 - 7)}╎ until`,
     "",
     op("narrow({ after: [banana, 2], until: [cherry, 4] })"),
     "",
     track("narrowed", [undefined, undefined, undefined, "n5", "n4"]),
-    keys("", [undefined, undefined, undefined, "[banana,5]", "[cherry,4]"]),
+    keys([undefined, undefined, undefined, "[banana,5]", "[cherry,4]"]),
   ),
 
   paginate: lines(
     track("filtered", FILTERED),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     "",
     op("paginate({ numItems: 2, cursor: null })"),
     "",
@@ -279,7 +284,7 @@ export const diagrams: Readonly<Record<string, string>> = {
 
   "end-cursor": lines(
     track("filtered", FILTERED),
-    keys("", BY_TEXT_KEYS),
+    keys(BY_TEXT_KEYS),
     "",
     op("paginate({ cursor: [apple,3], endCursor: [banana,5], numItems: 2 })"),
     "",


### PR DESCRIPTION
## Summary

The stream diagrams on the Streams page were a bit too wide for the docs layout, so most of them needed a horizontal scroll. This moves each track's name from a 14-character column on the left to the line above the track, with a `╰` joining the two, so every diagram is 13 characters narrower:

```text
by_text
╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
   [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
```

- The 6-column diagrams go from 87 to 74 characters, the 9-column merge diagram from 123 to 110.
- The legend gains one line describing where the name sits.
- In `scripts/streamDiagrams.ts`, `track` takes an optional column offset (used for the inner streams of a join, which previously had their own helper) and `keys` no longer takes a name. All tracks now end with `┤`, including a join's inner streams.
- A new test checks that an offset track's corner sits under its name and its elements line up with the outer track's columns.

Docs and tooling only, so no changeset.

## Verification

- `bun test scripts/streamDiagrams.test.ts`
- `pnpm check` (includes the diagram staleness check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m)_