### PR TITLE
Align the QueryStream vocabulary with stream libraries

### DIFF
--- a/.changeset/stream-empty-on-empty-concurrency.md
+++ b/.changeset/stream-empty-on-empty-concurrency.md
@@ -5,5 +5,5 @@
 Add three operations to `QueryStream`:
 
 - `QueryStream.empty` builds a query stream with no documents but a known order key and direction, so a merge over a dynamic list of streams has something to return when the list is empty: `QueryStream.empty<NotesDoc>()(["_creationTime"], "desc")`.
-- `QueryStream.leftJoin` is `flatMap` that keeps outer documents whose inner stream is empty, emitting `onEmpty(outer)` in their place — SQL's `LEFT JOIN` to `flatMap`'s inner join. The placeholder paginates like any element.
+- `QueryStream.flatMap` accepts an `onEmpty` option that keeps outer documents whose inner stream is empty, emitting `onEmpty(outer)` in their place — SQL's `LEFT JOIN` to the default inner join. The placeholder paginates like any element.
 - `QueryStream.filterEffect` and `QueryStream.mapEffect` accept `{ concurrency }` to run several documents' effects at once. Elements are still emitted in stream order, so the result remains a query stream.

--- a/.changeset/stream-querying-combinators.md
+++ b/.changeset/stream-querying-combinators.md
@@ -6,4 +6,4 @@ Add three combinators to `QueryStream`:
 
 - `QueryStream.flatMap` joins each document to an inner stream (e.g. each author to their messages), concatenating the order keys in the type system so the joined stream stays mergeable and paginable.
 - `QueryStream.distinct` emits the first document of each group of consecutive equal order-key prefixes, reading via a loose index scan (one indexed read per group) rather than scanning every row. The requested prefix must be a prefix of the stream's order key, enforced at the type level.
-- `QueryStream.orderBy` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged.
+- `QueryStream.renameKey` relabels a stream's order key positionally, so streams from different indexes or tables whose keys share value order but not field names can be merged.

--- a/.changeset/stream-reverse.md
+++ b/.changeset/stream-reverse.md
@@ -4,4 +4,4 @@
 
 Add `QueryStream.reverse`, which runs a composed query stream in the opposite direction. Every leaf is rebuilt with the other order, so the reversed stream reads from the index in that direction rather than collecting and reversing, and it stays a query stream: it merges and paginates like any other. The typical use is bidirectional pagination, loading a feed's earlier pages with the reverse of the stream that loads its later ones.
 
-Merges, `filter`/`map` and their effectful forms, `flatMap`/`leftJoin` (inner streams included), `orderBy`, and `empty` all reverse. A `distinct` stream throws when reversed, because the other direction would keep a different document per group; apply `distinct` to the reversed input instead.
+Merges, `filter`/`map` and their effectful forms, `flatMap` (inner streams included), `renameKey`, and `empty` all reverse. A `distinct` stream throws when reversed, because the other direction would keep a different document per group; apply `distinct` to the reversed input instead.

--- a/apps/docs/clients/foldkit.mdx
+++ b/apps/docs/clients/foldkit.mdx
@@ -484,7 +484,7 @@ When you navigate forward, the page you leave is pinned to the range it
 displayed — from its cursor to its continuation cursor — so going back reloads
 exactly that range, however the data has moved since. This is what keeps
 consecutive pages gap-free and duplicate-free for
-[stream-paginated queries](/server/database/streams#paginate), which have no
+[stream-paginated queries](/server/database/streams#paginating-a-stream), which have no
 query journal to remember page ranges. The page currently on screen is a live
 window of `initialNumItems` documents from its cursor, so it stays full as
 documents are inserted and deleted.

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -42,6 +42,20 @@ Effect.gen(function* () {
   `Stream` over one query; the former is a composable query stream.
 </Note>
 
+## The ordering contract
+
+Every query stream is sorted by its **order key** in its **direction**, and every operation on this page keeps it that way. That invariant is what a plain `Stream` lacks and what the rest of this page relies on: two streams sorted by the same key can be merged without buffering, a cursor is a key, and a page of any composition resumes by narrowing every underlying index query to the keys after that cursor.
+
+Both are part of the type. `reader.table("notes").stream("by_text")` is a `QueryStream<Doc, ["text", "_creationTime"], DocumentDecodeError, never, "asc">`: the document, the order key, the error and requirement channels, and the direction. `merge` refuses streams whose keys or directions differ, at compile time.
+
+Only three operations change the key at all:
+
+- `flatMap` extends it, appending the inner stream's key to the outer stream's.
+- `renameKey` relabels its fields, without reordering anything.
+- `reverse` flips the direction.
+
+Everything else keeps the key exactly as it is, and the sinks consume it.
+
 ## How this page is written
 
 Each operation is described with its SQL analogy, then shown on one small dataset. In SQL terms a query stream is an ordered result set — `reader.table("notes").stream("by_text")` is `SELECT * FROM notes ORDER BY text, _creationTime` — and each operation is a clause built around it.
@@ -86,22 +100,24 @@ by_text       ─ n1 ──────── n3 ──────── n2 ─
 
 ## Operations at a glance
 
-| Operation                                                     | In SQL                                                                    |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [`stream`](#creating-a-stream)                                | `SELECT * FROM table WHERE <index range> ORDER BY <index fields>`         |
-| [`Stream.runCollect`, `runHead`, `take`](#consuming-a-stream) | The whole result set, `LIMIT 1`, `LIMIT n`                                |
-| [`unique`](#consuming-a-stream)                               | A query expected to return at most one row                                |
-| [`empty`](#empty-streams)                                     | The empty relation, `WHERE false`, with the same `ORDER BY`               |
-| [`merge`](#merge)                                             | `UNION ALL` of queries with the same `ORDER BY`, kept in that order       |
-| [`filter` / `filterEffect`](#filter-and-map)                  | `WHERE` on any column; `WHERE EXISTS (subquery)` for the effectful form   |
-| [`map` / `mapEffect`](#filter-and-map)                        | The `SELECT` list; a scalar subquery in it for the effectful form         |
-| [`flatMap`](#join)                                            | `CROSS JOIN LATERAL` (`CROSS APPLY`), ordered by outer key then inner key |
-| [`leftJoin`](#left-join)                                      | `LEFT JOIN LATERAL`, with `onEmpty` standing in for the `NULL` columns    |
-| [`distinct`](#distinct)                                       | `SELECT DISTINCT ON (prefix)` as a loose index scan                       |
-| [`orderBy`](#rename-the-order-key)                            | Column aliases (`AS`) so `UNION ALL` branches line up                     |
-| [`reverse`](#reverse)                                         | `ORDER BY ... ASC` flipped to `DESC` (or back) on the whole query         |
-| [`narrow`](#narrow-to-a-key-range)                            | Keyset predicates on the `ORDER BY` columns                               |
-| [`paginate`](#paginating-a-stream)                            | Keyset pagination: `WHERE key > :cursor ORDER BY key LIMIT n`             |
+Grouped by what each operation does to the order key. The last column names the nearest thing in Effect's `Stream` module for readers who know it.
+
+| Operation                                                                 | Order key                                      | In SQL                                                                    | In Effect                                                     |
+| ------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| [`stream`](#creating-a-stream)                                            | The index's fields, minus those pinned by `eq` | `SELECT * FROM table WHERE <index range> ORDER BY <index fields>`         | A `Stream` that remembers how it is sorted                    |
+| [`empty`](#empty-streams)                                                 | As given                                       | The empty relation, `WHERE false`, with the same `ORDER BY`               | `Stream.empty` with a key                                     |
+| [`merge`](#merge)                                                         | Shared by every input; kept                    | `UNION ALL` of queries with the same `ORDER BY`, kept in that order       | Ordered, unlike `Stream.merge`; ZIO's `mergeSorted`           |
+| [`filter` / `filterEffect`](#filter-and-map)                              | Kept                                           | `WHERE` on any column; `WHERE EXISTS (subquery)` for the effectful form   | `Stream.filter`, `Stream.filterEffect`                        |
+| [`map` / `mapEffect`](#filter-and-map)                                    | Kept                                           | The `SELECT` list; a scalar subquery in it for the effectful form         | `Stream.map`, `Stream.mapEffect`                              |
+| [`distinct`](#distinct)                                                   | Kept                                           | `SELECT DISTINCT ON (prefix)` as a loose index scan                       | `Stream.changes` on a key prefix                              |
+| [`narrow`](#narrow-to-a-key-range)                                        | Kept                                           | Keyset predicates on the `ORDER BY` columns                               | `dropWhile` and `takeUntil` on the key, pushed into the index |
+| [`flatMap`](#flat-map)                                                    | Extended by the inner key                      | `CROSS JOIN LATERAL` (`CROSS APPLY`), ordered by outer key then inner key | `Stream.flatMap`, sequential like RxJS's `concatMap`          |
+| [`flatMap` with `onEmpty`](#keep-outer-documents-without-inner-documents) | Extended by the inner key                      | `LEFT JOIN LATERAL`, with `onEmpty` standing in for the `NULL` columns    | `Stream.orElseIfEmpty` on each inner stream                   |
+| [`renameKey`](#rename-the-order-key)                                      | Relabeled                                      | Column aliases (`AS`) so `UNION ALL` branches line up                     | Changes only the `Key` type parameter                         |
+| [`reverse`](#reverse)                                                     | Direction flipped                              | `ORDER BY ... ASC` flipped to `DESC` (or back) on the whole query         | `Array.reverse`, read that way from the index                 |
+| [`Stream.runCollect`, `runHead`, `take`](#consuming-a-stream)             | Consumed                                       | The whole result set, `LIMIT 1`, `LIMIT n`                                | Effect's own sinks                                            |
+| [`unique`](#consuming-a-stream)                                           | Consumed                                       | A query expected to return at most one row                                | `Stream.runHead` with a uniqueness check                      |
+| [`paginate`](#paginating-a-stream)                                        | Consumed                                       | Keyset pagination: `WHERE key > :cursor ORDER BY key LIMIT n`             | `Stream.take(numItems)` after narrowing to the cursor         |
 
 ## Creating a stream
 
@@ -154,9 +170,7 @@ Fields must be used in the order the index declares them, and each method only o
 
 ### Order keys
 
-The fields that still vary after pinning, followed by the implicit `_creationTime` tiebreaker, form the stream's **order key**. It is part of the stream's type: `reader.table("notes").stream("by_text")` has the type `QueryStream<Doc, ["text", "_creationTime"], DocumentDecodeError, never, "asc">` (the document, the order key, the error and requirement channels, and the order direction), while pinning the text with `eq` leaves `["_creationTime"]`.
-
-The order key determines which streams can be merged: two streams can only be merged when their order keys are the same, so a mismatch is caught at compile time.
+The fields that still vary after pinning, followed by the implicit `_creationTime` tiebreaker, form the stream's [order key](#the-ordering-contract). `reader.table("notes").stream("by_text")` has the key `["text", "_creationTime"]`, while pinning the text with `eq` leaves `["_creationTime"]`. The key is what decides which streams can be merged.
 
 ### Empty streams
 
@@ -237,9 +251,9 @@ eq "apple"    ─ n1 ──────── n3 ───────┤   → 
 eq "fig"      ┤   → None
 ```
 
-## Combining streams
+## Composing streams
 
-Each combinator below returns another query stream, so results stay mergeable and paginable.
+Each operation below returns another query stream, so results stay mergeable and paginable. They are grouped by what they do to the [order key](#the-ordering-contract): `merge` combines streams that share one; `filter`, `map`, `distinct`, and `narrow` keep it; `flatMap` extends it; `renameKey` relabels it; `reverse` flips its direction.
 
 ### Merge
 
@@ -351,90 +365,6 @@ reader
   );
 ```
 
-### Join
-
-`QueryStream.flatMap` runs an inner stream for each document of an outer stream and concatenates the results, ordered by the outer key and then the inner key.
-
-In SQL terms, `flatMap` is `CROSS JOIN LATERAL` (`CROSS APPLY`): the inner query can reference the outer row, and the result is ordered by the outer key, then the inner key. An outer row whose inner query returns nothing contributes no rows, so this is an inner join, not a left join.
-
-```ts
-// The comments on admin notes, grouped by note in note order and by
-// creation time within each note.
-const commentsOn = (note: NotesDoc) =>
-  reader.table("comments").stream("by_note", (q) => q.eq("noteId", note._id));
-
-reader
-  .table("notes")
-  .stream("by_role", (q) => q.eq("author.role", "admin"))
-  .pipe(QueryStream.flatMap(commentsOn, { innerKey: ["_creationTime"] }));
-```
-
-Each admin note's comment stream runs in turn. The result's key is the outer key followed by the inner key; `n5` has no comments, so it contributes only a filtered marker that keeps cursors moving:
-
-{/* stream-diagram: join */}
-
-```text
-admin         ─ n1 ──────────────────── n4 ──────── n5 ───────┤
-                [1]                     [4]         [5]
-of n1         ─ c1 ──────── c2 ───────
-of n4                                 ─ c3 ───────
-of n5                                             ┤
-
-              ╞═ flatMap((note) => commentsOn(note), { innerKey: ["_creationTime"] }) ═╡
-
-joined        ─ c1 ──────── c2 ──────── c3 ──────── (n5) ─────┤
-                [1,7]       [1,8]       [4,9]       [5,null]
-```
-
-Pass the inner streams' order key as `innerKey`; it is checked against the type of the stream the function returns. Inner streams must run in the outer stream's direction: with `QueryStream.flatMap(outer, f, options)` the outer stream fixes it and a differing inner stream is a type error, while with `outer.pipe(QueryStream.flatMap(f, options))` the inner streams fix it. A mismatch the types can't see fails when the join runs.
-
-The result's order key is the concatenation `["_creationTime", "_creationTime"]` here: the outer note's, then the comment's.
-
-### Left join
-
-`QueryStream.leftJoin` is `flatMap` that keeps outer documents whose inner stream is empty, emitting `onEmpty(outer)` in their place.
-
-In SQL terms, it is `LEFT JOIN LATERAL`: an outer row with no inner rows still appears once, with `onEmpty` standing in for the `NULL` inner columns, so every outer document contributes at least one element.
-
-```ts
-// Every admin note with its comments, and notes without any as a single
-// entry saying so.
-reader
-  .table("notes")
-  .stream("by_role", (q) => q.eq("author.role", "admin"))
-  .pipe(
-    QueryStream.leftJoin(
-      (note) =>
-        commentsOn(note).pipe(
-          QueryStream.map((comment) => ({ note, comment })),
-        ),
-      {
-        innerKey: ["_creationTime"],
-        onEmpty: (note) => ({ note, comment: undefined }),
-      },
-    ),
-  );
-```
-
-The placeholder (`∅n5`, that is `onEmpty(n5)`) takes the position the filtered marker had in the inner join, so it sorts first within its outer document and pagination steps past it like any element:
-
-{/* stream-diagram: left-join */}
-
-```text
-admin         ─ n1 ──────────────────── n4 ──────── n5 ───────┤
-                [1]                     [4]         [5]
-of n1         ─ c1 ──────── c2 ───────
-of n4                                 ─ c3 ───────
-of n5                                             ┤
-
-              ╞═ leftJoin((note) => commentsOn(note), { innerKey, onEmpty }) ═╡
-
-joined        ─ c1 ──────── c2 ──────── c3 ──────── ∅n5 ──────┤
-                [1,7]       [1,8]       [4,9]       [5,null]
-```
-
-The elements are the inner stream's documents or the placeholders, so give both a common shape as above. Outer documents filtered out before the join stay absent. Everything else, including the `innerKey` check and the direction rules, is `flatMap`'s.
-
 ### Distinct
 
 `QueryStream.distinct` keeps the first document for each distinct value of a prefix of the order key.
@@ -465,11 +395,125 @@ distinct      ─ n1 ───────────────────�
 
 The fields must be a prefix of the stream's order key, which is enforced at the type level. On a `flatMap` result, a prefix that reaches into the inner key groups by the outer document as well, since groups are runs of consecutive equal keys. A distinct stream can't be [reversed](#reverse), since the other direction would keep a different document per group. Apply `filter` (or `filterEffect`) _after_ `distinct` rather than before it, so that a filtered-out document can't hide its group's first match from a resumed page.
 
+### Narrow to a key range
+
+`QueryStream.narrow` restricts a stream to the order keys strictly after `after` and at or before `until`, in stream order. `paginate` uses it to resume from a cursor; call it yourself to bound a composed stream by key.
+
+In SQL terms, it adds keyset predicates on the `ORDER BY` columns, `WHERE (text, _creationTime) > (:after) AND (text, _creationTime) <= (:until)`, to every query in the composition. The bounds are pushed down through every combinator into the index ranges of the underlying queries, so the skipped keys are never read.
+
+```ts
+const between = QueryStream.narrow(reader.table("notes").stream("by_text"), {
+  after: ["banana", 2],
+  until: ["cherry", 4],
+});
+```
+
+The bounds become index-range predicates on the leaf, so the elements outside them are not read at all:
+
+{/* stream-diagram: narrow */}
+
+```text
+by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
+                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
+                                                  ╎ after                 ╎ until
+
+              ╞═ narrow({ after: [banana, 2], until: [cherry, 4] }) ═╡
+
+narrowed      ───────────────────────────────────── n5 ──────── n4 ───────┤
+                                                    [banana,5]  [cherry,4]
+```
+
+Cursors are serialized keys: `QueryStream.deserializeCursor(page.continueCursor)` turns a page's cursor into an `after` bound.
+
+### Flat-map
+
+`QueryStream.flatMap` runs an inner stream for each document of an outer stream and concatenates the results, ordered by the outer key and then the inner key.
+
+In SQL terms, `flatMap` is `CROSS JOIN LATERAL` (`CROSS APPLY`): the inner query can reference the outer row, and the result is ordered by the outer key, then the inner key. An outer row whose inner query returns nothing contributes no rows, so this is an inner join; [`onEmpty`](#keep-outer-documents-without-inner-documents) makes it a left join.
+
+```ts
+// The comments on admin notes, grouped by note in note order and by
+// creation time within each note.
+const commentsOn = (note: NotesDoc) =>
+  reader.table("comments").stream("by_note", (q) => q.eq("noteId", note._id));
+
+reader
+  .table("notes")
+  .stream("by_role", (q) => q.eq("author.role", "admin"))
+  .pipe(QueryStream.flatMap(commentsOn, { innerKey: ["_creationTime"] }));
+```
+
+Each admin note's comment stream runs in turn. The result's key is the outer key followed by the inner key; `n5` has no comments, so it contributes only a filtered marker that keeps cursors moving:
+
+{/* stream-diagram: flat-map */}
+
+```text
+admin         ─ n1 ──────────────────── n4 ──────── n5 ───────┤
+                [1]                     [4]         [5]
+of n1         ─ c1 ──────── c2 ───────
+of n4                                 ─ c3 ───────
+of n5                                             ┤
+
+              ╞═ flatMap((note) => commentsOn(note), { innerKey: ["_creationTime"] }) ═╡
+
+joined        ─ c1 ──────── c2 ──────── c3 ──────── (n5) ─────┤
+                [1,7]       [1,8]       [4,9]       [5,null]
+```
+
+Pass the inner streams' order key as `innerKey`; it is checked against the type of the stream the function returns. Inner streams must run in the outer stream's direction: with `QueryStream.flatMap(outer, f, options)` the outer stream fixes it and a differing inner stream is a type error, while with `outer.pipe(QueryStream.flatMap(f, options))` the inner streams fix it. A mismatch the types can't see fails when the join runs.
+
+The result's order key is the concatenation `["_creationTime", "_creationTime"]` here: the outer note's, then the comment's.
+
+### Keep outer documents without inner documents
+
+By default an outer document whose inner stream is empty contributes nothing. Pass `onEmpty` to `flatMap` to keep it: the document is emitted as `onEmpty(outer)`, and the element type widens to include that placeholder.
+
+In SQL terms, `onEmpty` turns the `CROSS JOIN LATERAL` into a `LEFT JOIN LATERAL`: an outer row with no inner rows still appears once, with the placeholder standing in for the `NULL` inner columns, so every outer document contributes at least one element.
+
+```ts
+// Every admin note with its comments, and notes without any as a single
+// entry saying so.
+reader
+  .table("notes")
+  .stream("by_role", (q) => q.eq("author.role", "admin"))
+  .pipe(
+    QueryStream.flatMap(
+      (note) =>
+        commentsOn(note).pipe(
+          QueryStream.map((comment) => ({ note, comment })),
+        ),
+      {
+        innerKey: ["_creationTime"],
+        onEmpty: (note) => ({ note, comment: undefined }),
+      },
+    ),
+  );
+```
+
+The placeholder (`∅n5`, that is `onEmpty(n5)`) takes the position the filtered marker had without `onEmpty`, so it sorts first within its outer document and pagination steps past it like any element:
+
+{/* stream-diagram: on-empty */}
+
+```text
+admin         ─ n1 ──────────────────── n4 ──────── n5 ───────┤
+                [1]                     [4]         [5]
+of n1         ─ c1 ──────── c2 ───────
+of n4                                 ─ c3 ───────
+of n5                                             ┤
+
+              ╞═ flatMap((note) => commentsOn(note), { innerKey, onEmpty }) ═╡
+
+joined        ─ c1 ──────── c2 ──────── c3 ──────── ∅n5 ──────┤
+                [1,7]       [1,8]       [4,9]       [5,null]
+```
+
+The elements are the inner stream's documents or the placeholders, so give both a common shape as above. Outer documents filtered out before the join stay absent. Everything else, including the `innerKey` check and the direction rules, is unchanged.
+
 ### Rename the order key
 
-`QueryStream.orderBy` relabels a stream's order key positionally without changing how it is sorted.
+`QueryStream.renameKey` relabels a stream's order key positionally. It does not sort: the elements and their order are untouched.
 
-In SQL terms, it is column aliasing (`AS`) that makes the branches of a `UNION ALL` line up by position. It is not `ORDER BY`, which it does not change; the elements and their order are untouched.
+In SQL terms, it is column aliasing (`AS`) that makes the branches of a `UNION ALL` line up by position, not `ORDER BY`.
 
 Use it to merge streams from different indexes or tables that sort by the same kind of value under different field names. Since merged streams must also share a document type, map each side to a common shape first:
 
@@ -495,20 +539,20 @@ const entries = QueryStream.merge([
         kind: "comment",
         text: comment.body,
       })),
-      QueryStream.orderBy(["text", "_creationTime"]),
+      QueryStream.renameKey(["text", "_creationTime"]),
     ),
 ]);
 ```
 
 Relabeling changes the key's field names and nothing else:
 
-{/* stream-diagram: order-by */}
+{/* stream-diagram: rename-key */}
 
 ```text
 by_body       ─ c1 ──────── c2 ──────── c3 ───────┤
                 [great,7]   [meh,8]     [nice,9]     key: [body, _creationTime]
 
-              ╞═ orderBy(["text", "_creationTime"]) ═╡
+              ╞═ renameKey(["text", "_creationTime"]) ═╡
 
 relabeled     ─ c1 ──────── c2 ──────── c3 ───────┤
                 [great,7]   [meh,8]     [nice,9]     key: [text, _creationTime]
@@ -516,7 +560,7 @@ relabeled     ─ c1 ──────── c2 ──────── c3 ─
 
 With matching key names, the two streams merge by their key values — here, alphabetically:
 
-{/* stream-diagram: order-by-merge */}
+{/* stream-diagram: rename-key-merge */}
 
 ```text
 notes         ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────────────────────────────────────────┤
@@ -555,37 +599,7 @@ reversed      ─ n6 ──────── n5 ──────── n4 ─
                 [6]         [5]         [4]         [3]         [2]         [1]
 ```
 
-Merges, filters and maps, joins (their inner streams included), `orderBy`, and `empty` all reverse. A `distinct` stream can't: it keeps the first document of each group, and a reversed scan would keep the last, so `reverse` throws. For the mirror query, reverse the input and apply `distinct` to that.
-
-### Narrow to a key range
-
-`QueryStream.narrow` restricts a stream to the order keys strictly after `after` and at or before `until`, in stream order. `paginate` uses it to resume from a cursor; call it yourself to bound a composed stream by key.
-
-In SQL terms, it adds keyset predicates on the `ORDER BY` columns, `WHERE (text, _creationTime) > (:after) AND (text, _creationTime) <= (:until)`, to every query in the composition. The bounds are pushed down through every combinator into the index ranges of the underlying queries, so the skipped keys are never read.
-
-```ts
-const between = QueryStream.narrow(reader.table("notes").stream("by_text"), {
-  after: ["banana", 2],
-  until: ["cherry", 4],
-});
-```
-
-The bounds become index-range predicates on the leaf, so the elements outside them are not read at all:
-
-{/* stream-diagram: narrow */}
-
-```text
-by_text       ─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
-                [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
-                                                  ╎ after                 ╎ until
-
-              ╞═ narrow({ after: [banana, 2], until: [cherry, 4] }) ═╡
-
-narrowed      ───────────────────────────────────── n5 ──────── n4 ───────┤
-                                                    [banana,5]  [cherry,4]
-```
-
-Cursors are serialized keys: `QueryStream.deserializeCursor(page.continueCursor)` turns a page's cursor into an `after` bound.
+Merges, filters and maps, flat-maps (their inner streams included), `renameKey`, and `empty` all reverse. A `distinct` stream can't: it keeps the first document of each group, and a reversed scan would keep the last, so `reverse` throws. For the mirror query, reverse the input and apply `distinct` to that.
 
 ## Paginating a stream
 

--- a/notes/stream-based-querying.md
+++ b/notes/stream-based-querying.md
@@ -441,7 +441,7 @@ The core of §4 is now implemented as an experimental API:
   type-level constraint (`Key` must extend `readonly [...Fields,
 ...rest]`); narrowing truncates bound keys to the distinct prefix, as in
   `convex-helpers`.
-- **`orderBy`** — re-keying: a position-for-position relabeling of the
+- **`renameKey`** — re-keying: a position-for-position relabeling of the
   order key (tuple-length-checked at the type level) that makes streams
   from different indexes or tables mergeable when their keys align
   positionally. Because order keys and bounds are pure _values_, the

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -633,7 +633,7 @@ export class QueryStream<
      * Positions in `keyFields` of the implicit `_id` tiebreakers the
      * type-level `Key` omits: normally the trailing one, plus — on a
      * `flatMap` result — the outer key's interior one. Combinators that
-     * relate the type-level key to the runtime key (`orderBy`, `distinct`)
+     * relate the type-level key to the runtime key (`renameKey`, `distinct`)
      * skip over them. Defaults to the trailing `_id`, if any.
      */
     readonly tiebreakers: ReadonlyArray<number> = appendedTiebreaker(
@@ -704,7 +704,8 @@ export const isQueryStream = (u: unknown): u is Any =>
  *
  * In SQL terms: the empty relation — `SELECT ... WHERE false` with the same
  * `ORDER BY` — so it merges with, and paginates like, any stream of that
- * key. *
+ * key.
+ *
  * Nothing can infer the document type from no documents, so it is supplied
  * as a type argument in a first, otherwise empty call:
  * `QueryStream.empty<NotesDoc>()(["text", "_creationTime"], "desc")`. The
@@ -844,7 +845,8 @@ const intersectIndexBounds = (
  * In SQL terms: an index range scan — `SELECT * FROM table WHERE <range>
  * ORDER BY <index fields> [DESC]`; the order key is the `ORDER BY` columns
  * left after the equality predicates. The value is a reusable description
- * of a query rather than a result. *
+ * of a query rather than a result.
+ *
  * Each run rebuilds the Convex queries from the reflection — the leaf's
  * bounds decomposed into Convex-expressible index ranges via `splitRange`
  * — and order keys are extracted from the *encoded* document before schema
@@ -1114,7 +1116,8 @@ const mergeStep =
  * result still in that order (a planner's merge append). It is an ordered
  * merge — the step of merge sort that combines sorted runs, always emitting
  * the smallest next key (the largest, descending) — not `Stream.merge`,
- * which interleaves inputs in arrival order. *
+ * which interleaves inputs in arrival order.
+ *
  * Streams with different order keys are a **type error** (`Key` is
  * invariant), and so are different directions: the first stream fixes the
  * direction and each later one must be assignable to it. A mismatch the
@@ -1286,7 +1289,8 @@ export interface EffectOptions {
  *
  * In SQL terms: a `WHERE` on any column, evaluated after the index scan —
  * rows it rejects were still read, and filtered-out elements still advance
- * cursors, so the result stays mergeable and paginable. *
+ * cursors, so the result stays mergeable and paginable.
+ *
  * Use `filterEffect` when the predicate needs to read the database or
  * another service.
  */
@@ -1365,7 +1369,8 @@ export const filterEffect = dual<
  *
  * In SQL terms: the `SELECT` list — projecting or computing columns while
  * the `ORDER BY` columns stay in force, so the result stays mergeable and
- * paginable. *
+ * paginable.
+ *
  * The mapper must not change the ordering semantics. Use `mapEffect` when
  * the mapper needs to read the database or another service.
  */
@@ -1399,7 +1404,8 @@ export const map = dual<
  *
  * In SQL terms: a scalar subquery in the `SELECT` list — a computed column
  * that reads other tables. The mapper's `E2`/`R2` flow into the stream's
- * channels. *
+ * channels.
+ *
  * The mapper must not change the ordering semantics.
  */
 export const mapEffect = dual<
@@ -1441,14 +1447,24 @@ export const mapEffect = dual<
  * In SQL terms: `CROSS JOIN LATERAL` (`CROSS APPLY`): the inner query can
  * reference the outer row, and the result is ordered by the outer key, then
  * the inner key. An outer row with no inner rows contributes none — an
- * inner join, not a left join. Inner streams run sequentially — each outer
+ * inner join — unless `options.onEmpty` is given, which makes it `LEFT JOIN
+ * LATERAL`: the row still appears once, with `onEmpty(outer)` standing in
+ * for the `NULL` inner columns. Inner streams run sequentially — each outer
  * element's is drained before the next outer element's begins — and the
  * order key is extended by the inner key (`flatMap` on `convex-helpers`
- * streams). *
+ * streams).
+ *
  * `options.innerKey` is the order key shared by *every* inner stream —
  * checked against `f`'s return type, so a mismatched literal is a type
  * error; each produced stream is also validated at runtime (a defect on
  * mismatch, like `merge`).
+ *
+ * `options.onEmpty` keeps outer documents whose inner stream is empty,
+ * emitting `onEmpty(outer)` in their place; the element type widens to
+ * include the placeholder. The placeholder takes the position an empty
+ * inner stream's marker would (the outer key followed by `null`s), so it
+ * sorts first within its outer document and pagination resumes past it like
+ * any element. Outer documents filtered out upstream stay absent.
  *
  * Cursor accounting: an outer document whose inner stream is empty — or
  * that was filtered out upstream — still contributes one filtered element
@@ -1474,13 +1490,17 @@ export const flatMap = dual<
     E2,
     R2,
     Direction extends OrderDirection,
+    Doc3 = never,
   >(
     f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
-    options: { readonly innerKey: NoInfer<InnerKey> },
+    options: {
+      readonly innerKey: NoInfer<InnerKey>;
+      readonly onEmpty?: ((doc: Doc) => Doc3) | undefined;
+    },
   ) => <Key extends ReadonlyArray<string>, E, R>(
     self: QueryStream<Doc, Key, E, R, Direction>,
   ) => QueryStream<
-    Doc2,
+    Doc2 | Doc3,
     readonly [...Key, ...InnerKey],
     E | E2,
     R | R2,
@@ -1496,12 +1516,16 @@ export const flatMap = dual<
     E2,
     R2,
     Direction extends OrderDirection,
+    Doc3 = never,
   >(
     self: QueryStream<Doc, Key, E, R, Direction>,
     f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, NoInfer<Direction>>,
-    options: { readonly innerKey: NoInfer<InnerKey> },
+    options: {
+      readonly innerKey: NoInfer<InnerKey>;
+      readonly onEmpty?: ((doc: Doc) => Doc3) | undefined;
+    },
   ) => QueryStream<
-    Doc2,
+    Doc2 | Doc3,
     readonly [...Key, ...InnerKey],
     E | E2,
     R | R2,
@@ -1510,80 +1534,6 @@ export const flatMap = dual<
 >(3, (self, f, options) => {
   // Runtime inner key fields follow the same convention as leaves: the
   // type-level key plus the implicit `_id` tiebreaker.
-  const innerKeyFields = withIdTiebreaker(options.innerKey);
-  return makeFlatMap(
-    self,
-    f,
-    innerKeyFields,
-    appendedTiebreaker(options.innerKey, innerKeyFields),
-    undefined,
-    {},
-  );
-});
-
-/**
- * A left join: `flatMap` that keeps outer documents whose inner stream is
- * empty, emitting `onEmpty(outer)` in their place.
- *
- * In SQL terms: `LEFT JOIN LATERAL` — an outer row with no inner rows still
- * appears once, with `onEmpty` standing in for the `NULL` inner columns, so
- * every outer document contributes at least one element. *
- * The placeholder takes the position an empty inner stream's marker would
- * (the outer key followed by `null`s), so it sorts first within its outer
- * document and pagination resumes past it like any element. Outer
- * documents filtered out upstream stay absent. Everything else — the
- * `innerKey` check, the direction rules, narrowing — is `flatMap`'s.
- */
-export const leftJoin = dual<
-  <
-    Doc,
-    Doc2,
-    Doc3,
-    InnerKey extends ReadonlyArray<string>,
-    E2,
-    R2,
-    Direction extends OrderDirection,
-  >(
-    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
-    options: {
-      readonly innerKey: NoInfer<InnerKey>;
-      readonly onEmpty: (doc: Doc) => Doc3;
-    },
-  ) => <Key extends ReadonlyArray<string>, E, R>(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<
-    Doc2 | Doc3,
-    readonly [...Key, ...InnerKey],
-    E | E2,
-    R | R2,
-    Direction
-  >,
-  <
-    Doc,
-    Key extends ReadonlyArray<string>,
-    E,
-    R,
-    Doc2,
-    Doc3,
-    InnerKey extends ReadonlyArray<string>,
-    E2,
-    R2,
-    Direction extends OrderDirection,
-  >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, NoInfer<Direction>>,
-    options: {
-      readonly innerKey: NoInfer<InnerKey>;
-      readonly onEmpty: (doc: Doc) => Doc3;
-    },
-  ) => QueryStream<
-    Doc2 | Doc3,
-    readonly [...Key, ...InnerKey],
-    E | E2,
-    R | R2,
-    Direction
-  >
->(3, (self, f, options) => {
   const innerKeyFields = withIdTiebreaker(options.innerKey);
   return makeFlatMap(
     self,
@@ -1658,7 +1608,7 @@ const makeFlatMap = <
   f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
   innerKeyFields: ReadonlyArray<string>,
   innerTiebreakers: ReadonlyArray<number>,
-  /** Present for a left join: what an outer document with no inner rows emits. */
+  /** What an outer document with no inner rows emits, if it is kept. */
   onEmpty: ((doc: Doc) => Doc3) | undefined,
   refinements: InnerRefinements,
 ): QueryStream<
@@ -1672,7 +1622,7 @@ const makeFlatMap = <
   const keyFields = Array.appendAll(self.keyFields, innerKeyFields);
   // The joined key keeps the outer key's tiebreaker *inside* it: the
   // type-level key `[...Key, ...InnerKey]` omits it, so it's recorded as a
-  // tiebreaker position for `orderBy`/`distinct` to skip.
+  // tiebreaker position for `renameKey`/`distinct` to skip.
   const tiebreakers = Array.appendAll(
     self.tiebreakers,
     Array.map(innerTiebreakers, (position) => position + outerLength),
@@ -1829,7 +1779,8 @@ const makeFlatMap = <
  * prefix, ...` — the first row of each group — executed as a loose index
  * scan (skip scan): after a group's first document, the underlying stream
  * is narrowed past the entire group, so each group costs one index seek
- * instead of a scan. *
+ * instead of a scan.
+ *
  * `fields` must be a prefix of the stream's order key — enforced at the
  * type level (`Key` must extend `readonly [...Fields, ...rest]`) and
  * validated at runtime.
@@ -1884,7 +1835,8 @@ export const distinct = dual<
  * In SQL terms: column aliases (`AS`) that make the branches of a `UNION
  * ALL` line up by position; not `ORDER BY`, which it does not change. The
  * elements and their order are untouched — it exists so that `merge`
- * accepts streams whose keys agree positionally. *
+ * accepts streams whose keys agree positionally.
+ *
  * Order keys are *values*, so relabeling changes only the names used for
  * compatibility validation — the element order is untouched, and narrowing
  * passes bounds through to the underlying stream unchanged. Use it to make
@@ -1901,7 +1853,7 @@ export const distinct = dual<
  * type-level key omits — the trailing one, and a `flatMap` result's
  * interior one — keep their names and positions.
  */
-export const orderBy = dual<
+export const renameKey = dual<
   <const NewKey extends ReadonlyArray<string>>(
     key: NewKey,
   ) => <
@@ -1928,9 +1880,9 @@ export const orderBy = dual<
     self: QueryStream<Doc, Key, E, R, Direction>,
     key: NewKey,
   ) => QueryStream<Doc, Types.Mutable<NewKey>, E, R, Direction>
->(2, (self, key) => orderByImpl(self, key));
+>(2, (self, key) => renameKeyImpl(self, key));
 
-const orderByImpl = <
+const renameKeyImpl = <
   Doc,
   Key extends ReadonlyArray<string>,
   E,
@@ -1944,7 +1896,7 @@ const orderByImpl = <
   const visible = visibleKeyFields(self);
   if (key.length !== visible.length) {
     throw new Error(
-      `QueryStream.orderBy: key ([${Array.join(key, ", ")}]) must have as many fields as the stream's order key ([${Array.join(visible, ", ")}])`,
+      `QueryStream.renameKey: key ([${Array.join(key, ", ")}]) must have as many fields as the stream's order key ([${Array.join(visible, ", ")}])`,
     );
   }
   // Relabel the type-visible positions in order; tiebreakers keep their
@@ -1959,7 +1911,8 @@ const orderByImpl = <
               Array.filter(self.tiebreakers, (position) => position < index)
                 .length,
           ),
-          () => new Error("QueryStream.orderBy: key/order-key length mismatch"),
+          () =>
+            new Error("QueryStream.renameKey: key/order-key length mismatch"),
         ),
   );
   return new QueryStream(
@@ -1969,9 +1922,9 @@ const orderByImpl = <
     undefined,
     // Bounds are positional values, so they apply to the underlying
     // stream as-is.
-    (bounds) => orderByImpl(narrowByKeyBounds(self, bounds), key),
+    (bounds) => renameKeyImpl(narrowByKeyBounds(self, bounds), key),
     self.tiebreakers,
-    () => orderByImpl(reverse(self), key),
+    () => renameKeyImpl(reverse(self), key),
   );
 };
 
@@ -2061,8 +2014,9 @@ const makeDistinct = <
  * whole query. Every leaf is rebuilt in the other `order`, so the elements
  * come out reversed but are read that way from the index rather than
  * collected and reversed, and the result is still a query stream — a
- * paginated feed can load its earlier pages with it. *
- * `merge`, the transforms, `flatMap`/`leftJoin`, `orderBy`, and `empty`
+ * paginated feed can load its earlier pages with it.
+ *
+ * `merge`, the transforms, `flatMap`, `renameKey`, and `empty`
  * reverse their inputs and re-apply themselves. A `distinct` stream can't
  * be reversed: it keeps the *first* document of each group, and a reversed
  * scan would keep the last, so `reverse` throws — reverse the input and
@@ -2397,7 +2351,8 @@ const midpointCursor = (readKeys: Chunk.Chunk<OrderKey>): string =>
  * `LIMIT`. It runs the stream narrowed to the keys after `cursor` (and up
  * to `endCursor`, when given), folds `numItems` present documents into a
  * page, and reports the key it stopped at as the next cursor; a cursor is a
- * key, not an offset, so a page costs one page of reads wherever it starts. *
+ * key, not an offset, so a page costs one page of reads wherever it starts.
+ *
  * Semantics follow `convex-helpers/server/stream`:
  *
  * - `cursor` is exclusive, `endCursor` inclusive; when `endCursor` is set,

--- a/packages/server/test/QueryStream.bench.ts
+++ b/packages/server/test/QueryStream.bench.ts
@@ -58,7 +58,7 @@ bench("flatMap", () => {
   return QueryStream.flatMap(notes, messagesOf, {
     innerKey: ["_creationTime"],
   });
-}).types([179, "instantiations"]);
+}).types([192, "instantiations"]);
 
 bench("stream → filter → merge → flatMap → paginate", () => {
   return QueryStream.merge([
@@ -68,4 +68,4 @@ bench("stream → filter → merge → flatMap → paginate", () => {
     QueryStream.flatMap(messagesOf, { innerKey: ["_creationTime"] }),
     QueryStream.paginate(paginationOpts),
   );
-}).types([2476, "instantiations"]);
+}).types([2491, "instantiations"]);

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -779,70 +779,72 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
-  it.effect("leftJoin keeps outer documents that have no inner rows", () =>
-    Effect.gen(function* () {
-      const c = yield* TestConfect.TestConfect;
+  it.effect(
+    "flatMap with onEmpty keeps outer documents that have no inner rows",
+    () =>
+      Effect.gen(function* () {
+        const c = yield* TestConfect.TestConfect;
 
-      yield* c.run(
-        Effect.gen(function* () {
-          const writer = yield* DatabaseWriter;
-          const reader = yield* DatabaseReader;
+        yield* c.run(
+          Effect.gen(function* () {
+            const writer = yield* DatabaseWriter;
+            const reader = yield* DatabaseReader;
 
-          for (const [text, tag] of [
-            ["b", "b1"],
-            ["a", "a1"],
-            ["a", "a2"],
-            ["x0", "none"],
-            ["x1", "a"],
-            ["x2", "b"],
-          ] as const) {
-            yield* writer.table("notes").insert({ text, tag });
-          }
+            for (const [text, tag] of [
+              ["b", "b1"],
+              ["a", "a1"],
+              ["a", "a2"],
+              ["x0", "none"],
+              ["x1", "a"],
+              ["x2", "b"],
+            ] as const) {
+              yield* writer.table("notes").insert({ text, tag });
+            }
 
-          const outer = reader
-            .table("notes")
-            .stream("by_text", (q) => q.gte("text", "x"));
-          type Note =
-            typeof outer extends Stream.Stream<infer A, any, any> ? A : never;
-          const inner = (note: Note) =>
-            reader
+            const outer = reader
               .table("notes")
-              .stream("by_text", (q) => q.eq("text", note.tag ?? ""));
+              .stream("by_text", (q) => q.gte("text", "x"));
+            type Note =
+              typeof outer extends Stream.Stream<infer A, any, any> ? A : never;
+            const inner = (note: Note) =>
+              reader
+                .table("notes")
+                .stream("by_text", (q) => q.eq("text", note.tag ?? ""));
 
-          // "x0" has no inner rows: the placeholder stands in for them, in
-          // the position its inner rows would have had, and pagination
-          // steps past it like any element.
-          const joined = outer.pipe(
-            QueryStream.leftJoin(inner, {
-              innerKey: ["_creationTime"],
-              onEmpty: (note) => ({ tag: `none for ${note.text}` }),
-            }),
-          );
-          const pages = yield* paginateAll(joined, 1);
-          expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
-            ["none for x0"],
-            ["a1"],
-            ["a2"],
-            ["b1"],
-          ]);
+            // "x0" has no inner rows: the placeholder stands in for them, in
+            // the position its inner rows would have had, and pagination
+            // steps past it like any element.
+            const joined = outer.pipe(
+              QueryStream.flatMap(inner, {
+                innerKey: ["_creationTime"],
+                onEmpty: (note) => ({ tag: `none for ${note.text}` }),
+              }),
+            );
+            const pages = yield* paginateAll(joined, 1);
+            expect(pages.map((page) => page.map((doc) => doc.tag))).toEqual([
+              ["none for x0"],
+              ["a1"],
+              ["a2"],
+              ["b1"],
+            ]);
 
-          // An outer document filtered out upstream contributes no
-          // placeholder.
-          const withoutX0 = outer.pipe(
-            QueryStream.filter((note) => note.text !== "x0"),
-            QueryStream.leftJoin(inner, {
-              innerKey: ["_creationTime"],
-              onEmpty: (note) => ({ tag: `none for ${note.text}` }),
-            }),
-          );
-          expect(
-            yield* Stream.runCollect(withoutX0).pipe(
-              Effect.map((docs) => docs.map((doc) => doc.tag)),
-            ),
-          ).toEqual(["a1", "a2", "b1"]);
-        }),
-      );
-    }).pipe(Effect.provide(TestConfect.layer)),
+            // An outer document filtered out upstream contributes no
+            // placeholder.
+            const withoutX0 = outer.pipe(
+              QueryStream.filter((note) => note.text !== "x0"),
+              QueryStream.flatMap(inner, {
+                innerKey: ["_creationTime"],
+                onEmpty: (note) => ({ tag: `none for ${note.text}` }),
+              }),
+            );
+            expect(
+              yield* Stream.runCollect(withoutX0).pipe(
+                Effect.map((docs) => docs.map((doc) => doc.tag)),
+              ),
+            ).toEqual(["a1", "a2", "b1"]);
+          }),
+        );
+      }).pipe(Effect.provide(TestConfect.layer)),
   );
 
   it.effect("effectful transforms keep stream order at any concurrency", () =>
@@ -1064,7 +1066,7 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
-  it.effect("orderBy relabels order keys so foreign streams merge", () =>
+  it.effect("renameKey relabels order keys so foreign streams merge", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
 
@@ -1100,7 +1102,7 @@ describe("QueryStream", () => {
           // interleaves the values: "a" < "admin" < "m" < "user".
           const merged = QueryStream.merge([
             byText,
-            byRole.pipe(QueryStream.orderBy(["text", "_creationTime"])),
+            byRole.pipe(QueryStream.renameKey(["text", "_creationTime"])),
           ]);
 
           const tags = yield* Stream.runCollect(merged).pipe(
@@ -1123,7 +1125,7 @@ describe("QueryStream", () => {
     }).pipe(Effect.provide(TestConfect.layer)),
   );
 
-  it.effect("orderBy and distinct see through flatMap tiebreakers", () =>
+  it.effect("renameKey and distinct see through flatMap tiebreakers", () =>
     Effect.gen(function* () {
       const c = yield* TestConfect.TestConfect;
 
@@ -1174,7 +1176,11 @@ describe("QueryStream", () => {
 
           // Relabeling names only the type-visible positions.
           const relabeled = joined.pipe(
-            QueryStream.orderBy(["outerText", "outerCreated", "innerCreated"]),
+            QueryStream.renameKey([
+              "outerText",
+              "outerCreated",
+              "innerCreated",
+            ]),
           );
           expect(relabeled.keyFields).toEqual([
             "outerText",
@@ -1503,6 +1509,12 @@ describe("QueryStream types", () => {
       expectTypeOf<KeyOf<typeof joined>>().toEqualTypeOf<
         readonly ["text", "_creationTime", "_creationTime"]
       >();
+      // Without onEmpty, the elements are exactly the inner documents.
+      expectTypeOf<
+        typeof joined extends Stream.Stream<infer A, any, any> ? A : never
+      >().toEqualTypeOf<
+        typeof pinned extends Stream.Stream<infer A, any, any> ? A : never
+      >();
 
       const joinedMismatched = QueryStream.flatMap(bounded, (_note) => pinned, {
         // @ts-expect-error — innerKey must match the inner stream's order key.
@@ -1524,14 +1536,17 @@ describe("QueryStream types", () => {
       const distinctPinnedAway = QueryStream.distinct(pinned, ["text"]);
       void distinctPinnedAway;
 
-      // orderBy relabels the order key position-for-position.
-      const relabeled = QueryStream.orderBy(full, ["renamed", "_creationTime"]);
+      // renameKey relabels the order key position-for-position.
+      const relabeled = QueryStream.renameKey(full, [
+        "renamed",
+        "_creationTime",
+      ]);
       expectTypeOf<KeyOf<typeof relabeled>>().toEqualTypeOf<
         ["renamed", "_creationTime"]
       >();
 
       // @ts-expect-error — the new key must have as many fields as the old.
-      const relabeledTooShort = QueryStream.orderBy(full, ["_creationTime"]);
+      const relabeledTooShort = QueryStream.renameKey(full, ["_creationTime"]);
       void relabeledTooShort;
 
       // empty takes its document type explicitly and its key literally.
@@ -1551,23 +1566,25 @@ describe("QueryStream types", () => {
         DirectionOf<typeof nothingDescending>
       >().toEqualTypeOf<"desc">();
 
-      // leftJoin's elements are the inner documents or the placeholder.
-      const leftJoined = QueryStream.leftJoin(bounded, (_note) => pinned, {
+      // With onEmpty, the elements are the inner documents or the placeholder.
+      const withPlaceholder = QueryStream.flatMap(bounded, (_note) => pinned, {
         innerKey: ["_creationTime"],
         onEmpty: (note) => ({ missingFor: note.text }),
       });
-      expectTypeOf<KeyOf<typeof leftJoined>>().toEqualTypeOf<
+      expectTypeOf<KeyOf<typeof withPlaceholder>>().toEqualTypeOf<
         readonly ["text", "_creationTime", "_creationTime"]
       >();
       expectTypeOf<
-        typeof leftJoined extends Stream.Stream<infer A, any, any> ? A : never
+        typeof withPlaceholder extends Stream.Stream<infer A, any, any>
+          ? A
+          : never
       >().toEqualTypeOf<
         | (typeof pinned extends Stream.Stream<infer A, any, any> ? A : never)
         | { missingFor: string }
       >();
 
       // A flatMap result relabels by its type-level (tiebreaker-free) key.
-      const relabeledJoin = QueryStream.orderBy(joined, ["a", "b", "c"]);
+      const relabeledJoin = QueryStream.renameKey(joined, ["a", "b", "c"]);
       expectTypeOf<KeyOf<typeof relabeledJoin>>().toEqualTypeOf<
         ["a", "b", "c"]
       >();

--- a/scripts/streamDiagrams.ts
+++ b/scripts/streamDiagrams.ts
@@ -166,7 +166,7 @@ export const diagrams: Readonly<Record<string, string>> = {
     keys("", BY_TEXT_KEYS),
   ),
 
-  join: lines(
+  "flat-map": lines(
     track("admin", ["n1", undefined, "n4", "n5"]),
     keys("", ["[1]", undefined, "[4]", "[5]"]),
     at("of n1", 0, ["c1", "c2"], ""),
@@ -179,14 +179,14 @@ export const diagrams: Readonly<Record<string, string>> = {
     keys("", ["[1,7]", "[1,8]", "[4,9]", "[5,null]"]),
   ),
 
-  "left-join": lines(
+  "on-empty": lines(
     track("admin", ["n1", undefined, "n4", "n5"]),
     keys("", ["[1]", undefined, "[4]", "[5]"]),
     at("of n1", 0, ["c1", "c2"], ""),
     at("of n4", 2, ["c3"], ""),
     at("of n5", 3, []),
     "",
-    op("leftJoin((note) => commentsOn(note), { innerKey, onEmpty })"),
+    op("flatMap((note) => commentsOn(note), { innerKey, onEmpty })"),
     "",
     track("joined", ["c1", "c2", "c3", "∅n5"]),
     keys("", ["[1,7]", "[1,8]", "[4,9]", "[5,null]"]),
@@ -209,17 +209,17 @@ export const diagrams: Readonly<Record<string, string>> = {
     ]),
   ),
 
-  "order-by": lines(
+  "rename-key": lines(
     track("by_body", ["c1", "c2", "c3"]),
     `${keys("", ["[great,7]", "[meh,8]", "[nice,9]"])}   key: [body, _creationTime]`,
     "",
-    op('orderBy(["text", "_creationTime"])'),
+    op('renameKey(["text", "_creationTime"])'),
     "",
     track("relabeled", ["c1", "c2", "c3"]),
     `${keys("", ["[great,7]", "[meh,8]", "[nice,9]"])}   key: [text, _creationTime]`,
   ),
 
-  "order-by-merge": lines(
+  "rename-key-merge": lines(
     track("notes", [...BY_TEXT, undefined, undefined, undefined]),
     track("relabeled", [
       undefined,


### PR DESCRIPTION
## Summary

Two `QueryStream` operation names came from SQL rather than from the stream and ordered-collection tradition the rest of the API follows. This PR renames them and restructures the Streams page around the invariant the API rests on.

### API

- **`leftJoin` is folded into `flatMap` as an optional `onEmpty`.** Stream libraries treat "the inner stream was empty" as a fallback on the inner stream (Effect's `Stream.orElseIfEmpty`, Opaleye and Rel8's `optional`) rather than as a second kind of join. `flatMap(f, { innerKey, onEmpty })` keeps outer documents with no inner documents, emitting `onEmpty(outer)`, and the element type widens to include the placeholder only when it is given. The signature is a single one with a defaulted `Doc3 = never`: an overloaded version cost 45% more type instantiations on a plain call, the single one costs 7%. The bench baselines are updated.
- **`orderBy` is renamed to `renameKey`.** It never ordered anything: it relabels the order key's fields so positionally matching keys can merge, and every other library uses `orderBy` for sorting. Its own docstring opened with "Re-key a stream".

Both are free to change now, since the stream API has only shipped in `10.0.0-next` prereleases; the existing changesets are edited rather than joined by new ones.

### Docs

- A new **The ordering contract** section right after the intro states the invariant: every stream is sorted by its order key in its direction, every operation preserves that, and only `flatMap` (extends), `renameKey` (relabels), and `reverse` (flips) touch it.
- **Operations at a glance** gains an "Order key" column and an "In Effect" column naming the nearest `Stream` operator per row, and its rows are grouped by effect on the key. The sections under *Composing streams* follow the same order.
- The join sections follow the operator: *Join* becomes *Flat-map*, and *Left join* becomes *Keep outer documents without inner documents*, a subsection on `onEmpty`.
- Diagram names follow the new vocabulary (`flat-map`, `on-empty`, `rename-key`, `rename-key-merge`); a stale `#paginate` anchor on the Foldkit page is fixed.
- Eleven stray trailing asterisks left in `QueryStream.ts` docstrings by an earlier edit are cleaned up.

## Verification

- `pnpm check`
- `pnpm test` (117 files, 1409 tests, no type errors)
- `npx vitest run --config vitest.mock-backend.config.ts test/mock-backend/queryStream.test.ts` in `packages/server`, with a new type test that a plain `flatMap` still yields exactly the inner document type
- `npx tsx test/QueryStream.bench.ts` in `packages/server`: `flatMap` +7% instantiations, the composed pipeline +0.6%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew3eU2fM2sYVSMTyYyix5m)_