### PR TITLE
Make Effect tracing boundaries intentional

### DIFF
--- a/.changeset/trace-operation-boundaries.md
+++ b/.changeset/trace-operation-boundaries.md
@@ -1,0 +1,7 @@
+---
+"@confect/cli": patch
+"@confect/js": patch
+"@confect/server": patch
+---
+
+Add named tracing boundaries to JavaScript client calls, server function runners, database inserts, patches, replacements and pagination, and code-generation passes in `confect codegen` and `confect dev`.

--- a/.claude/hooks/formatFile.ts
+++ b/.claude/hooks/formatFile.ts
@@ -65,13 +65,12 @@ const SUPPORTED_EXTENSIONS = new Set([
   ".hbs",
 ]);
 
-const isSupportedFileType = (filePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
+const isSupportedFileType = Effect.fnUntraced(function* (filePath: string) {
+  const path = yield* Path.Path;
 
-    const ext = String.toLowerCase(path.extname(filePath));
-    return SUPPORTED_EXTENSIONS.has(ext);
-  });
+  const ext = String.toLowerCase(path.extname(filePath));
+  return SUPPORTED_EXTENSIONS.has(ext);
+});
 
 const program = Effect.gen(function* () {
   const stdio = yield* Stdio;

--- a/.claude/hooks/lintFile.ts
+++ b/.claude/hooks/lintFile.ts
@@ -40,13 +40,12 @@ const SUPPORTED_EXTENSIONS = new Set([
   ".cts",
 ]);
 
-const isSupportedFileType = (filePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
+const isSupportedFileType = Effect.fnUntraced(function* (filePath: string) {
+  const path = yield* Path.Path;
 
-    const ext = String.toLowerCase(path.extname(filePath));
-    return SUPPORTED_EXTENSIONS.has(ext);
-  });
+  const ext = String.toLowerCase(path.extname(filePath));
+  return SUPPORTED_EXTENSIONS.has(ext);
+});
 
 const program = Effect.gen(function* () {
   const stdio = yield* Stdio;

--- a/packages/cli/src/Bundler.ts
+++ b/packages/cli/src/Bundler.ts
@@ -176,108 +176,105 @@ const captureBuildResultPlugin = (
  * claim resolutions (e.g. `convex.config` imports) before the workspace and
  * externalization heuristics see them.
  */
-export const bundle = (
+export const bundle = Effect.fn("Bundler.bundle")(function* (
   entryPoint: string,
   options?: { readonly plugins?: ReadonlyArray<esbuild.Plugin> },
-): Effect.Effect<Bundled, BundlerError, Path.Path | FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const fs = yield* FileSystem.FileSystem;
+): Effect.fn.Return<Bundled, BundlerError, Path.Path | FileSystem.FileSystem> {
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
 
-    const buildResultRef = yield* Ref.make<CapturedBuildResult>({
-      metafile: undefined,
-      warnings: [],
-    });
-
-    const cwd = path.dirname(entryPoint);
-    const skipPatterns = tsconfigPathsToRegExp(
-      loadTsConfig(cwd)?.data.compilerOptions?.paths ?? {},
-    );
-    const result = yield* Effect.tryPromise({
-      try: () =>
-        bundleRequire({
-          filepath: entryPoint,
-          cwd,
-          format: "esm",
-          esbuildOptions: {
-            plugins: [
-              ...(options?.plugins ?? []),
-              bundleWorkspacePlugin(path, fs, skipPatterns),
-              captureBuildResultPlugin(buildResultRef),
-            ],
-            logLevel: "silent",
-          },
-        }),
-      catch: (cause) => new BundlerError({ cause }),
-    }).pipe(
-      Effect.ensuring(
-        Effect.andThen(Ref.get(buildResultRef), (captured) =>
-          logCoalescedBuildWarnings(captured.warnings),
-        ),
-      ),
-    );
-
-    const { metafile } = yield* Ref.get(buildResultRef);
-    if (!metafile) {
-      return yield* Effect.die(new Error("esbuild metafile missing"));
-    }
-
-    return {
-      module: result.mod,
-      metafile: absolutizeMetafile(path, metafile, cwd),
-    };
+  const buildResultRef = yield* Ref.make<CapturedBuildResult>({
+    metafile: undefined,
+    warnings: [],
   });
 
-const findMetafileInputKey = (
+  const cwd = path.dirname(entryPoint);
+  const skipPatterns = tsconfigPathsToRegExp(
+    loadTsConfig(cwd)?.data.compilerOptions?.paths ?? {},
+  );
+  const result = yield* Effect.tryPromise({
+    try: () =>
+      bundleRequire({
+        filepath: entryPoint,
+        cwd,
+        format: "esm",
+        esbuildOptions: {
+          plugins: [
+            ...(options?.plugins ?? []),
+            bundleWorkspacePlugin(path, fs, skipPatterns),
+            captureBuildResultPlugin(buildResultRef),
+          ],
+          logLevel: "silent",
+        },
+      }),
+    catch: (cause) => new BundlerError({ cause }),
+  }).pipe(
+    Effect.ensuring(
+      Effect.andThen(Ref.get(buildResultRef), (captured) =>
+        logCoalescedBuildWarnings(captured.warnings),
+      ),
+    ),
+  );
+
+  const { metafile } = yield* Ref.get(buildResultRef);
+  if (!metafile) {
+    return yield* Effect.die(new Error("esbuild metafile missing"));
+  }
+
+  return {
+    module: result.mod,
+    metafile: absolutizeMetafile(path, metafile, cwd),
+  };
+});
+
+const findMetafileInputKey = Effect.fnUntraced(function* (
   metafile: esbuild.Metafile,
   absolutePath: string,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const resolved = path.resolve(absolutePath);
-    return Array.findFirst(
-      Object.keys(metafile.inputs),
-      (key) => path.resolve(key) === resolved,
-    );
-  });
+) {
+  const path = yield* Path.Path;
+  const resolved = path.resolve(absolutePath);
+  return Array.findFirst(
+    Object.keys(metafile.inputs),
+    (key) => path.resolve(key) === resolved,
+  );
+});
 
 /**
  * Returns `true` when the module bundled from `sourceAbsolutePath` declares a
  * direct import of `targetAbsolutePath` (according to the bundle's esbuild
  * metafile). Returns `false` if either path is missing from the metafile.
  */
-export const directlyImports = (
+export const directlyImports = Effect.fnUntraced(function* (
   bundled: Bundled,
   sourceAbsolutePath: string,
   targetAbsolutePath: string,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const sourceKey = yield* findMetafileInputKey(
-      bundled.metafile,
-      sourceAbsolutePath,
-    );
-    const targetKey = yield* findMetafileInputKey(
-      bundled.metafile,
-      targetAbsolutePath,
-    );
+) {
+  const path = yield* Path.Path;
+  const sourceKey = yield* findMetafileInputKey(
+    bundled.metafile,
+    sourceAbsolutePath,
+  );
+  const targetKey = yield* findMetafileInputKey(
+    bundled.metafile,
+    targetAbsolutePath,
+  );
 
-    return pipe(
-      Option.all([sourceKey, targetKey]),
-      Option.flatMap(([sourceKey_, targetKey_]) =>
-        Option.fromNullishOr(bundled.metafile.inputs[sourceKey_]).pipe(
-          Option.map((sourceInput) => {
-            const targetResolved = path.resolve(targetKey_);
-            return sourceInput.imports.some(
-              (importedFile) =>
-                path.resolve(importedFile.path) === targetResolved,
-            );
-          }),
-        ),
+  return pipe(
+    Option.all([sourceKey, targetKey]),
+    Option.flatMap(([sourceKey_, targetKey_]) =>
+      Option.fromNullishOr(bundled.metafile.inputs[sourceKey_]).pipe(
+        Option.map((sourceInput) => {
+          const targetResolved = path.resolve(targetKey_);
+          return sourceInput.imports.some(
+            (importedFile) =>
+              path.resolve(importedFile.path) === targetResolved,
+          );
+        }),
       ),
-      Option.getOrElse(() => false),
-    );
-  });
+    ),
+    Option.getOrElse(() => false),
+  );
+});
 
 /**
  * Returns the absolute paths of every module in the bundle that declares a

--- a/packages/cli/src/CodeBlockWriter.ts
+++ b/packages/cli/src/CodeBlockWriter.ts
@@ -2,6 +2,16 @@ import type { Options as CodeBlockWriterOptions } from "code-block-writer";
 import CodeBlockWriter_ from "code-block-writer";
 import * as Effect from "effect/Effect";
 
+const indentWriter = Effect.fnUntraced(function* <E, R>(
+  writer: CodeBlockWriter_,
+  effect: Effect.Effect<void, E, R>,
+): Effect.fn.Return<void, E, R> {
+  const indentationLevel = writer.getIndentationLevel();
+  writer.setIndentationLevel(indentationLevel + 1);
+  yield* effect;
+  writer.setIndentationLevel(indentationLevel);
+});
+
 export class CodeBlockWriter {
   private readonly writer: CodeBlockWriter_;
 
@@ -12,13 +22,7 @@ export class CodeBlockWriter {
   indent<E = never, R = never>(
     effect: Effect.Effect<void, E, R>,
   ): Effect.Effect<void, E, R> {
-    const writer = this.writer;
-    return Effect.gen(function* () {
-      const indentationLevel = writer.getIndentationLevel();
-      writer.setIndentationLevel(indentationLevel + 1);
-      yield* effect;
-      writer.setIndentationLevel(indentationLevel);
-    });
+    return indentWriter(this.writer, effect);
   }
 
   writeLine<E = never, R = never>(line: string): Effect.Effect<void, E, R> {

--- a/packages/cli/src/ConvexConfig.ts
+++ b/packages/cli/src/ConvexConfig.ts
@@ -182,105 +182,106 @@ const VALID_COMPONENT_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
  * installed on the app, in mount-name order. `displayPath` is used in error
  * messages (mirroring how impl/spec bundling reports relative paths).
  */
-export const discoverInstalledComponents = (
+export const discoverInstalledComponents = Effect.fn(
+  "ConvexConfig.discoverInstalledComponents",
+)(function* (
   convexConfigPath: string,
   displayPath: string,
-): Effect.Effect<
+): Effect.fn.Return<
   ReadonlyArray<InstalledComponent>,
   BuildError | InvalidConvexConfigError,
   Path.Path | FileSystem.FileSystem
-> =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
+> {
+  const path = yield* Path.Path;
 
-    const { module } = yield* Bundler.bundle(convexConfigPath, {
-      plugins: [componentConfigPlugin(path)],
-    }).pipe(Effect.mapError((error) => fromBundlerError(displayPath, error)));
+  const { module } = yield* Bundler.bundle(convexConfigPath, {
+    plugins: [componentConfigPlugin(path)],
+  }).pipe(Effect.mapError((error) => fromBundlerError(displayPath, error)));
 
-    const app = module.default as
-      | { _isRoot?: unknown; export?: unknown }
-      | null
-      | undefined;
+  const app = module.default as
+    | { _isRoot?: unknown; export?: unknown }
+    | null
+    | undefined;
 
-    if (
-      app === null ||
-      typeof app !== "object" ||
-      app._isRoot !== true ||
-      typeof app.export !== "function"
-    ) {
-      return yield* new InvalidConvexConfigError({
+  if (
+    app === null ||
+    typeof app !== "object" ||
+    app._isRoot !== true ||
+    typeof app.export !== "function"
+  ) {
+    return yield* new InvalidConvexConfigError({
+      configPath: displayPath,
+      reason:
+        "it must default-export the app definition created by `defineApp()`.",
+    });
+  }
+
+  const analysis = yield* Effect.try({
+    try: () => (app.export as () => unknown)(),
+    catch: (cause) =>
+      new InvalidConvexConfigError({
         configPath: displayPath,
-        reason:
-          "it must default-export the app definition created by `defineApp()`.",
-      });
-    }
+        reason: `exporting the app definition threw: ${globalThis.String(cause)}.`,
+      }),
+  });
 
-    const analysis = yield* Effect.try({
-      try: () => (app.export as () => unknown)(),
-      catch: (cause) =>
+  const decoded = yield* Schema.decodeUnknownEffect(AppDefinitionAnalysis)(
+    analysis,
+  ).pipe(
+    Effect.mapError(
+      (cause) =>
         new InvalidConvexConfigError({
           configPath: displayPath,
-          reason: `exporting the app definition threw: ${globalThis.String(cause)}.`,
+          reason: `the app definition's installed components could not be read: ${cause.message}.`,
         }),
+    ),
+  );
+
+  const components = pipe(
+    decoded.childComponents,
+    Array.map(
+      ({ name, path: componentDefinitionPath }): InstalledComponent => ({
+        name,
+        componentDefinitionPath,
+      }),
+    ),
+    Array.sort(byName),
+  );
+
+  const invalidNames = pipe(
+    components,
+    Array.map(({ name }) => name),
+    Array.filter((name) =>
+      Option.isNone(String.match(VALID_COMPONENT_NAME)(name)),
+    ),
+  );
+  if (Array.isArrayNonEmpty(invalidNames)) {
+    return yield* new InvalidConvexConfigError({
+      configPath: displayPath,
+      reason: `component names must be alphanumeric plus underscores, but got: ${pipe(
+        invalidNames,
+        Array.map((name) => `"${name}"`),
+        Array.join(", "),
+      )}. Pass a valid \`name\` to \`app.use\`.`,
     });
+  }
 
-    const decoded = yield* Schema.decodeUnknownEffect(AppDefinitionAnalysis)(
-      analysis,
-    ).pipe(
-      Effect.mapError(
-        (cause) =>
-          new InvalidConvexConfigError({
-            configPath: displayPath,
-            reason: `the app definition's installed components could not be read: ${cause.message}.`,
-          }),
-      ),
-    );
+  const duplicateNames = pipe(
+    components,
+    Array.groupBy(({ name }) => name),
+    Record.toEntries,
+    Array.filter(([, group]) => group.length > 1),
+    Array.map(([name]) => name),
+  );
+  if (Array.isArrayNonEmpty(duplicateNames)) {
+    return yield* new InvalidConvexConfigError({
+      configPath: displayPath,
+      reason: `multiple components are installed under the same name (${Array.join(duplicateNames, ", ")}); pass a unique \`name\` to \`app.use\` for each.`,
+    });
+  }
 
-    const components = pipe(
-      decoded.childComponents,
-      Array.map(
-        ({ name, path: componentDefinitionPath }): InstalledComponent => ({
-          name,
-          componentDefinitionPath,
-        }),
-      ),
-      Array.sort(byName),
-    );
-
-    const invalidNames = pipe(
-      components,
-      Array.map(({ name }) => name),
-      Array.filter((name) =>
-        Option.isNone(String.match(VALID_COMPONENT_NAME)(name)),
-      ),
-    );
-    if (Array.isArrayNonEmpty(invalidNames)) {
-      return yield* new InvalidConvexConfigError({
-        configPath: displayPath,
-        reason: `component names must be alphanumeric plus underscores, but got: ${pipe(
-          invalidNames,
-          Array.map((name) => `"${name}"`),
-          Array.join(", "),
-        )}. Pass a valid \`name\` to \`app.use\`.`,
-      });
-    }
-
-    const duplicateNames = pipe(
-      components,
-      Array.groupBy(({ name }) => name),
-      Record.toEntries,
-      Array.filter(([, group]) => group.length > 1),
-      Array.map(([name]) => name),
-    );
-    if (Array.isArrayNonEmpty(duplicateNames)) {
-      return yield* new InvalidConvexConfigError({
-        configPath: displayPath,
-        reason: `multiple components are installed under the same name (${Array.join(duplicateNames, ", ")}); pass a unique \`name\` to \`app.use\` for each.`,
-      });
-    }
-
-    return components;
-  });
+  return components;
+});
 
 /**
  * The module specifier the generated registry's `ComponentApi` type import

--- a/packages/cli/src/GroupPath.ts
+++ b/packages/cli/src/GroupPath.ts
@@ -30,35 +30,35 @@ export const append = (groupPath: GroupPath, groupName: string): GroupPath =>
 /**
  * Expects a path string of the form `./group1/group2.ts`, relative to the Convex functions directory.
  */
-export const fromGroupModulePath = (groupModulePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
+export const fromGroupModulePath = Effect.fnUntraced(function* (
+  groupModulePath: string,
+) {
+  const path = yield* Path.Path;
 
-    const { dir, name, ext } = path.parse(groupModulePath);
+  const { dir, name, ext } = path.parse(groupModulePath);
 
-    if (ext === ".ts") {
-      const dirSegments = Array.filter(
-        String.split(dir, path.sep),
-        String.isNonEmpty,
-      );
-      yield* Effect.logDebug(Array.append(dirSegments, name));
-      return make(Array.append(dirSegments, name));
-    } else {
-      return yield* new GroupModulePathIsNotATypeScriptFileError({
-        path: groupModulePath,
-      });
-    }
-  });
+  if (ext === ".ts") {
+    const dirSegments = Array.filter(
+      String.split(dir, path.sep),
+      String.isNonEmpty,
+    );
+    yield* Effect.logDebug(Array.append(dirSegments, name));
+    return make(Array.append(dirSegments, name));
+  } else {
+    return yield* new GroupModulePathIsNotATypeScriptFileError({
+      path: groupModulePath,
+    });
+  }
+});
 
 /**
  * Get the module path for a group, relative to the Convex functions directory.
  */
-export const modulePath = (groupPath: GroupPath) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
+export const modulePath = Effect.fnUntraced(function* (groupPath: GroupPath) {
+  const path = yield* Path.Path;
 
-    return path.join(...groupPath.pathSegments) + ".ts";
-  });
+  return path.join(...groupPath.pathSegments) + ".ts";
+});
 
 export const getGroupSpec = (
   spec: Spec.AnyWithProps,

--- a/packages/cli/src/LeafModule.ts
+++ b/packages/cli/src/LeafModule.ts
@@ -43,24 +43,23 @@ export interface LeafModule {
 export const SPEC_SUFFIX = ".spec.ts";
 export const IMPL_SUFFIX = ".impl.ts";
 
-const swapModuleSuffix = (
+const swapModuleSuffix = Effect.fnUntraced(function* (
   relativePath: string,
   fromSuffix: string,
   toSuffix: string,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const { dir, name, ext } = path.parse(relativePath);
-    if (ext !== ".ts" || !name.endsWith(fromSuffix.slice(0, -".ts".length))) {
-      return relativePath;
-    }
+) {
+  const path = yield* Path.Path;
+  const { dir, name, ext } = path.parse(relativePath);
+  if (ext !== ".ts" || !name.endsWith(fromSuffix.slice(0, -".ts".length))) {
+    return relativePath;
+  }
 
-    const stem = name.slice(0, -fromSuffix.slice(0, -".ts".length).length);
-    const nextName = `${stem}${toSuffix.slice(0, -".ts".length)}`;
-    return dir.length > 0
-      ? path.join(dir, `${nextName}${ext}`)
-      : `${nextName}${ext}`;
-  });
+  const stem = name.slice(0, -fromSuffix.slice(0, -".ts".length).length);
+  const nextName = `${stem}${toSuffix.slice(0, -".ts".length)}`;
+  return dir.length > 0
+    ? path.join(dir, `${nextName}${ext}`)
+    : `${nextName}${ext}`;
+});
 
 export const isLeafSpecPath = (relativePath: string) =>
   relativePath.endsWith(SPEC_SUFFIX);
@@ -68,47 +67,47 @@ export const isLeafSpecPath = (relativePath: string) =>
 export const isLeafImplPath = (relativePath: string) =>
   relativePath.endsWith(IMPL_SUFFIX);
 
-export const exportNameFromModulePath = (relativePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const { name, ext } = path.parse(relativePath);
-    if (ext !== ".ts") {
-      return name;
-    }
-    return name.endsWith(".spec") ? name.slice(0, -".spec".length) : name;
-  });
+export const exportNameFromModulePath = Effect.fnUntraced(function* (
+  relativePath: string,
+) {
+  const path = yield* Path.Path;
+  const { name, ext } = path.parse(relativePath);
+  if (ext !== ".ts") {
+    return name;
+  }
+  return name.endsWith(".spec") ? name.slice(0, -".spec".length) : name;
+});
 
-export const groupPathFromRelativeModulePath = (relativePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const { dir, name, ext } = path.parse(relativePath);
-    const stem =
-      ext === ".ts" && name.endsWith(".spec")
-        ? name.slice(0, -".spec".length)
-        : name;
-    const dirSegments = Array.filter(
-      String.split(dir, path.sep),
-      String.isNonEmpty,
-    );
-    const pathSegments = Array.append(dirSegments, stem) as [
-      string,
-      ...string[],
-    ];
-    return {
-      pathSegments,
-      groupPathDot: Array.join(pathSegments, "."),
-    };
-  });
+export const groupPathFromRelativeModulePath = Effect.fnUntraced(function* (
+  relativePath: string,
+) {
+  const path = yield* Path.Path;
+  const { dir, name, ext } = path.parse(relativePath);
+  const stem =
+    ext === ".ts" && name.endsWith(".spec")
+      ? name.slice(0, -".spec".length)
+      : name;
+  const dirSegments = Array.filter(
+    String.split(dir, path.sep),
+    String.isNonEmpty,
+  );
+  const pathSegments = Array.append(dirSegments, stem) as [string, ...string[]];
+  return {
+    pathSegments,
+    groupPathDot: Array.join(pathSegments, "."),
+  };
+});
 
-export const specImportPathFromGenerated = (specRelativePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const withoutExt = toPosixPath(
-      path,
-      yield* removePathExtension(specRelativePath),
-    );
-    return `../${withoutExt}`;
-  });
+export const specImportPathFromGenerated = Effect.fnUntraced(function* (
+  specRelativePath: string,
+) {
+  const path = yield* Path.Path;
+  const withoutExt = toPosixPath(
+    path,
+    yield* removePathExtension(specRelativePath),
+  );
+  return `../${withoutExt}`;
+});
 
 export const specPathForImpl = (implRelativePath: string) =>
   swapModuleSuffix(implRelativePath, IMPL_SUFFIX, SPEC_SUFFIX);
@@ -116,11 +115,12 @@ export const specPathForImpl = (implRelativePath: string) =>
 export const implPathForSpec = (specRelativePath: string) =>
   swapModuleSuffix(specRelativePath, SPEC_SUFFIX, IMPL_SUFFIX);
 
-export const registeredFunctionsRelativePath = (leaf: LeafModule) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    return path.join("registeredFunctions", ...leaf.pathSegments) + ".ts";
-  });
+export const registeredFunctionsRelativePath = Effect.fnUntraced(function* (
+  leaf: LeafModule,
+) {
+  const path = yield* Path.Path;
+  return path.join("registeredFunctions", ...leaf.pathSegments) + ".ts";
+});
 
 export const discoverLeafSpecFiles = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -169,30 +169,30 @@ export const discoverLeafImplFiles = Effect.gen(function* () {
   });
 });
 
-export const toLeafModule = (specRelativePath: string) =>
-  Effect.gen(function* () {
-    const exportName = yield* exportNameFromModulePath(specRelativePath);
-    const { pathSegments, groupPathDot } =
-      yield* groupPathFromRelativeModulePath(specRelativePath);
-    const specImportPath = yield* specImportPathFromGenerated(specRelativePath);
+export const toLeafModule = Effect.fnUntraced(function* (
+  specRelativePath: string,
+) {
+  const exportName = yield* exportNameFromModulePath(specRelativePath);
+  const { pathSegments, groupPathDot } =
+    yield* groupPathFromRelativeModulePath(specRelativePath);
+  const specImportPath = yield* specImportPathFromGenerated(specRelativePath);
 
-    return {
-      relativePath: specRelativePath,
-      pathSegments,
-      groupPathDot,
-      exportName,
-      // Unknown until the spec is bundled; see `LeafModule.runtime`.
-      runtime: Option.none(),
-      specImportPath,
-    } satisfies LeafModule;
-  });
+  return {
+    relativePath: specRelativePath,
+    pathSegments,
+    groupPathDot,
+    exportName,
+    // Unknown until the spec is bundled; see `LeafModule.runtime`.
+    runtime: Option.none(),
+    specImportPath,
+  } satisfies LeafModule;
+});
 
-const absoluteModulePath = (relativePath: string) =>
-  Effect.gen(function* () {
-    const confectDirectory = yield* ConfectDirectory.get;
-    const path = yield* Path.Path;
-    return path.resolve(confectDirectory, relativePath);
-  });
+const absoluteModulePath = Effect.fnUntraced(function* (relativePath: string) {
+  const confectDirectory = yield* ConfectDirectory.get;
+  const path = yield* Path.Path;
+  return path.resolve(confectDirectory, relativePath);
+});
 
 /**
  * Every `*.spec.ts` is reachable from `_generated/spec.ts`, which the client
@@ -211,31 +211,33 @@ const absoluteModulePath = (relativePath: string) =>
  * shared helper a spec pulls in — while only ever flagging modules that
  * genuinely reach the client.
  */
-const validateClientSafety = (leaf: LeafModule, bundled: Bundler.Bundled) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = path.resolve(yield* ConfectDirectory.get);
+const validateClientSafety = Effect.fnUntraced(function* (
+  leaf: LeafModule,
+  bundled: Bundler.Bundled,
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = path.resolve(yield* ConfectDirectory.get);
 
-    const isCheckedUserModule = (absolutePath: string) => {
-      const relative = path.relative(confectDirectory, absolutePath);
-      return !relative.startsWith("..") && !path.isAbsolute(relative);
-    };
+  const isCheckedUserModule = (absolutePath: string) => {
+    const relative = path.relative(confectDirectory, absolutePath);
+    return !relative.startsWith("..") && !path.isAbsolute(relative);
+  };
 
-    const importers = Bundler.importersOfPackage(
-      bundled,
-      "@confect/server",
-      isCheckedUserModule,
-    );
+  const importers = Bundler.importersOfPackage(
+    bundled,
+    "@confect/server",
+    isCheckedUserModule,
+  );
 
-    if (importers.length > 0) {
-      return yield* new SpecImportsServerError({
-        specPath: leaf.relativePath,
-        importerPaths: Array.map(importers, (absolutePath) =>
-          toPosixPath(path, path.relative(confectDirectory, absolutePath)),
-        ),
-      });
-    }
-  });
+  if (importers.length > 0) {
+    return yield* new SpecImportsServerError({
+      specPath: leaf.relativePath,
+      importerPaths: Array.map(importers, (absolutePath) =>
+        toPosixPath(path, path.relative(confectDirectory, absolutePath)),
+      ),
+    });
+  }
+});
 
 /**
  * Validate that the leaf's spec file default-exports a `GroupSpec`, and that
@@ -246,25 +248,26 @@ const validateClientSafety = (leaf: LeafModule, bundled: Bundler.Bundled) =>
  * time). The group's runtime (`Convex` vs `Node`) is whatever the spec
  * declares — it is not constrained by the file's location.
  */
-export const validateSpec = (leaf: LeafModule) =>
-  Effect.gen(function* () {
-    const absolutePath = yield* absoluteModulePath(leaf.relativePath);
-    const bundled = yield* Bundler.bundle(absolutePath).pipe(
-      Effect.mapError((error) => fromBundlerError(leaf.relativePath, error)),
-    );
+export const validateSpec = Effect.fn("LeafModule.validateSpec")(function* (
+  leaf: LeafModule,
+) {
+  const absolutePath = yield* absoluteModulePath(leaf.relativePath);
+  const bundled = yield* Bundler.bundle(absolutePath).pipe(
+    Effect.mapError((error) => fromBundlerError(leaf.relativePath, error)),
+  );
 
-    const groupSpec = bundled.module.default;
+  const groupSpec = bundled.module.default;
 
-    if (!GroupSpec.isGroupSpec(groupSpec)) {
-      return yield* new SpecMissingDefaultGroupSpecError({
-        specPath: leaf.relativePath,
-      });
-    }
+  if (!GroupSpec.isGroupSpec(groupSpec)) {
+    return yield* new SpecMissingDefaultGroupSpecError({
+      specPath: leaf.relativePath,
+    });
+  }
 
-    yield* validateClientSafety(leaf, bundled);
+  yield* validateClientSafety(leaf, bundled);
 
-    return groupSpec;
-  });
+  return groupSpec;
+});
 
 /**
  * Walk the built `Context` for a `Finalized` `GroupImpl` service value. The
@@ -285,102 +288,104 @@ const findFinalizedGroupImpl = <S>(
  * `Context.Reference` is cached globally and would otherwise accumulate
  * items across impls.
  */
-const buildImplLayer = (implLayer: Layer.Layer<unknown>) =>
-  Effect.gen(function* () {
-    const registry = Ref.makeUnsafe<RegistryItems.RegistryItems>({});
-    return yield* Layer.build(
-      implLayer as Layer.Layer<unknown, never, never>,
-    ).pipe(Effect.provideService(Registry.Registry, registry));
-  }).pipe(Effect.scoped);
+const buildImplLayer = Effect.fnUntraced(function* (
+  implLayer: Layer.Layer<unknown>,
+) {
+  const registry = Ref.makeUnsafe<RegistryItems.RegistryItems>({});
+  return yield* Layer.build(
+    implLayer as Layer.Layer<unknown, never, never>,
+  ).pipe(Effect.provideService(Registry.Registry, registry));
+}, Effect.scoped);
 
 /**
  * Validate that the leaf's sibling impl file imports the spec, default-exports
  * a finalized `GroupImpl` layer, and provides a `FunctionImpl` for every
  * function declared by the spec.
  */
-export const validateImpl = (leaf: LeafModule) =>
-  Effect.gen(function* () {
-    const implRelativePath = yield* implPathForSpec(leaf.relativePath);
-    const implAbsolutePath = yield* absoluteModulePath(implRelativePath);
-    const specAbsolutePath = yield* absoluteModulePath(leaf.relativePath);
+export const validateImpl = Effect.fn("LeafModule.validateImpl")(function* (
+  leaf: LeafModule,
+) {
+  const implRelativePath = yield* implPathForSpec(leaf.relativePath);
+  const implAbsolutePath = yield* absoluteModulePath(implRelativePath);
+  const specAbsolutePath = yield* absoluteModulePath(leaf.relativePath);
 
-    const bundled = yield* Bundler.bundle(implAbsolutePath).pipe(
-      Effect.mapError((error) => fromBundlerError(implRelativePath, error)),
-    );
+  const bundled = yield* Bundler.bundle(implAbsolutePath).pipe(
+    Effect.mapError((error) => fromBundlerError(implRelativePath, error)),
+  );
 
-    if (
-      !(yield* Bundler.directlyImports(
-        bundled,
-        implAbsolutePath,
-        specAbsolutePath,
-      ))
-    ) {
-      return yield* new ImplMissingSpecImportError({
-        implPath: implRelativePath,
-        expectedSpecPath: leaf.relativePath,
-      });
-    }
+  if (
+    !(yield* Bundler.directlyImports(
+      bundled,
+      implAbsolutePath,
+      specAbsolutePath,
+    ))
+  ) {
+    return yield* new ImplMissingSpecImportError({
+      implPath: implRelativePath,
+      expectedSpecPath: leaf.relativePath,
+    });
+  }
 
-    if (!Layer.isLayer(bundled.module.default)) {
-      return yield* new ImplMissingDefaultLayerError({
-        implPath: implRelativePath,
-      });
-    }
+  if (!Layer.isLayer(bundled.module.default)) {
+    return yield* new ImplMissingDefaultLayerError({
+      implPath: implRelativePath,
+    });
+  }
 
-    const { module: specModule } = yield* Bundler.bundle(specAbsolutePath).pipe(
-      Effect.mapError((error) => fromBundlerError(leaf.relativePath, error)),
-    );
-    const groupSpec = specModule.default as GroupSpec.AnyWithProps;
-    const expectedFunctionNames = Object.keys(groupSpec.functions);
+  const { module: specModule } = yield* Bundler.bundle(specAbsolutePath).pipe(
+    Effect.mapError((error) => fromBundlerError(leaf.relativePath, error)),
+  );
+  const groupSpec = specModule.default as GroupSpec.AnyWithProps;
+  const expectedFunctionNames = Object.keys(groupSpec.functions);
 
-    const context = yield* buildImplLayer(
-      bundled.module.default as Layer.Layer<unknown>,
-    );
-    const finalizedGroupImpl = yield* Option.match(
-      findFinalizedGroupImpl(context),
-      {
-        onNone: () => new ImplNotFinalizedError({ implPath: implRelativePath }),
-        onSome: Effect.succeed,
-      },
-    );
+  const context = yield* buildImplLayer(
+    bundled.module.default as Layer.Layer<unknown>,
+  );
+  const finalizedGroupImpl = yield* Option.match(
+    findFinalizedGroupImpl(context),
+    {
+      onNone: () => new ImplNotFinalizedError({ implPath: implRelativePath }),
+      onSome: Effect.succeed,
+    },
+  );
 
-    const registeredSet = new Set(finalizedGroupImpl.registeredFunctionNames);
-    const missing = expectedFunctionNames.filter(
-      (name) => !registeredSet.has(name),
-    );
+  const registeredSet = new Set(finalizedGroupImpl.registeredFunctionNames);
+  const missing = expectedFunctionNames.filter(
+    (name) => !registeredSet.has(name),
+  );
 
-    if (missing.length > 0) {
-      return yield* new ImplMissingFunctionsError({
-        implPath: implRelativePath,
-        groupPath: leaf.groupPathDot,
-        missingFunctionNames: missing,
-      });
-    }
+  if (missing.length > 0) {
+    return yield* new ImplMissingFunctionsError({
+      implPath: implRelativePath,
+      groupPath: leaf.groupPathDot,
+      missingFunctionNames: missing,
+    });
+  }
 
-    const expectedMiddlewareKeys = [
-      ...new Set([
-        ...(groupSpec.middlewareSpecs ?? []).map(
+  const expectedMiddlewareKeys = [
+    ...new Set([
+      ...(groupSpec.middlewareSpecs ?? []).map(
+        (middlewareSpec) => middlewareSpec.key,
+      ),
+      ...Object.values(groupSpec.functions).flatMap((function_) =>
+        (function_.middlewareSpecs ?? []).map(
           (middlewareSpec) => middlewareSpec.key,
         ),
-        ...Object.values(groupSpec.functions).flatMap((function_) =>
-          (function_.middlewareSpecs ?? []).map(
-            (middlewareSpec) => middlewareSpec.key,
-          ),
-        ),
-      ]),
-    ];
-    const registeredMiddlewareKeys = new Set(
-      finalizedGroupImpl.registeredMiddlewareKeys ?? [],
-    );
-    const missingMiddleware = expectedMiddlewareKeys.filter(
-      (key) => !registeredMiddlewareKeys.has(key),
-    );
+      ),
+    ]),
+  ];
+  const registeredMiddlewareKeys = new Set(
+    finalizedGroupImpl.registeredMiddlewareKeys ?? [],
+  );
+  const missingMiddleware = expectedMiddlewareKeys.filter(
+    (key) => !registeredMiddlewareKeys.has(key),
+  );
 
-    if (missingMiddleware.length > 0) {
-      return yield* new ImplMissingMiddlewareError({
-        implPath: implRelativePath,
-        groupPath: leaf.groupPathDot,
-        missingMiddlewareKeys: missingMiddleware,
-      });
-    }
-  });
+  if (missingMiddleware.length > 0) {
+    return yield* new ImplMissingMiddlewareError({
+      implPath: implRelativePath,
+      groupPath: leaf.groupPathDot,
+      missingMiddlewareKeys: missingMiddleware,
+    });
+  }
+});

--- a/packages/cli/src/TableModule.ts
+++ b/packages/cli/src/TableModule.ts
@@ -30,12 +30,13 @@ export interface TableModule {
   readonly tableName: string;
 }
 
-const tableNameFromRelativePath = (relativePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const { name } = path.parse(relativePath);
-    return name;
-  });
+const tableNameFromRelativePath = Effect.fnUntraced(function* (
+  relativePath: string,
+) {
+  const path = yield* Path.Path;
+  const { name } = path.parse(relativePath);
+  return name;
+});
 
 const listTableFiles = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -132,26 +133,27 @@ export const discover = Effect.gen(function* () {
  * table modules typically `import { Id } from "../_generated/id"` for
  * cross-table references.
  */
-export const validate = (tableModules: ReadonlyArray<TableModule>) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
+export const validate = Effect.fnUntraced(function* (
+  tableModules: ReadonlyArray<TableModule>,
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
 
-    yield* Effect.forEach(
-      tableModules,
-      ({ relativePath }) =>
-        Effect.gen(function* () {
-          const absolutePath = path.resolve(confectDirectory, relativePath);
-          const { module } = yield* Bundler.bundle(absolutePath).pipe(
-            Effect.mapError((error) => fromBundlerError(relativePath, error)),
-          );
+  yield* Effect.forEach(
+    tableModules,
+    ({ relativePath }) =>
+      Effect.gen(function* () {
+        const absolutePath = path.resolve(confectDirectory, relativePath);
+        const { module } = yield* Bundler.bundle(absolutePath).pipe(
+          Effect.mapError((error) => fromBundlerError(relativePath, error)),
+        );
 
-          if (!Table.isUnnamedTable(module.default)) {
-            return yield* new InvalidTableDefaultExportError({
-              tablePath: relativePath,
-            });
-          }
-        }),
-      { concurrency: "unbounded" },
-    );
-  });
+        if (!Table.isUnnamedTable(module.default)) {
+          return yield* new InvalidTableDefaultExportError({
+            tablePath: relativePath,
+          });
+        }
+      }),
+    { concurrency: "unbounded" },
+  );
+});

--- a/packages/cli/src/TableModule.ts
+++ b/packages/cli/src/TableModule.ts
@@ -89,19 +89,18 @@ export const discover = Effect.gen(function* () {
 
   const tableModules = yield* Effect.forEach(
     relativePaths,
-    (relativePath) =>
-      Effect.gen(function* () {
-        const tableName = yield* tableNameFromRelativePath(relativePath);
-        yield* Effect.try({
-          try: () => Identifier.validateConfectTableIdentifier(tableName),
-          catch: (e) =>
-            new InvalidTableFilenameError({
-              tablePath: relativePath,
-              reason: e instanceof Error ? e.message : String(e),
-            }),
-        });
-        return { relativePath, tableName } satisfies TableModule;
-      }),
+    Effect.fnUntraced(function* (relativePath: string) {
+      const tableName = yield* tableNameFromRelativePath(relativePath);
+      yield* Effect.try({
+        try: () => Identifier.validateConfectTableIdentifier(tableName),
+        catch: (e) =>
+          new InvalidTableFilenameError({
+            tablePath: relativePath,
+            reason: e instanceof Error ? e.message : String(e),
+          }),
+      });
+      return { relativePath, tableName } satisfies TableModule;
+    }),
     { concurrency: "unbounded" },
   );
 
@@ -139,21 +138,24 @@ export const validate = Effect.fnUntraced(function* (
   const path = yield* Path.Path;
   const confectDirectory = yield* ConfectDirectory.get;
 
+  const validateRelativePath = Effect.fnUntraced(function* (
+    relativePath: string,
+  ) {
+    const absolutePath = path.resolve(confectDirectory, relativePath);
+    const { module } = yield* Bundler.bundle(absolutePath).pipe(
+      Effect.mapError((error) => fromBundlerError(relativePath, error)),
+    );
+
+    if (!Table.isUnnamedTable(module.default)) {
+      return yield* new InvalidTableDefaultExportError({
+        tablePath: relativePath,
+      });
+    }
+  });
+
   yield* Effect.forEach(
     tableModules,
-    ({ relativePath }) =>
-      Effect.gen(function* () {
-        const absolutePath = path.resolve(confectDirectory, relativePath);
-        const { module } = yield* Bundler.bundle(absolutePath).pipe(
-          Effect.mapError((error) => fromBundlerError(relativePath, error)),
-        );
-
-        if (!Table.isUnnamedTable(module.default)) {
-          return yield* new InvalidTableDefaultExportError({
-            tablePath: relativePath,
-          });
-        }
-      }),
+    ({ relativePath }: TableModule) => validateRelativePath(relativePath),
     { concurrency: "unbounded" },
   );
 });

--- a/packages/cli/src/confect/codegen.ts
+++ b/packages/cli/src/confect/codegen.ts
@@ -126,7 +126,7 @@ export const codegenHandler = Effect.gen(function* () {
 
   const anyWritesHappened = yield* Ref.get(tracker);
   return { functionPaths, anyWritesHappened };
-});
+}).pipe(Effect.withSpan("Cli.codegen"));
 
 const runCodegen = Effect.gen(function* () {
   yield* generateConfectGeneratedDirectory;
@@ -255,75 +255,73 @@ const loadAndValidateLeafModules = Effect.gen(function* () {
  * `GroupSpec.groups` map at runtime, surfacing as a confusing
  * `Refs.make` error rather than a codegen-time diagnostic.
  */
-export const validateNoParentChildNameCollisions = (
+export const validateNoParentChildNameCollisions = Effect.fnUntraced(function* (
   leaves: ReadonlyArray<LeafModule>,
   groupSpecsByPosixRelativePath: ReadonlyMap<string, GroupSpec.AnyWithProps>,
-) =>
-  Effect.gen(function* () {
-    // Convex and Node groups share one namespace, so they assemble into a
-    // single tree. A Node group nested under a Convex parent (or vice versa) is
-    // caught here by the parent/child collision check.
-    const nodes = assemblyNodesFromLeaves(leaves);
-    yield* Effect.forEach(nodes, (n) =>
-      checkAssemblyNodeForCollisions(n, groupSpecsByPosixRelativePath),
-    );
-  });
+) {
+  // Convex and Node groups share one namespace, so they assemble into a
+  // single tree. A Node group nested under a Convex parent (or vice versa) is
+  // caught here by the parent/child collision check.
+  const nodes = assemblyNodesFromLeaves(leaves);
+  yield* Effect.forEach(nodes, (n) =>
+    checkAssemblyNodeForCollisions(n, groupSpecsByPosixRelativePath),
+  );
+});
 
-const checkAssemblyNodeForCollisions = (
+const checkAssemblyNodeForCollisions = Effect.fnUntraced(function* (
   node: SpecAssemblyNode,
   groupSpecsByPosixRelativePath: ReadonlyMap<string, GroupSpec.AnyWithProps>,
-): Effect.Effect<void, ParentChildNameCollisionError> =>
-  Effect.gen(function* () {
-    yield* Option.match(node.importBinding, {
-      onNone: () => Effect.void,
-      onSome: (binding) =>
-        Effect.gen(function* () {
-          if (node.children.length === 0) return;
-          const parentRelativePath = bindingToRelativeSpecPath(
-            binding.importPath,
-          );
-          const parentGroupSpec =
-            groupSpecsByPosixRelativePath.get(parentRelativePath);
-          if (parentGroupSpec === undefined) return;
-          yield* Effect.forEach(node.children, (child) => {
-            if (
-              Object.prototype.hasOwnProperty.call(
-                parentGroupSpec.functions,
-                child.segment,
-              )
-            ) {
-              return Effect.fail(
-                new ParentChildNameCollisionError({
-                  parentSpecPath: parentRelativePath,
-                  childSpecPath: childRepresentativeSpecPath(child),
-                  collisionName: child.segment,
-                  collisionKind: "function",
-                }),
-              );
-            }
-            if (
-              Object.prototype.hasOwnProperty.call(
-                parentGroupSpec.groups,
-                child.segment,
-              )
-            ) {
-              return Effect.fail(
-                new ParentChildNameCollisionError({
-                  parentSpecPath: parentRelativePath,
-                  childSpecPath: childRepresentativeSpecPath(child),
-                  collisionName: child.segment,
-                  collisionKind: "group",
-                }),
-              );
-            }
-            return Effect.void;
-          });
-        }),
-    });
-    yield* Effect.forEach(node.children, (child) =>
-      checkAssemblyNodeForCollisions(child, groupSpecsByPosixRelativePath),
-    );
+): Effect.fn.Return<void, ParentChildNameCollisionError> {
+  yield* Option.match(node.importBinding, {
+    onNone: () => Effect.void,
+    onSome: (binding) =>
+      Effect.gen(function* () {
+        if (node.children.length === 0) return;
+        const parentRelativePath = bindingToRelativeSpecPath(
+          binding.importPath,
+        );
+        const parentGroupSpec =
+          groupSpecsByPosixRelativePath.get(parentRelativePath);
+        if (parentGroupSpec === undefined) return;
+        yield* Effect.forEach(node.children, (child) => {
+          if (
+            Object.prototype.hasOwnProperty.call(
+              parentGroupSpec.functions,
+              child.segment,
+            )
+          ) {
+            return Effect.fail(
+              new ParentChildNameCollisionError({
+                parentSpecPath: parentRelativePath,
+                childSpecPath: childRepresentativeSpecPath(child),
+                collisionName: child.segment,
+                collisionKind: "function",
+              }),
+            );
+          }
+          if (
+            Object.prototype.hasOwnProperty.call(
+              parentGroupSpec.groups,
+              child.segment,
+            )
+          ) {
+            return Effect.fail(
+              new ParentChildNameCollisionError({
+                parentSpecPath: parentRelativePath,
+                childSpecPath: childRepresentativeSpecPath(child),
+                collisionName: child.segment,
+                collisionKind: "group",
+              }),
+            );
+          }
+          return Effect.void;
+        });
+      }),
   });
+  yield* Effect.forEach(node.children, (child) =>
+    checkAssemblyNodeForCollisions(child, groupSpecsByPosixRelativePath),
+  );
+});
 
 /**
  * `LeafModule.specImportPath` is the import path used from inside the
@@ -355,31 +353,32 @@ const childRepresentativeSpecPath = (node: SpecAssemblyNode): string => {
   return node.segment;
 };
 
-const validateOrphanImpls = (specFiles: ReadonlyArray<string>) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const implFiles = yield* discoverLeafImplFiles;
-    const specPaths = new Set(specFiles);
+const validateOrphanImpls = Effect.fnUntraced(function* (
+  specFiles: ReadonlyArray<string>,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const implFiles = yield* discoverLeafImplFiles;
+  const specPaths = new Set(specFiles);
 
-    yield* Effect.forEach(implFiles, (implRelativePath) =>
-      Effect.gen(function* () {
-        const specRelativePath = yield* specPathForImpl(implRelativePath);
-        if (specPaths.has(specRelativePath)) {
-          return;
-        }
+  yield* Effect.forEach(implFiles, (implRelativePath) =>
+    Effect.gen(function* () {
+      const specRelativePath = yield* specPathForImpl(implRelativePath);
+      if (specPaths.has(specRelativePath)) {
+        return;
+      }
 
-        const specAbsolutePath = path.join(confectDirectory, specRelativePath);
-        if (!(yield* fs.exists(specAbsolutePath))) {
-          return yield* new MissingSpecFileError({
-            implPath: implRelativePath,
-            expectedSpecPath: specRelativePath,
-          });
-        }
-      }),
-    );
-  });
+      const specAbsolutePath = path.join(confectDirectory, specRelativePath);
+      if (!(yield* fs.exists(specAbsolutePath))) {
+        return yield* new MissingSpecFileError({
+          implPath: implRelativePath,
+          expectedSpecPath: specRelativePath,
+        });
+      }
+    }),
+  );
+});
 
 const removeLegacyFiles = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -398,134 +397,136 @@ const removeLegacyFiles = Effect.gen(function* () {
   );
 });
 
-const generateAssembledSpecs = (leaves: ReadonlyArray<LeafModule>) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedSpecPath = yield* GENERATED_SPEC_PATH;
+const generateAssembledSpecs = Effect.fnUntraced(function* (
+  leaves: ReadonlyArray<LeafModule>,
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedSpecPath = yield* GENERATED_SPEC_PATH;
 
-    // A single assembled spec holds every group regardless of runtime — a Node
-    // group's `makeNode()` lives in its imported leaf spec, so the assembled
-    // file is runtime-agnostic. Always emit it (even empty) so downstream
-    // readers (`loadGeneratedSpec`, `generateRefs`) always find a spec module.
-    const nodes = assemblyNodesFromLeaves(leaves);
-    const specContents = yield* templates.assembledSpec({ nodes });
-    yield* writeFileStringAndLog(
-      path.join(confectDirectory, generatedSpecPath),
-      specContents,
-    );
-  });
+  // A single assembled spec holds every group regardless of runtime — a Node
+  // group's `makeNode()` lives in its imported leaf spec, so the assembled
+  // file is runtime-agnostic. Always emit it (even empty) so downstream
+  // readers (`loadGeneratedSpec`, `generateRefs`) always find a spec module.
+  const nodes = assemblyNodesFromLeaves(leaves);
+  const specContents = yield* templates.assembledSpec({ nodes });
+  yield* writeFileStringAndLog(
+    path.join(confectDirectory, generatedSpecPath),
+    specContents,
+  );
+});
 
 const validateImplModules = (leaves: ReadonlyArray<LeafModule>) =>
   Effect.forEach(leaves, validateImpl);
 
-const generateGroupRegisteredFunctions = (leaves: ReadonlyArray<LeafModule>) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
+const generateGroupRegisteredFunctions = Effect.fnUntraced(function* (
+  leaves: ReadonlyArray<LeafModule>,
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
 
-    yield* Effect.forEach(leaves, (leaf) =>
-      Effect.gen(function* () {
-        const registryRelativePath =
-          yield* registeredFunctionsRelativePath(leaf);
-        const registryPath = path.join(
-          confectDirectory,
-          "_generated",
-          registryRelativePath,
-        );
-        const registryDir = path.dirname(registryPath);
-        const fs = yield* FileSystem.FileSystem;
-        if (!(yield* fs.exists(registryDir))) {
-          yield* fs.makeDirectory(registryDir, { recursive: true });
-        }
+  yield* Effect.forEach(leaves, (leaf) =>
+    Effect.gen(function* () {
+      const registryRelativePath = yield* registeredFunctionsRelativePath(leaf);
+      const registryPath = path.join(
+        confectDirectory,
+        "_generated",
+        registryRelativePath,
+      );
+      const registryDir = path.dirname(registryPath);
+      const fs = yield* FileSystem.FileSystem;
+      if (!(yield* fs.exists(registryDir))) {
+        yield* fs.makeDirectory(registryDir, { recursive: true });
+      }
 
-        const implRelativePath = yield* implPathForSpec(leaf.relativePath);
-        const schemaImportPath = yield* toModuleImportPath(
-          path.relative(
-            path.dirname(registryPath),
-            path.join(confectDirectory, "_generated", "schema.ts"),
-          ),
-        );
-        // The group's own leaf spec (sibling of its impl), referenced
-        // type-only by the registry to shape its returned record.
-        const specImportPath = yield* toModuleImportPath(
-          path.relative(
-            path.dirname(registryPath),
-            path.join(confectDirectory, leaf.relativePath),
-          ),
-        );
-        const implImportPath = yield* toModuleImportPath(
-          path.relative(
-            path.dirname(registryPath),
-            path.join(confectDirectory, implRelativePath),
-          ),
-        );
+      const implRelativePath = yield* implPathForSpec(leaf.relativePath);
+      const schemaImportPath = yield* toModuleImportPath(
+        path.relative(
+          path.dirname(registryPath),
+          path.join(confectDirectory, "_generated", "schema.ts"),
+        ),
+      );
+      // The group's own leaf spec (sibling of its impl), referenced
+      // type-only by the registry to shape its returned record.
+      const specImportPath = yield* toModuleImportPath(
+        path.relative(
+          path.dirname(registryPath),
+          path.join(confectDirectory, leaf.relativePath),
+        ),
+      );
+      const implImportPath = yield* toModuleImportPath(
+        path.relative(
+          path.dirname(registryPath),
+          path.join(confectDirectory, implRelativePath),
+        ),
+      );
 
-        // Every leaf reaching this point came through
-        // `loadAndValidateLeafModules`, which stamps the runtime from the
-        // validated spec — so `None` here means that invariant was broken.
-        const runtime = yield* Option.match(leaf.runtime, {
-          onNone: () =>
-            Effect.die(
-              new Error(
-                `Runtime for '${leaf.relativePath}' was not resolved before registry generation.`,
-              ),
+      // Every leaf reaching this point came through
+      // `loadAndValidateLeafModules`, which stamps the runtime from the
+      // validated spec — so `None` here means that invariant was broken.
+      const runtime = yield* Option.match(leaf.runtime, {
+        onNone: () =>
+          Effect.die(
+            new Error(
+              `Runtime for '${leaf.relativePath}' was not resolved before registry generation.`,
             ),
-          onSome: Effect.succeed,
-        });
+          ),
+        onSome: Effect.succeed,
+      });
 
-        const contents = yield* templates.registeredFunctionsForGroup({
-          schemaImportPath,
-          specImportPath,
-          implImportPath,
-          layerExportName: leaf.exportName,
-          useNode: runtime === "Node",
-        });
+      const contents = yield* templates.registeredFunctionsForGroup({
+        schemaImportPath,
+        specImportPath,
+        implImportPath,
+        layerExportName: leaf.exportName,
+        useNode: runtime === "Node",
+      });
 
-        yield* writeFileStringAndLog(registryPath, contents);
-      }),
-    );
-  });
+      yield* writeFileStringAndLog(registryPath, contents);
+    }),
+  );
+});
 
-const removeObsoleteRegisteredFunctions = (leaves: ReadonlyArray<LeafModule>) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const registryRoot = path.join(
-      confectDirectory,
-      "_generated",
-      "registeredFunctions",
-    );
+const removeObsoleteRegisteredFunctions = Effect.fnUntraced(function* (
+  leaves: ReadonlyArray<LeafModule>,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const registryRoot = path.join(
+    confectDirectory,
+    "_generated",
+    "registeredFunctions",
+  );
 
-    if (!(yield* fs.exists(registryRoot))) {
-      return;
-    }
+  if (!(yield* fs.exists(registryRoot))) {
+    return;
+  }
 
-    const expected = new Set(
-      yield* Effect.forEach(leaves, (leaf) =>
-        registeredFunctionsRelativePath(leaf),
-      ),
-    );
+  const expected = new Set(
+    yield* Effect.forEach(leaves, (leaf) =>
+      registeredFunctionsRelativePath(leaf),
+    ),
+  );
 
-    const existing = yield* fs.readDirectory(registryRoot, { recursive: true });
-    yield* Effect.forEach(existing, (relativePath) => {
-      if (path.extname(relativePath) !== ".ts") {
-        return Effect.void;
-      }
-      const normalized = path.join("registeredFunctions", relativePath);
-      if (!expected.has(normalized)) {
-        return Effect.gen(function* () {
-          const absolutePath = path.join(registryRoot, relativePath);
-          if (yield* fs.exists(absolutePath)) {
-            yield* removePathIfExists(absolutePath);
-            yield* logFileRemoved(absolutePath);
-          }
-        });
-      }
+  const existing = yield* fs.readDirectory(registryRoot, { recursive: true });
+  yield* Effect.forEach(existing, (relativePath) => {
+    if (path.extname(relativePath) !== ".ts") {
       return Effect.void;
-    });
+    }
+    const normalized = path.join("registeredFunctions", relativePath);
+    if (!expected.has(normalized)) {
+      return Effect.gen(function* () {
+        const absolutePath = path.join(registryRoot, relativePath);
+        if (yield* fs.exists(absolutePath)) {
+          yield* removePathIfExists(absolutePath);
+          yield* logFileRemoved(absolutePath);
+        }
+      });
+    }
+    return Effect.void;
   });
+});
 
 const getGeneratedSpecPath = Effect.gen(function* () {
   const path = yield* Path.Path;
@@ -570,18 +571,19 @@ export const loadPreviousFunctionPaths = Effect.gen(function* () {
  * Remove a now-obsolete `_generated/<name>.ts` if present (and log it), for
  * projects upgrading from a version that still emitted it.
  */
-const removeObsoleteGeneratedFile = (fileName: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const filePath = path.join(confectDirectory, "_generated", fileName);
+const removeObsoleteGeneratedFile = Effect.fnUntraced(function* (
+  fileName: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const filePath = path.join(confectDirectory, "_generated", fileName);
 
-    if (yield* fs.exists(filePath)) {
-      yield* removePathIfExists(filePath);
-      yield* logFileRemoved(filePath);
-    }
-  });
+  if (yield* fs.exists(filePath)) {
+    yield* removePathIfExists(filePath);
+    yield* logFileRemoved(filePath);
+  }
+});
 
 // `_generated/api.ts` is no longer imported by generated or impl code: impls
 // take the database schema (`_generated/schema`) directly, and per-group
@@ -634,165 +636,159 @@ const warnIfNoTables = (
       )
     : Effect.void;
 
-const tableModuleBindings = (
+const tableModuleBindings = Effect.fnUntraced(function* (
   tableModules: ReadonlyArray<TableModule.TableModule>,
   generatedFilePath: string,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedDir = path.dirname(generatedFilePath);
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedDir = path.dirname(generatedFilePath);
 
-    const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
+  const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
 
-    return yield* Effect.forEach(tableModules, (tableModule) =>
+  return yield* Effect.forEach(tableModules, (tableModule) =>
+    Effect.gen(function* () {
+      const wrapperAbsolutePath = path.join(
+        confectDirectory,
+        generatedTablesDirname,
+        `${tableModule.tableName}.ts`,
+      );
+      const importPath = yield* toModuleImportPath(
+        path.relative(generatedDir, wrapperAbsolutePath),
+      );
+      return {
+        importPath,
+        tableName: tableModule.tableName,
+      };
+    }),
+  );
+});
+
+const generateIdConstructor = Effect.fnUntraced(function* (
+  tableModules: ReadonlyArray<TableModule.TableModule>,
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedIdPath = yield* GENERATED_ID_PATH;
+  const idPath = path.join(confectDirectory, generatedIdPath);
+
+  const tableNames = Array.map(
+    tableModules,
+    (tableModule) => tableModule.tableName,
+  );
+  const contents = yield* templates.id({ tableNames });
+
+  yield* writeFileStringAndLog(idPath, contents);
+});
+
+const generateTableWrappers = Effect.fnUntraced(function* (
+  tableModules: ReadonlyArray<TableModule.TableModule>,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
+  const wrappersDir = path.join(confectDirectory, generatedTablesDirname);
+
+  if (!(yield* fs.exists(wrappersDir))) {
+    yield* fs.makeDirectory(wrappersDir, { recursive: true });
+  }
+
+  yield* Effect.forEach(
+    tableModules,
+    (tableModule) =>
       Effect.gen(function* () {
-        const wrapperAbsolutePath = path.join(
+        const wrapperPath = path.join(
           confectDirectory,
           generatedTablesDirname,
           `${tableModule.tableName}.ts`,
         );
-        const importPath = yield* toModuleImportPath(
-          path.relative(generatedDir, wrapperAbsolutePath),
+        const unnamedAbsolutePath = path.join(
+          confectDirectory,
+          tableModule.relativePath,
         );
-        return {
-          importPath,
+        const unnamedImportPath = yield* toModuleImportPath(
+          path.relative(path.dirname(wrapperPath), unnamedAbsolutePath),
+        );
+        const contents = yield* templates.tableWrapper({
           tableName: tableModule.tableName,
-        };
+          unnamedImportPath,
+        });
+        yield* writeFileStringAndLog(wrapperPath, contents);
       }),
-    );
-  });
-
-const generateIdConstructor = (
-  tableModules: ReadonlyArray<TableModule.TableModule>,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedIdPath = yield* GENERATED_ID_PATH;
-    const idPath = path.join(confectDirectory, generatedIdPath);
-
-    const tableNames = Array.map(
-      tableModules,
-      (tableModule) => tableModule.tableName,
-    );
-    const contents = yield* templates.id({ tableNames });
-
-    yield* writeFileStringAndLog(idPath, contents);
-  });
-
-const generateTableWrappers = (
-  tableModules: ReadonlyArray<TableModule.TableModule>,
-) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
-    const wrappersDir = path.join(confectDirectory, generatedTablesDirname);
-
-    if (!(yield* fs.exists(wrappersDir))) {
-      yield* fs.makeDirectory(wrappersDir, { recursive: true });
-    }
-
-    yield* Effect.forEach(
-      tableModules,
-      (tableModule) =>
-        Effect.gen(function* () {
-          const wrapperPath = path.join(
-            confectDirectory,
-            generatedTablesDirname,
-            `${tableModule.tableName}.ts`,
-          );
-          const unnamedAbsolutePath = path.join(
-            confectDirectory,
-            tableModule.relativePath,
-          );
-          const unnamedImportPath = yield* toModuleImportPath(
-            path.relative(path.dirname(wrapperPath), unnamedAbsolutePath),
-          );
-          const contents = yield* templates.tableWrapper({
-            tableName: tableModule.tableName,
-            unnamedImportPath,
-          });
-          yield* writeFileStringAndLog(wrapperPath, contents);
-        }),
-      { concurrency: "unbounded" },
-    );
-  });
+    { concurrency: "unbounded" },
+  );
+});
 
 /**
  * Remove any stale `_generated/tables/*.ts` wrapper whose source table
  * has been deleted or renamed. Mirrors `removeObsoleteRegisteredFunctions`
  * for the wrapper directory.
  */
-const removeObsoleteTableWrappers = (
+const removeObsoleteTableWrappers = Effect.fnUntraced(function* (
   tableModules: ReadonlyArray<TableModule.TableModule>,
-) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
-    const wrappersDir = path.join(confectDirectory, generatedTablesDirname);
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
+  const wrappersDir = path.join(confectDirectory, generatedTablesDirname);
 
-    if (!(yield* fs.exists(wrappersDir))) {
-      return;
-    }
+  if (!(yield* fs.exists(wrappersDir))) {
+    return;
+  }
 
-    const expected = new Set(
-      Array.map(tableModules, (tableModule) => `${tableModule.tableName}.ts`),
-    );
-    const existing = yield* fs.readDirectory(wrappersDir, { recursive: true });
-    yield* Effect.forEach(existing, (entry) => {
-      if (path.extname(entry) !== ".ts") {
-        return Effect.void;
-      }
-      if (!expected.has(entry)) {
-        return Effect.gen(function* () {
-          const absolutePath = path.join(wrappersDir, entry);
-          if (yield* fs.exists(absolutePath)) {
-            yield* removePathIfExists(absolutePath);
-            yield* logFileRemoved(absolutePath);
-          }
-        });
-      }
+  const expected = new Set(
+    Array.map(tableModules, (tableModule) => `${tableModule.tableName}.ts`),
+  );
+  const existing = yield* fs.readDirectory(wrappersDir, { recursive: true });
+  yield* Effect.forEach(existing, (entry) => {
+    if (path.extname(entry) !== ".ts") {
       return Effect.void;
-    });
+    }
+    if (!expected.has(entry)) {
+      return Effect.gen(function* () {
+        const absolutePath = path.join(wrappersDir, entry);
+        if (yield* fs.exists(absolutePath)) {
+          yield* removePathIfExists(absolutePath);
+          yield* logFileRemoved(absolutePath);
+        }
+      });
+    }
+    return Effect.void;
   });
+});
 
-const generateRuntimeSchema = (
+const generateRuntimeSchema = Effect.fnUntraced(function* (
   tableModules: ReadonlyArray<TableModule.TableModule>,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedSchemaPath = yield* GENERATED_SCHEMA_PATH;
-    const schemaPath = path.join(confectDirectory, generatedSchemaPath);
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedSchemaPath = yield* GENERATED_SCHEMA_PATH;
+  const schemaPath = path.join(confectDirectory, generatedSchemaPath);
 
-    const bindings = yield* tableModuleBindings(tableModules, schemaPath);
-    const contents = yield* templates.runtimeSchema({ tableModules: bindings });
+  const bindings = yield* tableModuleBindings(tableModules, schemaPath);
+  const contents = yield* templates.runtimeSchema({ tableModules: bindings });
 
-    yield* writeFileStringAndLog(schemaPath, contents);
-  });
+  yield* writeFileStringAndLog(schemaPath, contents);
+});
 
-const generateConvexSchema = (
+const generateConvexSchema = Effect.fnUntraced(function* (
   tableModules: ReadonlyArray<TableModule.TableModule>,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const generatedConvexSchemaPath = yield* GENERATED_CONVEX_SCHEMA_PATH;
-    const convexSchemaPath = path.join(
-      confectDirectory,
-      generatedConvexSchemaPath,
-    );
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const generatedConvexSchemaPath = yield* GENERATED_CONVEX_SCHEMA_PATH;
+  const convexSchemaPath = path.join(
+    confectDirectory,
+    generatedConvexSchemaPath,
+  );
 
-    const bindings = yield* tableModuleBindings(tableModules, convexSchemaPath);
-    const contents = yield* templates.convexSchema({ tableModules: bindings });
+  const bindings = yield* tableModuleBindings(tableModules, convexSchemaPath);
+  const contents = yield* templates.convexSchema({ tableModules: bindings });
 
-    yield* writeFileStringAndLog(convexSchemaPath, contents);
-  });
+  yield* writeFileStringAndLog(convexSchemaPath, contents);
+});
 
 const generateConvexSchemaReexport = Effect.gen(function* () {
   const path = yield* Path.Path;
@@ -845,54 +841,54 @@ const generateServices = Effect.gen(function* () {
  * interfaces in `_generated/docs.ts`. Catch that up front with a clear error
  * rather than letting `tsc` report a duplicate-identifier later.
  */
-const validateNoDocNameCollisions = (
+const validateNoDocNameCollisions = Effect.fnUntraced(function* (
   tableModules: ReadonlyArray<TableModule.TableModule>,
-) =>
-  Effect.gen(function* () {
-    const collisions = pipe(
-      tableModules,
-      Array.groupBy((tableModule) =>
-        DocName.fromTableName(tableModule.tableName),
-      ),
-      Record.toEntries,
-      Array.filter(([, group]) => group.length > 1),
-      Array.map(([docName, group]) => ({
-        docName,
-        tableNames: Array.map(group, (tableModule) => tableModule.tableName),
-      })),
-    );
+) {
+  const collisions = pipe(
+    tableModules,
+    Array.groupBy((tableModule) =>
+      DocName.fromTableName(tableModule.tableName),
+    ),
+    Record.toEntries,
+    Array.filter(([, group]) => group.length > 1),
+    Array.map(([docName, group]) => ({
+      docName,
+      tableNames: Array.map(group, (tableModule) => tableModule.tableName),
+    })),
+  );
 
-    if (Array.isReadonlyArrayNonEmpty(collisions)) {
-      return yield* new CodegenError.ConflictingDocNameError({ collisions });
-    }
+  if (Array.isReadonlyArrayNonEmpty(collisions)) {
+    return yield* new CodegenError.ConflictingDocNameError({ collisions });
+  }
+});
+
+const generateDocs = Effect.fnUntraced(function* (
+  tableModules: ReadonlyArray<TableModule.TableModule>,
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+
+  const confectGeneratedDirectory = path.join(confectDirectory, "_generated");
+
+  const docsPath = path.join(confectGeneratedDirectory, "docs.ts");
+  const generatedSchemaPath = yield* GENERATED_SCHEMA_PATH;
+  const schemaImportPath = yield* toModuleImportPath(
+    path.relative(
+      path.dirname(docsPath),
+      path.join(confectDirectory, generatedSchemaPath),
+    ),
+  );
+
+  const docsContentsString = yield* templates.docs({
+    schemaImportPath,
+    tables: Array.map(tableModules, (tableModule) => ({
+      tableName: tableModule.tableName,
+      docName: DocName.fromTableName(tableModule.tableName),
+    })),
   });
 
-const generateDocs = (tableModules: ReadonlyArray<TableModule.TableModule>) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-
-    const confectGeneratedDirectory = path.join(confectDirectory, "_generated");
-
-    const docsPath = path.join(confectGeneratedDirectory, "docs.ts");
-    const generatedSchemaPath = yield* GENERATED_SCHEMA_PATH;
-    const schemaImportPath = yield* toModuleImportPath(
-      path.relative(
-        path.dirname(docsPath),
-        path.join(confectDirectory, generatedSchemaPath),
-      ),
-    );
-
-    const docsContentsString = yield* templates.docs({
-      schemaImportPath,
-      tables: Array.map(tableModules, (tableModule) => ({
-        tableName: tableModule.tableName,
-        docName: DocName.fromTableName(tableModule.tableName),
-      })),
-    });
-
-    yield* writeFileStringAndLog(docsPath, docsContentsString);
-  });
+  yield* writeFileStringAndLog(docsPath, docsContentsString);
+});
 
 const generateRefs = Effect.gen(function* () {
   const path = yield* Path.Path;

--- a/packages/cli/src/confect/codegen.ts
+++ b/packages/cli/src/confect/codegen.ts
@@ -211,8 +211,9 @@ const loadAndValidateLeafModules = Effect.gen(function* () {
   const confectDirectory = yield* ConfectDirectory.get;
   const specFiles = yield* discoverLeafSpecFiles;
 
-  const results = yield* Effect.forEach(specFiles, (specRelativePath) =>
-    Effect.gen(function* () {
+  const results = yield* Effect.forEach(
+    specFiles,
+    Effect.fnUntraced(function* (specRelativePath: string) {
       const discovered = yield* toLeafModule(specRelativePath);
       const groupSpec = yield* validateSpec(discovered);
       // Fill in the runtime now that the spec is bundled; discovery left it `None`.
@@ -362,8 +363,9 @@ const validateOrphanImpls = Effect.fnUntraced(function* (
   const implFiles = yield* discoverLeafImplFiles;
   const specPaths = new Set(specFiles);
 
-  yield* Effect.forEach(implFiles, (implRelativePath) =>
-    Effect.gen(function* () {
+  yield* Effect.forEach(
+    implFiles,
+    Effect.fnUntraced(function* (implRelativePath: string) {
       const specRelativePath = yield* specPathForImpl(implRelativePath);
       if (specPaths.has(specRelativePath)) {
         return;
@@ -386,8 +388,9 @@ const removeLegacyFiles = Effect.gen(function* () {
   const confectDirectory = yield* ConfectDirectory.get;
   const legacyPaths = yield* LEGACY_PATHS;
 
-  yield* Effect.forEach(legacyPaths, (relativePath) =>
-    Effect.gen(function* () {
+  yield* Effect.forEach(
+    legacyPaths,
+    Effect.fnUntraced(function* (relativePath: string) {
       const absolutePath = path.join(confectDirectory, relativePath);
       if (yield* fs.exists(absolutePath)) {
         yield* removePathIfExists(absolutePath);
@@ -425,8 +428,9 @@ const generateGroupRegisteredFunctions = Effect.fnUntraced(function* (
   const path = yield* Path.Path;
   const confectDirectory = yield* ConfectDirectory.get;
 
-  yield* Effect.forEach(leaves, (leaf) =>
-    Effect.gen(function* () {
+  yield* Effect.forEach(
+    leaves,
+    Effect.fnUntraced(function* (leaf: LeafModule) {
       const registryRelativePath = yield* registeredFunctionsRelativePath(leaf);
       const registryPath = path.join(
         confectDirectory,
@@ -646,8 +650,9 @@ const tableModuleBindings = Effect.fnUntraced(function* (
 
   const generatedTablesDirname = yield* GENERATED_TABLES_DIRNAME;
 
-  return yield* Effect.forEach(tableModules, (tableModule) =>
-    Effect.gen(function* () {
+  return yield* Effect.forEach(
+    tableModules,
+    Effect.fnUntraced(function* (tableModule: TableModule.TableModule) {
       const wrapperAbsolutePath = path.join(
         confectDirectory,
         generatedTablesDirname,
@@ -696,26 +701,25 @@ const generateTableWrappers = Effect.fnUntraced(function* (
 
   yield* Effect.forEach(
     tableModules,
-    (tableModule) =>
-      Effect.gen(function* () {
-        const wrapperPath = path.join(
-          confectDirectory,
-          generatedTablesDirname,
-          `${tableModule.tableName}.ts`,
-        );
-        const unnamedAbsolutePath = path.join(
-          confectDirectory,
-          tableModule.relativePath,
-        );
-        const unnamedImportPath = yield* toModuleImportPath(
-          path.relative(path.dirname(wrapperPath), unnamedAbsolutePath),
-        );
-        const contents = yield* templates.tableWrapper({
-          tableName: tableModule.tableName,
-          unnamedImportPath,
-        });
-        yield* writeFileStringAndLog(wrapperPath, contents);
-      }),
+    Effect.fnUntraced(function* (tableModule: TableModule.TableModule) {
+      const wrapperPath = path.join(
+        confectDirectory,
+        generatedTablesDirname,
+        `${tableModule.tableName}.ts`,
+      );
+      const unnamedAbsolutePath = path.join(
+        confectDirectory,
+        tableModule.relativePath,
+      );
+      const unnamedImportPath = yield* toModuleImportPath(
+        path.relative(path.dirname(wrapperPath), unnamedAbsolutePath),
+      );
+      const contents = yield* templates.tableWrapper({
+        tableName: tableModule.tableName,
+        unnamedImportPath,
+      });
+      yield* writeFileStringAndLog(wrapperPath, contents);
+    }),
     { concurrency: "unbounded" },
   );
 });

--- a/packages/cli/src/confect/dev.ts
+++ b/packages/cli/src/confect/dev.ts
@@ -106,76 +106,74 @@ const changeChar = (change: "Added" | "Removed" | "Modified") =>
     Match.exhaustive,
   );
 
-const logFileChangeIndented = (
+const logFileChangeIndented = Effect.fnUntraced(function* (
   change: "Added" | "Removed" | "Modified",
   fullPath: string,
-) =>
-  Effect.gen(function* () {
-    const projectRoot = yield* ProjectRoot.get;
-    const path = yield* Path.Path;
+) {
+  const projectRoot = yield* ProjectRoot.get;
+  const path = yield* Path.Path;
 
-    const prefix = projectRoot + path.sep;
-    const suffix = pipe(fullPath, String.startsWith(prefix))
-      ? pipe(fullPath, String.slice(prefix.length))
-      : fullPath;
+  const prefix = projectRoot + path.sep;
+  const suffix = pipe(fullPath, String.startsWith(prefix))
+    ? pipe(fullPath, String.slice(prefix.length))
+    : fullPath;
 
-    const { char, color } = changeChar(change);
+  const { char, color } = changeChar(change);
 
-    yield* Console.log(
-      `${color(char)} ${Ansi.blackBright(prefix)}${color(suffix)}`,
-    );
-  });
+  yield* Console.log(
+    `${color(char)} ${Ansi.blackBright(prefix)}${color(suffix)}`,
+  );
+});
 
-const logFunctionPathDiff = (
+const logFunctionPathDiff = Effect.fnUntraced(function* (
   previous: FunctionPaths.FunctionPaths,
   current: FunctionPaths.FunctionPaths,
-) =>
-  Effect.gen(function* () {
-    const {
-      functionsAdded,
-      functionsRemoved,
-      groupsRemoved,
-      groupsAdded,
-      groupsChanged,
-    } = FunctionPaths.diff(previous, current);
+) {
+  const {
+    functionsAdded,
+    functionsRemoved,
+    groupsRemoved,
+    groupsAdded,
+    groupsChanged,
+  } = FunctionPaths.diff(previous, current);
 
-    const logForGroups = (
-      groupPaths: GroupPaths.GroupPaths,
-      fnPaths: FunctionPaths.FunctionPaths,
-      logFn: typeof logFunctionAdded,
-    ) =>
-      Effect.forEach(groupPaths, (gp) =>
-        Effect.forEach(
-          Array.fromIterable(
-            HashSet.filter(fnPaths, (fp) => Equal.equals(fp.groupPath, gp)),
-          ),
-          logFn,
+  const logForGroups = (
+    groupPaths: GroupPaths.GroupPaths,
+    fnPaths: FunctionPaths.FunctionPaths,
+    logFn: typeof logFunctionAdded,
+  ) =>
+    Effect.forEach(groupPaths, (gp) =>
+      Effect.forEach(
+        Array.fromIterable(
+          HashSet.filter(fnPaths, (fp) => Equal.equals(fp.groupPath, gp)),
         ),
-      );
-
-    yield* logForGroups(groupsRemoved, functionsRemoved, logFunctionRemoved);
-    yield* logForGroups(groupsAdded, functionsAdded, logFunctionAdded);
-    yield* Effect.forEach(groupsChanged, (gp) =>
-      Effect.gen(function* () {
-        yield* Effect.forEach(
-          Array.fromIterable(
-            HashSet.filter(functionsAdded, (fp) =>
-              Equal.equals(fp.groupPath, gp),
-            ),
-          ),
-          logFunctionAdded,
-        );
-        yield* Effect.forEach(
-          Array.fromIterable(
-            HashSet.filter(functionsRemoved, (fp) =>
-              Equal.equals(fp.groupPath, gp),
-            ),
-          ),
-          logFunctionRemoved,
-        );
-      }),
+        logFn,
+      ),
     );
-  });
+
+  yield* logForGroups(groupsRemoved, functionsRemoved, logFunctionRemoved);
+  yield* logForGroups(groupsAdded, functionsAdded, logFunctionAdded);
+  yield* Effect.forEach(groupsChanged, (gp) =>
+    Effect.gen(function* () {
+      yield* Effect.forEach(
+        Array.fromIterable(
+          HashSet.filter(functionsAdded, (fp) =>
+            Equal.equals(fp.groupPath, gp),
+          ),
+        ),
+        logFunctionAdded,
+      );
+      yield* Effect.forEach(
+        Array.fromIterable(
+          HashSet.filter(functionsRemoved, (fp) =>
+            Equal.equals(fp.groupPath, gp),
+          ),
+        ),
+        logFunctionRemoved,
+      );
+    }),
+  );
+});
 
 export const dev = Command.make("dev", {}, () =>
   Effect.gen(function* () {
@@ -261,20 +259,19 @@ const watcherMessagesSignature = (messages: WatcherMessages): string =>
  * happens when one root cause (e.g. a missing import) breaks every entry
  * point's build at the same source location.
  */
-const logChangedWatcherMessages = (
+const logChangedWatcherMessages = Effect.fnUntraced(function* (
   messagesRef: Ref.Ref<WatcherMessages>,
   lastLoggedSignatureRef: Ref.Ref<string>,
   log: (messages: ReadonlyArray<esbuild.Message>) => Effect.Effect<void>,
-) =>
-  Effect.gen(function* () {
-    const messages = yield* Ref.get(messagesRef);
-    const signature = watcherMessagesSignature(messages);
-    const previous = yield* Ref.get(lastLoggedSignatureRef);
-    if (signature === previous) return;
-    yield* Ref.set(lastLoggedSignatureRef, signature);
-    if (messages.size === 0) return;
-    yield* log(dedupeWatcherMessages(messages));
-  });
+) {
+  const messages = yield* Ref.get(messagesRef);
+  const signature = watcherMessagesSignature(messages);
+  const previous = yield* Ref.get(lastLoggedSignatureRef);
+  if (signature === previous) return;
+  yield* Ref.set(lastLoggedSignatureRef, signature);
+  if (messages.size === 0) return;
+  yield* log(dedupeWatcherMessages(messages));
+});
 
 /**
  * Block until the signal queue has been quiet for `quiescence`. esbuild
@@ -283,122 +280,120 @@ const logChangedWatcherMessages = (
  * Bounded by `maxWait` so pathological signal floods can't pin the
  * loop forever.
  */
-const drainUntilQuiescent = (
+const drainUntilQuiescent = Effect.fnUntraced(function* (
   signal: Queue.Queue<void>,
   quiescence: Duration.Duration,
   maxWait: Duration.Duration,
-) =>
-  Effect.gen(function* () {
-    const start = yield* Clock.currentTimeMillis;
-    const maxMillis = Duration.toMillis(maxWait);
-    const loop: Effect.Effect<void> = Effect.gen(function* () {
-      yield* Effect.sleep(quiescence);
-      const drained = yield* Queue.clear(signal);
-      if (drained.length === 0) return;
-      const now = yield* Clock.currentTimeMillis;
-      if (now - start < maxMillis) {
-        yield* loop;
-      }
-    });
-    yield* loop;
+) {
+  const start = yield* Clock.currentTimeMillis;
+  const maxMillis = Duration.toMillis(maxWait);
+  const loop: Effect.Effect<void> = Effect.gen(function* () {
+    yield* Effect.sleep(quiescence);
+    const drained = yield* Queue.clear(signal);
+    if (drained.length === 0) return;
+    const now = yield* Clock.currentTimeMillis;
+    if (now - start < maxMillis) {
+      yield* loop;
+    }
   });
+  yield* loop;
+});
 
-const syncLoop = (
+const syncLoop = Effect.fnUntraced(function* (
   signal: Queue.Queue<void>,
   pendingRef: Ref.Ref<Pending>,
   initialFunctionPaths: FunctionPaths.FunctionPaths,
   watcherErrorsRef: Ref.Ref<WatcherMessages>,
   watcherWarningsRef: Ref.Ref<WatcherMessages>,
-) =>
-  Effect.gen(function* () {
-    const functionPathsRef = yield* Ref.make(initialFunctionPaths);
-    const lastLoggedErrorsRef = yield* Ref.make<string>("");
-    const lastLoggedWarningsRef = yield* Ref.make<string>("");
+) {
+  const functionPathsRef = yield* Ref.make(initialFunctionPaths);
+  const lastLoggedErrorsRef = yield* Ref.make<string>("");
+  const lastLoggedWarningsRef = yield* Ref.make<string>("");
 
-    return yield* Effect.forever(
-      Effect.gen(function* () {
-        yield* Effect.logDebug("Running sync loop…");
-        // Wait for the first signal of a burst, then keep absorbing
-        // follow-up signals from other watchers' onEnds until the queue
-        // stays quiet for `COALESCE_QUIESCENCE`.
-        yield* Queue.take(signal);
+  return yield* Effect.forever(
+    Effect.gen(function* () {
+      yield* Effect.logDebug("Running sync loop…");
+      // Wait for the first signal of a burst, then keep absorbing
+      // follow-up signals from other watchers' onEnds until the queue
+      // stays quiet for `COALESCE_QUIESCENCE`.
+      yield* Queue.take(signal);
+      yield* drainUntilQuiescent(
+        signal,
+        COALESCE_QUIESCENCE,
+        COALESCE_MAX_WAIT,
+      );
+
+      yield* logChangedWatcherMessages(
+        watcherErrorsRef,
+        lastLoggedErrorsRef,
+        logCoalescedBuildErrors,
+      );
+      yield* logChangedWatcherMessages(
+        watcherWarningsRef,
+        lastLoggedWarningsRef,
+        logCoalescedBuildWarnings,
+      );
+
+      const pending = yield* Ref.getAndSet(pendingRef, pendingInit);
+
+      if (!isPendingDirty(pending)) {
+        // No-op signal (e.g. a late echo after a previous cycle
+        // already drained). Stay silent.
+        return;
+      }
+
+      yield* logPending("Dependencies may have changed, reloading…");
+
+      if (pending.specDirty) {
+        const current = yield* codegenHandler.pipe(
+          Effect.tap(({ functionPaths: nextFunctionPaths }) =>
+            Effect.gen(function* () {
+              const previous = yield* Ref.get(functionPathsRef);
+              yield* logFunctionPathDiff(previous, nextFunctionPaths);
+              yield* Ref.set(functionPathsRef, nextFunctionPaths);
+            }),
+          ),
+          CodegenError.catchAndLog,
+        );
+        if (Option.isNone(current)) {
+          return;
+        }
+        // Drain any stragglers from this cycle's burst (slow watchers
+        // whose onEnd fired after the first quiescence) plus, when
+        // codegen wrote, the echo signals esbuild emits in response
+        // to our writes. Reset `pendingRef` so those drained signals
+        // don't carry a dirty flag into the next cycle.
+        if (current.value.anyWritesHappened) {
+          yield* Effect.sleep(ECHO_COOLDOWN);
+        }
         yield* drainUntilQuiescent(
           signal,
           COALESCE_QUIESCENCE,
           COALESCE_MAX_WAIT,
         );
+        yield* Ref.set(pendingRef, pendingInit);
+      }
 
-        yield* logChangedWatcherMessages(
-          watcherErrorsRef,
-          lastLoggedErrorsRef,
-          logCoalescedBuildErrors,
-        );
-        yield* logChangedWatcherMessages(
-          watcherWarningsRef,
-          lastLoggedWarningsRef,
-          logCoalescedBuildWarnings,
-        );
+      const dirtyOptionalFiles = [
+        ...(pending.httpDirty
+          ? [syncOptionalFile(generateHttp, "http.ts")]
+          : []),
+        ...(pending.cronsDirty
+          ? [syncOptionalFile(generateCrons, "crons.ts")]
+          : []),
+        ...(pending.authDirty
+          ? [syncOptionalFile(generateAuthConfig, "auth.config.ts")]
+          : []),
+      ];
 
-        const pending = yield* Ref.getAndSet(pendingRef, pendingInit);
+      yield* Array.isReadonlyArrayNonEmpty(dirtyOptionalFiles)
+        ? Effect.all(dirtyOptionalFiles, { concurrency: "unbounded" })
+        : Effect.void;
 
-        if (!isPendingDirty(pending)) {
-          // No-op signal (e.g. a late echo after a previous cycle
-          // already drained). Stay silent.
-          return;
-        }
-
-        yield* logPending("Dependencies may have changed, reloading…");
-
-        if (pending.specDirty) {
-          const current = yield* codegenHandler.pipe(
-            Effect.tap(({ functionPaths: nextFunctionPaths }) =>
-              Effect.gen(function* () {
-                const previous = yield* Ref.get(functionPathsRef);
-                yield* logFunctionPathDiff(previous, nextFunctionPaths);
-                yield* Ref.set(functionPathsRef, nextFunctionPaths);
-              }),
-            ),
-            CodegenError.catchAndLog,
-          );
-          if (Option.isNone(current)) {
-            return;
-          }
-          // Drain any stragglers from this cycle's burst (slow watchers
-          // whose onEnd fired after the first quiescence) plus, when
-          // codegen wrote, the echo signals esbuild emits in response
-          // to our writes. Reset `pendingRef` so those drained signals
-          // don't carry a dirty flag into the next cycle.
-          if (current.value.anyWritesHappened) {
-            yield* Effect.sleep(ECHO_COOLDOWN);
-          }
-          yield* drainUntilQuiescent(
-            signal,
-            COALESCE_QUIESCENCE,
-            COALESCE_MAX_WAIT,
-          );
-          yield* Ref.set(pendingRef, pendingInit);
-        }
-
-        const dirtyOptionalFiles = [
-          ...(pending.httpDirty
-            ? [syncOptionalFile(generateHttp, "http.ts")]
-            : []),
-          ...(pending.cronsDirty
-            ? [syncOptionalFile(generateCrons, "crons.ts")]
-            : []),
-          ...(pending.authDirty
-            ? [syncOptionalFile(generateAuthConfig, "auth.config.ts")]
-            : []),
-        ];
-
-        yield* Array.isReadonlyArrayNonEmpty(dirtyOptionalFiles)
-          ? Effect.all(dirtyOptionalFiles, { concurrency: "unbounded" })
-          : Effect.void;
-
-        yield* logSuccess("Generated files are up-to-date");
-      }),
-    );
-  });
+      yield* logSuccess("Generated files are up-to-date");
+    }),
+  );
+});
 
 interface EntryPoint {
   readonly absolutePath: string;
@@ -418,18 +413,20 @@ const discoverEntryPoints = Effect.gen(function* () {
   const projectRoot = yield* ProjectRoot.get;
   const confectDirectory = yield* ConfectDirectory.get;
 
-  const tryEntry = (relativePath: string, pendingKey: PendingKey) =>
-    Effect.gen(function* () {
-      const absolutePath = path.join(confectDirectory, relativePath);
-      if (!(yield* fs.exists(absolutePath))) {
-        return Option.none<EntryPoint>();
-      }
-      return Option.some<EntryPoint>({
-        absolutePath,
-        displayPath: path.relative(projectRoot, absolutePath),
-        pendingKey,
-      });
+  const tryEntry = Effect.fnUntraced(function* (
+    relativePath: string,
+    pendingKey: PendingKey,
+  ) {
+    const absolutePath = path.join(confectDirectory, relativePath);
+    if (!(yield* fs.exists(absolutePath))) {
+      return Option.none<EntryPoint>();
+    }
+    return Option.some<EntryPoint>({
+      absolutePath,
+      displayPath: path.relative(projectRoot, absolutePath),
+      pendingKey,
     });
+  });
 
   const generatedSpecPath = yield* GENERATED_SPEC_PATH;
 
@@ -604,84 +601,83 @@ const createEntryPointWatcher = (
  * their existing context, so a structural change doesn't churn watchers
  * for unrelated files.
  */
-const entryPointsWatcher = (
+const entryPointsWatcher = Effect.fnUntraced(function* (
   signal: Queue.Queue<void>,
   pendingRef: Ref.Ref<Pending>,
   restartQueue: Queue.Queue<void>,
   watcherErrorsRef: Ref.Ref<WatcherMessages>,
   watcherWarningsRef: Ref.Ref<WatcherMessages>,
-) =>
-  Effect.gen(function* () {
-    const parentScope = yield* Effect.scope;
-    const scopesRef = yield* Ref.make(new Map<string, Scope.Closeable>());
-    const path = yield* Path.Path;
-    const fs = yield* FileSystem.FileSystem;
-    const projectRoot = yield* ProjectRoot.get;
-    // Discover the user's `tsconfig.json#paths` once at watcher startup so
-    // `~/...`-style aliases pointing into the user's source tree get bundled
-    // by esbuild instead of externalized via `bundle-require`'s `node_modules`
-    // heuristic. `loadTsConfig` walks up from `projectRoot` to find a
-    // `tsconfig.json`; if none exists, `paths` is empty and `notExternal` is
-    // `[]`, leaving the externalization rule unchanged.
-    const tsconfig = loadTsConfig(projectRoot);
-    const notExternal = tsconfigPathsToRegExp(
-      tsconfig?.data.compilerOptions?.paths ?? {},
+) {
+  const parentScope = yield* Effect.scope;
+  const scopesRef = yield* Ref.make(new Map<string, Scope.Closeable>());
+  const path = yield* Path.Path;
+  const fs = yield* FileSystem.FileSystem;
+  const projectRoot = yield* ProjectRoot.get;
+  // Discover the user's `tsconfig.json#paths` once at watcher startup so
+  // `~/...`-style aliases pointing into the user's source tree get bundled
+  // by esbuild instead of externalized via `bundle-require`'s `node_modules`
+  // heuristic. `loadTsConfig` walks up from `projectRoot` to find a
+  // `tsconfig.json`; if none exists, `paths` is empty and `notExternal` is
+  // `[]`, leaving the externalization rule unchanged.
+  const tsconfig = loadTsConfig(projectRoot);
+  const notExternal = tsconfigPathsToRegExp(
+    tsconfig?.data.compilerOptions?.paths ?? {},
+  );
+
+  const sync = Effect.gen(function* () {
+    const desired = yield* discoverEntryPoints;
+    const desiredByPath = new Map(
+      desired.map((entryPoint) => [entryPoint.absolutePath, entryPoint]),
+    );
+    const current = yield* Ref.get(scopesRef);
+
+    yield* Effect.forEach(
+      Array.fromIterable(current),
+      ([absolutePath, childScope]) =>
+        desiredByPath.has(absolutePath)
+          ? Effect.void
+          : Scope.close(childScope, Exit.void).pipe(
+              Effect.andThen(
+                Ref.update(scopesRef, (scopes) => {
+                  const updated = new Map(scopes);
+                  updated.delete(absolutePath);
+                  return updated;
+                }),
+              ),
+            ),
     );
 
-    const sync = Effect.gen(function* () {
-      const desired = yield* discoverEntryPoints;
-      const desiredByPath = new Map(
-        desired.map((entryPoint) => [entryPoint.absolutePath, entryPoint]),
-      );
-      const current = yield* Ref.get(scopesRef);
+    yield* Effect.forEach(desired, (entry) =>
+      Effect.gen(function* () {
+        const existing = yield* Ref.get(scopesRef);
+        if (existing.has(entry.absolutePath)) return;
 
-      yield* Effect.forEach(
-        Array.fromIterable(current),
-        ([absolutePath, childScope]) =>
-          desiredByPath.has(absolutePath)
-            ? Effect.void
-            : Scope.close(childScope, Exit.void).pipe(
-                Effect.andThen(
-                  Ref.update(scopesRef, (scopes) => {
-                    const updated = new Map(scopes);
-                    updated.delete(absolutePath);
-                    return updated;
-                  }),
-                ),
-              ),
-      );
-
-      yield* Effect.forEach(desired, (entry) =>
-        Effect.gen(function* () {
-          const existing = yield* Ref.get(scopesRef);
-          if (existing.has(entry.absolutePath)) return;
-
-          const childScope = yield* Scope.fork(parentScope, "sequential");
-          yield* createEntryPointWatcher(
-            path,
-            fs,
-            entry,
-            notExternal,
-            signal,
-            pendingRef,
-            watcherErrorsRef,
-            watcherWarningsRef,
-          ).pipe(Scope.provide(childScope));
-          yield* Ref.update(scopesRef, (scopes) => {
-            const updated = new Map(scopes);
-            updated.set(entry.absolutePath, childScope);
-            return updated;
-          });
-        }),
-      );
-    });
-
-    yield* sync;
-
-    return yield* Effect.forever(
-      Queue.take(restartQueue).pipe(Effect.andThen(sync)),
+        const childScope = yield* Scope.fork(parentScope, "sequential");
+        yield* createEntryPointWatcher(
+          path,
+          fs,
+          entry,
+          notExternal,
+          signal,
+          pendingRef,
+          watcherErrorsRef,
+          watcherWarningsRef,
+        ).pipe(Scope.provide(childScope));
+        yield* Ref.update(scopesRef, (scopes) => {
+          const updated = new Map(scopes);
+          updated.set(entry.absolutePath, childScope);
+          return updated;
+        });
+      }),
     );
   });
+
+  yield* sync;
+
+  return yield* Effect.forever(
+    Queue.take(restartQueue).pipe(Effect.andThen(sync)),
+  );
+});
 
 /**
  * Single recursive `fs.watch` on `confect/`. Flips the matching dirty flag
@@ -690,30 +686,29 @@ const entryPointsWatcher = (
  * `restartQueue` when an entry point is created or removed so the watcher
  * manager picks up the new set.
  */
-const confectStructureWatcher = (
+const confectStructureWatcher = Effect.fnUntraced(function* (
   signal: Queue.Queue<void>,
   pendingRef: Ref.Ref<Pending>,
   restartQueue: Queue.Queue<void>,
-) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
 
-    yield* pipe(
-      fs.watch(confectDirectory),
-      Stream.debounce(Duration.millis(200)),
-      Stream.runForEach((event) =>
-        handleConfectChange({
-          relativePath: path.relative(confectDirectory, event.path),
-          eventTag: event._tag,
-          signal,
-          pendingRef,
-          restartQueue,
-        }),
-      ),
-    );
-  });
+  yield* pipe(
+    fs.watch(confectDirectory),
+    Stream.debounce(Duration.millis(200)),
+    Stream.runForEach((event) =>
+      handleConfectChange({
+        relativePath: path.relative(confectDirectory, event.path),
+        eventTag: event._tag,
+        signal,
+        pendingRef,
+        restartQueue,
+      }),
+    ),
+  );
+});
 
 /**
  * Non-recursive `fs.watch` on the convex directory, reacting only to
@@ -723,32 +718,31 @@ const confectStructureWatcher = (
  * `restartQueue` so the entry-point watcher set picks up (or drops) the
  * config's esbuild watcher.
  */
-const convexConfigStructureWatcher = (
+const convexConfigStructureWatcher = Effect.fnUntraced(function* (
   signal: Queue.Queue<void>,
   pendingRef: Ref.Ref<Pending>,
   restartQueue: Queue.Queue<void>,
-) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const convexDirectory = yield* ConvexDirectory.get;
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const convexDirectory = yield* ConvexDirectory.get;
 
-    yield* pipe(
-      fs.watch(convexDirectory),
-      Stream.debounce(Duration.millis(200)),
-      Stream.runForEach((event) =>
-        path.relative(convexDirectory, event.path) === CONVEX_CONFIG_FILENAME
-          ? flipDirtyAndSignal(
-              pendingRef,
-              signal,
-              "specDirty",
-              restartQueue,
-              event._tag !== "Update",
-            )
-          : Effect.void,
-      ),
-    );
-  });
+  yield* pipe(
+    fs.watch(convexDirectory),
+    Stream.debounce(Duration.millis(200)),
+    Stream.runForEach((event) =>
+      path.relative(convexDirectory, event.path) === CONVEX_CONFIG_FILENAME
+        ? flipDirtyAndSignal(
+            pendingRef,
+            signal,
+            "specDirty",
+            restartQueue,
+            event._tag !== "Update",
+          )
+        : Effect.void,
+    ),
+  );
+});
 
 const TOP_LEVEL_OPTIONAL_KEYS: ReadonlyMap<string, PendingKey> = new Map([
   ["http.ts", "httpDirty"],

--- a/packages/cli/src/confect/dev.ts
+++ b/packages/cli/src/confect/dev.ts
@@ -647,8 +647,9 @@ const entryPointsWatcher = Effect.fnUntraced(function* (
             ),
     );
 
-    yield* Effect.forEach(desired, (entry) =>
-      Effect.gen(function* () {
+    yield* Effect.forEach(
+      desired,
+      Effect.fnUntraced(function* (entry) {
         const existing = yield* Ref.get(scopesRef);
         if (existing.has(entry.absolutePath)) return;
 

--- a/packages/cli/src/confect/dev.ts
+++ b/packages/cli/src/confect/dev.ts
@@ -31,6 +31,7 @@ import { ConfectDirectory } from "../ConfectDirectory";
 import { CONVEX_CONFIG_FILENAME } from "../ConvexConfig";
 import { ConvexDirectory } from "../ConvexDirectory";
 import * as FunctionPaths from "../FunctionPaths";
+import type * as GroupPath from "../GroupPath";
 import type * as GroupPaths from "../GroupPaths";
 import {
   discoverLeafImplFiles,
@@ -153,8 +154,9 @@ const logFunctionPathDiff = Effect.fnUntraced(function* (
 
   yield* logForGroups(groupsRemoved, functionsRemoved, logFunctionRemoved);
   yield* logForGroups(groupsAdded, functionsAdded, logFunctionAdded);
-  yield* Effect.forEach(groupsChanged, (gp) =>
-    Effect.gen(function* () {
+  yield* Effect.forEach(
+    groupsChanged,
+    Effect.fnUntraced(function* (gp: GroupPath.GroupPath) {
       yield* Effect.forEach(
         Array.fromIterable(
           HashSet.filter(functionsAdded, (fp) =>
@@ -649,7 +651,7 @@ const entryPointsWatcher = Effect.fnUntraced(function* (
 
     yield* Effect.forEach(
       desired,
-      Effect.fnUntraced(function* (entry) {
+      Effect.fnUntraced(function* (entry: EntryPoint) {
         const existing = yield* Ref.get(scopesRef);
         if (existing.has(entry.absolutePath)) return;
 

--- a/packages/cli/src/log.ts
+++ b/packages/cli/src/log.ts
@@ -37,8 +37,8 @@ export const formatPath = (relativePath: string): string => {
 
 // --- File operation logs ---
 
-const logFile = (char: string, color: Ansi.Style) => (fullPath: string) =>
-  Effect.gen(function* () {
+const logFile = (char: string, color: Ansi.Style) =>
+  Effect.fnUntraced(function* (fullPath: string) {
     const projectRoot = yield* ProjectRoot.get;
     const path = yield* Path.Path;
 

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -11,29 +11,35 @@ export const functions = ({
   functionNames,
   registeredFunctionsImportPath,
   useNode = false,
+}: Parameters<typeof functionsEffect>[0]) =>
+  functionsEffect({ functionNames, registeredFunctionsImportPath, useNode });
+
+const functionsEffect = Effect.fnUntraced(function* ({
+  functionNames,
+  registeredFunctionsImportPath,
+  useNode = false,
 }: {
   functionNames: string[];
   registeredFunctionsImportPath: string;
   useNode?: boolean;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    if (useNode) {
-      yield* cbw.writeLine(`"use node";`);
-      yield* cbw.blankLine();
-    }
+  if (useNode) {
+    yield* cbw.writeLine(`"use node";`);
+    yield* cbw.blankLine();
+  }
 
-    yield* cbw.writeLine(
-      `import registeredFunctions from "${registeredFunctionsImportPath}";`,
-    );
-    yield* cbw.newLine();
-    yield* Effect.forEach(functionNames, (name) =>
-      cbw.writeLine(`export const ${name} = registeredFunctions.${name};`),
-    );
+  yield* cbw.writeLine(
+    `import registeredFunctions from "${registeredFunctionsImportPath}";`,
+  );
+  yield* cbw.newLine();
+  yield* Effect.forEach(functionNames, (name) =>
+    cbw.writeLine(`export const ${name} = registeredFunctions.${name};`),
+  );
 
-    return yield* cbw.toString();
-  });
+  return yield* cbw.toString();
+});
 
 /**
  * Emit `convex/schema.ts` as a one-line re-export of the codegen-emitted
@@ -44,18 +50,20 @@ export const functions = ({
  */
 export const schema = ({
   convexSchemaImportPath,
+}: Parameters<typeof schemaEffect>[0]) =>
+  schemaEffect({ convexSchemaImportPath });
+
+const schemaEffect = Effect.fnUntraced(function* ({
+  convexSchemaImportPath,
 }: {
   convexSchemaImportPath: string;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    yield* cbw.writeLine(
-      `export { default } from "${convexSchemaImportPath}";`,
-    );
+  yield* cbw.writeLine(`export { default } from "${convexSchemaImportPath}";`);
 
-    return yield* cbw.toString();
-  });
+  return yield* cbw.toString();
+});
 
 interface TableModuleBinding {
   readonly importPath: string;
@@ -84,59 +92,63 @@ interface TableModuleBinding {
  */
 export const runtimeSchema = ({
   tableModules,
+}: Parameters<typeof runtimeSchemaEffect>[0]) =>
+  runtimeSchemaEffect({ tableModules });
+
+const runtimeSchemaEffect = Effect.fnUntraced(function* ({
+  tableModules,
 }: {
   tableModules: ReadonlyArray<TableModuleBinding>;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    yield* cbw.writeLine(
-      `import { DatabaseSchema as $DatabaseSchema } from "@confect/server";`,
+  yield* cbw.writeLine(
+    `import { DatabaseSchema as $DatabaseSchema } from "@confect/server";`,
+  );
+
+  if (tableModules.length > 0) {
+    yield* cbw.blankLine();
+    yield* Effect.forEach(tableModules, ({ tableName, importPath }) =>
+      cbw.writeLine(`import ${tableName} from "${importPath}";`),
     );
+  }
 
-    if (tableModules.length > 0) {
-      yield* cbw.blankLine();
-      yield* Effect.forEach(tableModules, ({ tableName, importPath }) =>
-        cbw.writeLine(`import ${tableName} from "${importPath}";`),
-      );
-    }
+  yield* cbw.blankLine();
 
-    yield* cbw.blankLine();
+  if (tableModules.length === 0) {
+    yield* cbw.writeLine(
+      `const databaseSchema: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});`,
+    );
+  } else {
+    yield* cbw.writeLine(
+      `const databaseSchema: $DatabaseSchema.DatabaseSchema<`,
+    );
+    yield* cbw.indent(
+      Effect.forEach(
+        tableModules,
+        ({ tableName }, i) =>
+          cbw.writeLine(
+            `typeof ${tableName}${i === tableModules.length - 1 ? "" : " |"}`,
+          ),
+        { discard: true },
+      ),
+    );
+    yield* cbw.writeLine(`> = $DatabaseSchema.make({`);
+    yield* cbw.indent(
+      Effect.gen(function* () {
+        for (const { tableName } of tableModules) {
+          yield* cbw.writeLine(`${tableName},`);
+        }
+      }),
+    );
+    yield* cbw.writeLine(`});`);
+  }
 
-    if (tableModules.length === 0) {
-      yield* cbw.writeLine(
-        `const databaseSchema: $DatabaseSchema.DatabaseSchema = $DatabaseSchema.make({});`,
-      );
-    } else {
-      yield* cbw.writeLine(
-        `const databaseSchema: $DatabaseSchema.DatabaseSchema<`,
-      );
-      yield* cbw.indent(
-        Effect.forEach(
-          tableModules,
-          ({ tableName }, i) =>
-            cbw.writeLine(
-              `typeof ${tableName}${i === tableModules.length - 1 ? "" : " |"}`,
-            ),
-          { discard: true },
-        ),
-      );
-      yield* cbw.writeLine(`> = $DatabaseSchema.make({`);
-      yield* cbw.indent(
-        Effect.gen(function* () {
-          for (const { tableName } of tableModules) {
-            yield* cbw.writeLine(`${tableName},`);
-          }
-        }),
-      );
-      yield* cbw.writeLine(`});`);
-    }
+  yield* cbw.blankLine();
+  yield* cbw.writeLine(`export default databaseSchema;`);
 
-    yield* cbw.blankLine();
-    yield* cbw.writeLine(`export default databaseSchema;`);
-
-    return yield* cbw.toString();
-  });
+  return yield* cbw.toString();
+});
 
 /**
  * Emit `confect/_generated/convexSchema.ts` — the Convex deploy-time
@@ -156,46 +168,48 @@ export const runtimeSchema = ({
  */
 export const convexSchema = ({
   tableModules,
+}: Parameters<typeof convexSchemaEffect>[0]) =>
+  convexSchemaEffect({ tableModules });
+
+const convexSchemaEffect = Effect.fnUntraced(function* ({
+  tableModules,
 }: {
   tableModules: ReadonlyArray<TableModuleBinding>;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    yield* cbw.writeLine(
-      `import { defineSchema as $defineSchema } from "convex/server";`,
-    );
+  yield* cbw.writeLine(
+    `import { defineSchema as $defineSchema } from "convex/server";`,
+  );
 
-    if (tableModules.length > 0) {
-      yield* cbw.writeLine(
-        `import { Table as $Table } from "@confect/server";`,
-      );
-      yield* cbw.blankLine();
-      yield* Effect.forEach(tableModules, ({ tableName, importPath }) =>
-        cbw.writeLine(`import ${tableName} from "${importPath}";`),
-      );
-    }
-
+  if (tableModules.length > 0) {
+    yield* cbw.writeLine(`import { Table as $Table } from "@confect/server";`);
     yield* cbw.blankLine();
+    yield* Effect.forEach(tableModules, ({ tableName, importPath }) =>
+      cbw.writeLine(`import ${tableName} from "${importPath}";`),
+    );
+  }
 
-    if (tableModules.length === 0) {
-      yield* cbw.writeLine(`export default $defineSchema({});`);
-    } else {
-      yield* cbw.writeLine(`export default $defineSchema({`);
-      yield* cbw.indent(
-        Effect.gen(function* () {
-          for (const { tableName } of tableModules) {
-            yield* cbw.writeLine(
-              `${tableName}: $Table.tableDefinition(${tableName}),`,
-            );
-          }
-        }),
-      );
-      yield* cbw.writeLine(`});`);
-    }
+  yield* cbw.blankLine();
 
-    return yield* cbw.toString();
-  });
+  if (tableModules.length === 0) {
+    yield* cbw.writeLine(`export default $defineSchema({});`);
+  } else {
+    yield* cbw.writeLine(`export default $defineSchema({`);
+    yield* cbw.indent(
+      Effect.gen(function* () {
+        for (const { tableName } of tableModules) {
+          yield* cbw.writeLine(
+            `${tableName}: $Table.tableDefinition(${tableName}),`,
+          );
+        }
+      }),
+    );
+    yield* cbw.writeLine(`});`);
+  }
+
+  return yield* cbw.toString();
+});
 
 /**
  * Emit `confect/_generated/id.ts` — a type-constrained `Id` constructor and
@@ -207,28 +221,34 @@ export const convexSchema = ({
  * When the table directory is empty the `TableNames` union resolves to
  * `never`, which still lets the file typecheck against an empty workspace.
  */
-export const id = ({ tableNames }: { tableNames: ReadonlyArray<string> }) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+export const id = ({ tableNames }: Parameters<typeof idEffect>[0]) =>
+  idEffect({ tableNames });
 
-    yield* cbw.writeLine(`import { GenericId } from "@confect/core";`);
-    yield* cbw.blankLine();
+const idEffect = Effect.fnUntraced(function* ({
+  tableNames,
+}: {
+  tableNames: ReadonlyArray<string>;
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    const union =
-      tableNames.length === 0
-        ? "never"
-        : tableNames.map((n) => `"${n}"`).join(" | ");
-    yield* cbw.writeLine(`export type TableNames = ${union};`);
-    yield* cbw.blankLine();
+  yield* cbw.writeLine(`import { GenericId } from "@confect/core";`);
+  yield* cbw.blankLine();
 
-    yield* cbw.writeLine(
-      `export const Id = <const TableName extends TableNames>(`,
-    );
-    yield* cbw.indent(cbw.writeLine(`tableName: TableName,`));
-    yield* cbw.writeLine(`) => GenericId.GenericId(tableName);`);
+  const union =
+    tableNames.length === 0
+      ? "never"
+      : tableNames.map((n) => `"${n}"`).join(" | ");
+  yield* cbw.writeLine(`export type TableNames = ${union};`);
+  yield* cbw.blankLine();
 
-    return yield* cbw.toString();
-  });
+  yield* cbw.writeLine(
+    `export const Id = <const TableName extends TableNames>(`,
+  );
+  yield* cbw.indent(cbw.writeLine(`tableName: TableName,`));
+  yield* cbw.writeLine(`) => GenericId.GenericId(tableName);`);
+
+  return yield* cbw.toString();
+});
 
 /**
  * Emit `confect/_generated/tables/<tableName>.ts` — a two-line wrapper that
@@ -239,52 +259,77 @@ export const id = ({ tableNames }: { tableNames: ReadonlyArray<string> }) =>
 export const tableWrapper = ({
   tableName,
   unnamedImportPath,
+}: Parameters<typeof tableWrapperEffect>[0]) =>
+  tableWrapperEffect({ tableName, unnamedImportPath });
+
+const tableWrapperEffect = Effect.fnUntraced(function* ({
+  tableName,
+  unnamedImportPath,
 }: {
   tableName: string;
   unnamedImportPath: string;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    yield* cbw.writeLine(`import unnamed from "${unnamedImportPath}";`);
-    yield* cbw.blankLine();
-    yield* cbw.writeLine(`export default unnamed("${tableName}");`);
+  yield* cbw.writeLine(`import unnamed from "${unnamedImportPath}";`);
+  yield* cbw.blankLine();
+  yield* cbw.writeLine(`export default unnamed("${tableName}");`);
 
-    return yield* cbw.toString();
-  });
+  return yield* cbw.toString();
+});
 
-export const http = ({ httpImportPath }: { httpImportPath: string }) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+export const http = ({ httpImportPath }: Parameters<typeof httpEffect>[0]) =>
+  httpEffect({ httpImportPath });
 
-    yield* cbw.writeLine(`import http from "${httpImportPath}";`);
-    yield* cbw.newLine();
-    yield* cbw.writeLine(`export default http;`);
+const httpEffect = Effect.fnUntraced(function* ({
+  httpImportPath,
+}: {
+  httpImportPath: string;
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    return yield* cbw.toString();
-  });
+  yield* cbw.writeLine(`import http from "${httpImportPath}";`);
+  yield* cbw.newLine();
+  yield* cbw.writeLine(`export default http;`);
 
-export const crons = ({ cronsImportPath }: { cronsImportPath: string }) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+  return yield* cbw.toString();
+});
 
-    yield* cbw.writeLine(`import crons from "${cronsImportPath}";`);
-    yield* cbw.newLine();
-    yield* cbw.writeLine(`export default crons.convexCronJobs;`);
+export const crons = ({ cronsImportPath }: Parameters<typeof cronsEffect>[0]) =>
+  cronsEffect({ cronsImportPath });
 
-    return yield* cbw.toString();
-  });
+const cronsEffect = Effect.fnUntraced(function* ({
+  cronsImportPath,
+}: {
+  cronsImportPath: string;
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-export const authConfig = ({ authImportPath }: { authImportPath: string }) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+  yield* cbw.writeLine(`import crons from "${cronsImportPath}";`);
+  yield* cbw.newLine();
+  yield* cbw.writeLine(`export default crons.convexCronJobs;`);
 
-    yield* cbw.writeLine(`import auth from "${authImportPath}";`);
-    yield* cbw.newLine();
-    yield* cbw.writeLine(`export default auth;`);
+  return yield* cbw.toString();
+});
 
-    return yield* cbw.toString();
-  });
+export const authConfig = ({
+  authImportPath,
+}: Parameters<typeof authConfigEffect>[0]) =>
+  authConfigEffect({ authImportPath });
+
+const authConfigEffect = Effect.fnUntraced(function* ({
+  authImportPath,
+}: {
+  authImportPath: string;
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+
+  yield* cbw.writeLine(`import auth from "${authImportPath}";`);
+  yield* cbw.newLine();
+  yield* cbw.writeLine(`export default auth;`);
+
+  return yield* cbw.toString();
+});
 
 /**
  * Emit `confect/_generated/components.ts` — a typed registry of the Convex
@@ -305,55 +350,65 @@ export const authConfig = ({ authImportPath }: { authImportPath: string }) =>
  */
 export const components = ({
   components: installedComponents,
+}: Parameters<typeof componentsEffect>[0]) =>
+  componentsEffect({ components: installedComponents });
+
+const componentsEffect = Effect.fnUntraced(function* ({
+  components: installedComponents,
 }: {
   components: ReadonlyArray<{ name: string; typeImportPath: string }>;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    yield* cbw.writeLine(`import { componentsGeneric } from "convex/server";`);
-    yield* cbw.blankLine();
+  yield* cbw.writeLine(`import { componentsGeneric } from "convex/server";`);
+  yield* cbw.blankLine();
 
-    if (installedComponents.length === 0) {
-      yield* cbw.writeLine(`export type Components = {};`);
-    } else {
-      yield* cbw.writeLine(`export type Components = {`);
-      yield* cbw.indent(
-        Effect.forEach(
-          installedComponents,
-          ({ name, typeImportPath }) =>
-            cbw.writeLine(
-              `"${name}": import("${typeImportPath}/_generated/component.js").ComponentApi<"${name}">;`,
-            ),
-          { discard: true },
-        ),
-      );
-      yield* cbw.writeLine(`};`);
-    }
-    yield* cbw.blankLine();
-
-    yield* cbw.writeLine(
-      `export const components: Components = componentsGeneric() as any;`,
+  if (installedComponents.length === 0) {
+    yield* cbw.writeLine(`export type Components = {};`);
+  } else {
+    yield* cbw.writeLine(`export type Components = {`);
+    yield* cbw.indent(
+      Effect.forEach(
+        installedComponents,
+        ({ name, typeImportPath }) =>
+          cbw.writeLine(
+            `"${name}": import("${typeImportPath}/_generated/component.js").ComponentApi<"${name}">;`,
+          ),
+        { discard: true },
+      ),
     );
+    yield* cbw.writeLine(`};`);
+  }
+  yield* cbw.blankLine();
 
-    return yield* cbw.toString();
-  });
+  yield* cbw.writeLine(
+    `export const components: Components = componentsGeneric() as any;`,
+  );
 
-export const refs = ({ specImportPath }: { specImportPath: string }) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+  return yield* cbw.toString();
+});
 
-    yield* cbw.writeLine(`import { Refs } from "@confect/core";`);
-    yield* cbw.writeLine(`import spec from "${specImportPath}";`);
-    yield* cbw.blankLine();
-    yield* cbw.writeLine(
-      `const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);`,
-    );
-    yield* cbw.blankLine();
-    yield* cbw.writeLine(`export default refs;`);
+export const refs = ({ specImportPath }: Parameters<typeof refsEffect>[0]) =>
+  refsEffect({ specImportPath });
 
-    return yield* cbw.toString();
-  });
+const refsEffect = Effect.fnUntraced(function* ({
+  specImportPath,
+}: {
+  specImportPath: string;
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+
+  yield* cbw.writeLine(`import { Refs } from "@confect/core";`);
+  yield* cbw.writeLine(`import spec from "${specImportPath}";`);
+  yield* cbw.blankLine();
+  yield* cbw.writeLine(
+    `const refs: Refs.FromSpec<typeof spec> = Refs.make(spec);`,
+  );
+  yield* cbw.blankLine();
+  yield* cbw.writeLine(`export default refs;`);
+
+  return yield* cbw.toString();
+});
 
 /**
  * Emit `_generated/docs.ts`: one named `type <table>` alias per table plus a
@@ -370,47 +425,67 @@ export const refs = ({ specImportPath }: { specImportPath: string }) =>
 export const docs = ({
   schemaImportPath,
   tables,
+}: Parameters<typeof docsEffect>[0]) =>
+  docsEffect({ schemaImportPath, tables });
+
+const docsEffect = Effect.fnUntraced(function* ({
+  schemaImportPath,
+  tables,
 }: {
   schemaImportPath: string;
   tables: ReadonlyArray<{ tableName: string; docName: string }>;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    // With no tables there is nothing to import — emitting the (unused) imports
-    // would trip `noUnusedLocals`.
-    if (tables.length === 0) {
-      yield* cbw.writeLine(`export interface Docs {}`);
-      return yield* cbw.toString();
-    }
-
-    yield* cbw.writeLine(`import type { Document } from "@confect/server";`);
-    yield* cbw.writeLine(
-      `import type schemaDefinition from "${schemaImportPath}";`,
-    );
-    yield* cbw.blankLine();
-
-    for (const { tableName, docName } of tables) {
-      yield* cbw.writeLine(
-        `export type ${docName} = Document.Document<typeof schemaDefinition, "${tableName}">;`,
-      );
-    }
-    yield* cbw.blankLine();
-
-    yield* cbw.writeLine(`export interface Docs {`);
-    yield* cbw.indent(
-      Effect.gen(function* () {
-        for (const { tableName, docName } of tables) {
-          yield* cbw.writeLine(`${tableName}: ${docName};`);
-        }
-      }),
-    );
-    yield* cbw.writeLine(`}`);
-
+  // With no tables there is nothing to import — emitting the (unused) imports
+  // would trip `noUnusedLocals`.
+  if (tables.length === 0) {
+    yield* cbw.writeLine(`export interface Docs {}`);
     return yield* cbw.toString();
-  });
+  }
+
+  yield* cbw.writeLine(`import type { Document } from "@confect/server";`);
+  yield* cbw.writeLine(
+    `import type schemaDefinition from "${schemaImportPath}";`,
+  );
+  yield* cbw.blankLine();
+
+  for (const { tableName, docName } of tables) {
+    yield* cbw.writeLine(
+      `export type ${docName} = Document.Document<typeof schemaDefinition, "${tableName}">;`,
+    );
+  }
+  yield* cbw.blankLine();
+
+  yield* cbw.writeLine(`export interface Docs {`);
+  yield* cbw.indent(
+    Effect.gen(function* () {
+      for (const { tableName, docName } of tables) {
+        yield* cbw.writeLine(`${tableName}: ${docName};`);
+      }
+    }),
+  );
+  yield* cbw.writeLine(`}`);
+
+  return yield* cbw.toString();
+});
 
 export const registeredFunctionsForGroup = ({
+  schemaImportPath,
+  specImportPath,
+  implImportPath,
+  layerExportName,
+  useNode = false,
+}: Parameters<typeof registeredFunctionsForGroupEffect>[0]) =>
+  registeredFunctionsForGroupEffect({
+    schemaImportPath,
+    specImportPath,
+    implImportPath,
+    layerExportName,
+    useNode,
+  });
+
+const registeredFunctionsForGroupEffect = Effect.fnUntraced(function* ({
   schemaImportPath,
   specImportPath,
   implImportPath,
@@ -422,278 +497,277 @@ export const registeredFunctionsForGroup = ({
   implImportPath: string;
   layerExportName: string;
   useNode?: boolean;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    if (useNode) {
-      yield* cbw.writeLine(
-        `import { RegisteredFunctions } from "@confect/server";`,
-      );
-      yield* cbw.writeLine(
-        `import { RegisteredNodeFunction } from "@confect/server/node";`,
-      );
-    } else {
-      yield* cbw.writeLine(
-        `import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";`,
-      );
-    }
+  if (useNode) {
+    yield* cbw.writeLine(
+      `import { RegisteredFunctions } from "@confect/server";`,
+    );
+    yield* cbw.writeLine(
+      `import { RegisteredNodeFunction } from "@confect/server/node";`,
+    );
+  } else {
+    yield* cbw.writeLine(
+      `import { RegisteredConvexFunction, RegisteredFunctions } from "@confect/server";`,
+    );
+  }
 
-    yield* cbw.writeLine(`import databaseSchema from "${schemaImportPath}";`);
-    yield* cbw.writeLine(`import ${layerExportName} from "${implImportPath}";`);
-    yield* cbw.blankLine();
-    // The group's own leaf spec is referenced type-only (`typeof import(...)`),
-    // so the spec module is erased at transpile time and never enters the
-    // per-function bundle; only `databaseSchema` and the impl are runtime
-    // imports. Typing from the leaf spec (not the project-wide assembled spec)
-    // keeps the registry's type dependent solely on its own group.
-    const specType = `typeof import("${specImportPath}")["default"]`;
-    const makeFn = useNode
-      ? "RegisteredNodeFunction.make"
-      : "RegisteredConvexFunction.make";
-    yield* cbw.writeLine(
-      `export default RegisteredFunctions.buildForGroup<${specType}>(databaseSchema, ${layerExportName}, ${makeFn});`,
-    );
+  yield* cbw.writeLine(`import databaseSchema from "${schemaImportPath}";`);
+  yield* cbw.writeLine(`import ${layerExportName} from "${implImportPath}";`);
+  yield* cbw.blankLine();
+  // The group's own leaf spec is referenced type-only (`typeof import(...)`),
+  // so the spec module is erased at transpile time and never enters the
+  // per-function bundle; only `databaseSchema` and the impl are runtime
+  // imports. Typing from the leaf spec (not the project-wide assembled spec)
+  // keeps the registry's type dependent solely on its own group.
+  const specType = `typeof import("${specImportPath}")["default"]`;
+  const makeFn = useNode
+    ? "RegisteredNodeFunction.make"
+    : "RegisteredConvexFunction.make";
+  yield* cbw.writeLine(
+    `export default RegisteredFunctions.buildForGroup<${specType}>(databaseSchema, ${layerExportName}, ${makeFn});`,
+  );
 
-    return yield* cbw.toString();
-  });
+  return yield* cbw.toString();
+});
 
-export const services = ({ schemaImportPath }: { schemaImportPath: string }) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+export const services = ({
+  schemaImportPath,
+}: Parameters<typeof servicesEffect>[0]) =>
+  servicesEffect({ schemaImportPath });
 
-    // Imports
-    yield* cbw.writeLine("import {");
-    yield* cbw.indent(
-      Effect.gen(function* () {
-        yield* cbw.writeLine("ActionCtx as ActionCtx_,");
-        yield* cbw.writeLine("ActionRunner as ActionRunner_,");
-        yield* cbw.writeLine("Auth as Auth_,");
-        yield* cbw.writeLine("type DataModel,");
-        yield* cbw.writeLine("DatabaseReader as DatabaseReader_,");
-        yield* cbw.writeLine("DatabaseWriter as DatabaseWriter_,");
-        yield* cbw.writeLine("MutationCtx as MutationCtx_,");
-        yield* cbw.writeLine("MutationRunner as MutationRunner_,");
-        yield* cbw.writeLine("QueryCtx as QueryCtx_,");
-        yield* cbw.writeLine("QueryRunner as QueryRunner_,");
-        yield* cbw.writeLine("Scheduler as Scheduler_,");
-        yield* cbw.writeLine("StorageActionWriter as StorageActionWriter_,");
-        yield* cbw.writeLine("StorageReader as StorageReader_,");
-        yield* cbw.writeLine("StorageWriter as StorageWriter_,");
-        yield* cbw.writeLine("VectorSearch as VectorSearch_,");
-      }),
-    );
-    yield* cbw.writeLine(`} from "@confect/server";`);
-    yield* cbw.writeLine(
-      `import type schemaDefinition from "${schemaImportPath}";`,
-    );
-    yield* cbw.writeLine(`import type { Docs } from "./docs";`);
-    yield* cbw.blankLine();
+const servicesEffect = Effect.fnUntraced(function* ({
+  schemaImportPath,
+}: {
+  schemaImportPath: string;
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    // Auth
-    yield* cbw.writeLine("export const Auth = Auth_.Auth;");
-    yield* cbw.writeLine("export type Auth = typeof Auth.Identifier;");
-    yield* cbw.blankLine();
+  // Imports
+  yield* cbw.writeLine("import {");
+  yield* cbw.indent(
+    Effect.gen(function* () {
+      yield* cbw.writeLine("ActionCtx as ActionCtx_,");
+      yield* cbw.writeLine("ActionRunner as ActionRunner_,");
+      yield* cbw.writeLine("Auth as Auth_,");
+      yield* cbw.writeLine("type DataModel,");
+      yield* cbw.writeLine("DatabaseReader as DatabaseReader_,");
+      yield* cbw.writeLine("DatabaseWriter as DatabaseWriter_,");
+      yield* cbw.writeLine("MutationCtx as MutationCtx_,");
+      yield* cbw.writeLine("MutationRunner as MutationRunner_,");
+      yield* cbw.writeLine("QueryCtx as QueryCtx_,");
+      yield* cbw.writeLine("QueryRunner as QueryRunner_,");
+      yield* cbw.writeLine("Scheduler as Scheduler_,");
+      yield* cbw.writeLine("StorageActionWriter as StorageActionWriter_,");
+      yield* cbw.writeLine("StorageReader as StorageReader_,");
+      yield* cbw.writeLine("StorageWriter as StorageWriter_,");
+      yield* cbw.writeLine("VectorSearch as VectorSearch_,");
+    }),
+  );
+  yield* cbw.writeLine(`} from "@confect/server";`);
+  yield* cbw.writeLine(
+    `import type schemaDefinition from "${schemaImportPath}";`,
+  );
+  yield* cbw.writeLine(`import type { Docs } from "./docs";`);
+  yield* cbw.blankLine();
 
-    // Scheduler
-    yield* cbw.writeLine("export const Scheduler = Scheduler_.Scheduler;");
-    yield* cbw.writeLine(
-      "export type Scheduler = typeof Scheduler.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // Auth
+  yield* cbw.writeLine("export const Auth = Auth_.Auth;");
+  yield* cbw.writeLine("export type Auth = typeof Auth.Identifier;");
+  yield* cbw.blankLine();
 
-    // StorageReader
-    yield* cbw.writeLine(
-      "export const StorageReader = StorageReader_.StorageReader;",
-    );
-    yield* cbw.writeLine(
-      "export type StorageReader = typeof StorageReader.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // Scheduler
+  yield* cbw.writeLine("export const Scheduler = Scheduler_.Scheduler;");
+  yield* cbw.writeLine("export type Scheduler = typeof Scheduler.Identifier;");
+  yield* cbw.blankLine();
 
-    // StorageWriter
-    yield* cbw.writeLine(
-      "export const StorageWriter = StorageWriter_.StorageWriter;",
-    );
-    yield* cbw.writeLine(
-      "export type StorageWriter = typeof StorageWriter.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // StorageReader
+  yield* cbw.writeLine(
+    "export const StorageReader = StorageReader_.StorageReader;",
+  );
+  yield* cbw.writeLine(
+    "export type StorageReader = typeof StorageReader.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // StorageActionWriter
-    yield* cbw.writeLine(
-      "export const StorageActionWriter = StorageActionWriter_.StorageActionWriter;",
-    );
-    yield* cbw.writeLine(
-      "export type StorageActionWriter = typeof StorageActionWriter.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // StorageWriter
+  yield* cbw.writeLine(
+    "export const StorageWriter = StorageWriter_.StorageWriter;",
+  );
+  yield* cbw.writeLine(
+    "export type StorageWriter = typeof StorageWriter.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // VectorSearch
-    yield* cbw.writeLine(
-      "export const VectorSearch: VectorSearch_.VectorSearchTag<",
-    );
-    yield* cbw.indent(
-      cbw.writeLine("DataModel.FromSchema<typeof schemaDefinition>"),
-    );
-    yield* cbw.writeLine(
-      "> = VectorSearch_.VectorSearch<DataModel.FromSchema<typeof schemaDefinition>>();",
-    );
-    yield* cbw.writeLine(
-      "export type VectorSearch = typeof VectorSearch.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // StorageActionWriter
+  yield* cbw.writeLine(
+    "export const StorageActionWriter = StorageActionWriter_.StorageActionWriter;",
+  );
+  yield* cbw.writeLine(
+    "export type StorageActionWriter = typeof StorageActionWriter.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // DatabaseReader
-    yield* cbw.writeLine(
-      "export const DatabaseReader: DatabaseReader_.DatabaseReaderTag<",
-    );
-    yield* cbw.indent(
-      Effect.gen(function* () {
-        yield* cbw.writeLine("typeof schemaDefinition,");
-        yield* cbw.writeLine("Docs");
-      }),
-    );
-    yield* cbw.writeLine(
-      "> = DatabaseReader_.DatabaseReader<typeof schemaDefinition, Docs>();",
-    );
-    yield* cbw.writeLine(
-      "export type DatabaseReader = typeof DatabaseReader.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // VectorSearch
+  yield* cbw.writeLine(
+    "export const VectorSearch: VectorSearch_.VectorSearchTag<",
+  );
+  yield* cbw.indent(
+    cbw.writeLine("DataModel.FromSchema<typeof schemaDefinition>"),
+  );
+  yield* cbw.writeLine(
+    "> = VectorSearch_.VectorSearch<DataModel.FromSchema<typeof schemaDefinition>>();",
+  );
+  yield* cbw.writeLine(
+    "export type VectorSearch = typeof VectorSearch.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // DatabaseWriter
-    yield* cbw.writeLine(
-      "export const DatabaseWriter: DatabaseWriter_.DatabaseWriterTag<",
-    );
-    yield* cbw.indent(
-      Effect.gen(function* () {
-        yield* cbw.writeLine("typeof schemaDefinition,");
-        yield* cbw.writeLine("Docs");
-      }),
-    );
-    yield* cbw.writeLine(
-      "> = DatabaseWriter_.DatabaseWriter<typeof schemaDefinition, Docs>();",
-    );
-    yield* cbw.writeLine(
-      "export type DatabaseWriter = typeof DatabaseWriter.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // DatabaseReader
+  yield* cbw.writeLine(
+    "export const DatabaseReader: DatabaseReader_.DatabaseReaderTag<",
+  );
+  yield* cbw.indent(
+    Effect.gen(function* () {
+      yield* cbw.writeLine("typeof schemaDefinition,");
+      yield* cbw.writeLine("Docs");
+    }),
+  );
+  yield* cbw.writeLine(
+    "> = DatabaseReader_.DatabaseReader<typeof schemaDefinition, Docs>();",
+  );
+  yield* cbw.writeLine(
+    "export type DatabaseReader = typeof DatabaseReader.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // QueryRunner
-    yield* cbw.writeLine(
-      "export const QueryRunner = QueryRunner_.QueryRunner;",
-    );
-    yield* cbw.writeLine(
-      "export type QueryRunner = typeof QueryRunner.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // DatabaseWriter
+  yield* cbw.writeLine(
+    "export const DatabaseWriter: DatabaseWriter_.DatabaseWriterTag<",
+  );
+  yield* cbw.indent(
+    Effect.gen(function* () {
+      yield* cbw.writeLine("typeof schemaDefinition,");
+      yield* cbw.writeLine("Docs");
+    }),
+  );
+  yield* cbw.writeLine(
+    "> = DatabaseWriter_.DatabaseWriter<typeof schemaDefinition, Docs>();",
+  );
+  yield* cbw.writeLine(
+    "export type DatabaseWriter = typeof DatabaseWriter.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // MutationRunner
-    yield* cbw.writeLine(
-      "export const MutationRunner = MutationRunner_.MutationRunner;",
-    );
-    yield* cbw.writeLine(
-      "export type MutationRunner = typeof MutationRunner.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // QueryRunner
+  yield* cbw.writeLine("export const QueryRunner = QueryRunner_.QueryRunner;");
+  yield* cbw.writeLine(
+    "export type QueryRunner = typeof QueryRunner.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // ActionRunner
-    yield* cbw.writeLine(
-      "export const ActionRunner = ActionRunner_.ActionRunner;",
-    );
-    yield* cbw.writeLine(
-      "export type ActionRunner = typeof ActionRunner.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // MutationRunner
+  yield* cbw.writeLine(
+    "export const MutationRunner = MutationRunner_.MutationRunner;",
+  );
+  yield* cbw.writeLine(
+    "export type MutationRunner = typeof MutationRunner.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // QueryCtx
-    yield* cbw.writeLine("export const QueryCtx: QueryCtx_.QueryCtxTag<");
-    yield* cbw.indent(
-      cbw.writeLine(
-        "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
-      ),
-    );
-    yield* cbw.writeLine("> = QueryCtx_.QueryCtx<");
-    yield* cbw.indent(
-      cbw.writeLine(
-        "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
-      ),
-    );
-    yield* cbw.writeLine(">();");
-    yield* cbw.writeLine("export type QueryCtx = typeof QueryCtx.Identifier;");
-    yield* cbw.blankLine();
+  // ActionRunner
+  yield* cbw.writeLine(
+    "export const ActionRunner = ActionRunner_.ActionRunner;",
+  );
+  yield* cbw.writeLine(
+    "export type ActionRunner = typeof ActionRunner.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    // MutationCtx
-    yield* cbw.writeLine(
-      "export const MutationCtx: MutationCtx_.MutationCtxTag<",
-    );
-    yield* cbw.indent(
-      cbw.writeLine(
-        "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
-      ),
-    );
-    yield* cbw.writeLine("> = MutationCtx_.MutationCtx<");
-    yield* cbw.indent(
-      cbw.writeLine(
-        "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
-      ),
-    );
-    yield* cbw.writeLine(">();");
-    yield* cbw.writeLine(
-      "export type MutationCtx = typeof MutationCtx.Identifier;",
-    );
-    yield* cbw.blankLine();
+  // QueryCtx
+  yield* cbw.writeLine("export const QueryCtx: QueryCtx_.QueryCtxTag<");
+  yield* cbw.indent(
+    cbw.writeLine(
+      "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
+    ),
+  );
+  yield* cbw.writeLine("> = QueryCtx_.QueryCtx<");
+  yield* cbw.indent(
+    cbw.writeLine(
+      "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
+    ),
+  );
+  yield* cbw.writeLine(">();");
+  yield* cbw.writeLine("export type QueryCtx = typeof QueryCtx.Identifier;");
+  yield* cbw.blankLine();
 
-    // ActionCtx
-    yield* cbw.writeLine("export const ActionCtx: ActionCtx_.ActionCtxTag<");
-    yield* cbw.indent(
-      cbw.writeLine(
-        "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
-      ),
-    );
-    yield* cbw.writeLine("> = ActionCtx_.ActionCtx<");
-    yield* cbw.indent(
-      cbw.writeLine(
-        "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
-      ),
-    );
-    yield* cbw.writeLine(">();");
-    yield* cbw.writeLine(
-      "export type ActionCtx = typeof ActionCtx.Identifier;",
-    );
+  // MutationCtx
+  yield* cbw.writeLine(
+    "export const MutationCtx: MutationCtx_.MutationCtxTag<",
+  );
+  yield* cbw.indent(
+    cbw.writeLine(
+      "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
+    ),
+  );
+  yield* cbw.writeLine("> = MutationCtx_.MutationCtx<");
+  yield* cbw.indent(
+    cbw.writeLine(
+      "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
+    ),
+  );
+  yield* cbw.writeLine(">();");
+  yield* cbw.writeLine(
+    "export type MutationCtx = typeof MutationCtx.Identifier;",
+  );
+  yield* cbw.blankLine();
 
-    return yield* cbw.toString();
-  });
+  // ActionCtx
+  yield* cbw.writeLine("export const ActionCtx: ActionCtx_.ActionCtxTag<");
+  yield* cbw.indent(
+    cbw.writeLine(
+      "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
+    ),
+  );
+  yield* cbw.writeLine("> = ActionCtx_.ActionCtx<");
+  yield* cbw.indent(
+    cbw.writeLine(
+      "DataModel.ToConvex<DataModel.FromSchema<typeof schemaDefinition>>",
+    ),
+  );
+  yield* cbw.writeLine(">();");
+  yield* cbw.writeLine("export type ActionCtx = typeof ActionCtx.Identifier;");
 
-const writeChildAddGroupAt = (
+  return yield* cbw.toString();
+});
+
+const writeChildAddGroupAt = Effect.fnUntraced(function* (
   cbw: CodeBlockWriter,
   child: SpecAssemblyNode,
   groupFactory: string,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    yield* cbw.write(".addGroupAt(");
-    yield* cbw.quote(child.segment);
-    yield* cbw.write(", ");
-    yield* writeGroupAssembly(cbw, child, groupFactory);
-    yield* cbw.write(")");
-  });
+): Effect.fn.Return<void> {
+  yield* cbw.write(".addGroupAt(");
+  yield* cbw.quote(child.segment);
+  yield* cbw.write(", ");
+  yield* writeGroupAssembly(cbw, child, groupFactory);
+  yield* cbw.write(")");
+});
 
-const writeGroupFactoryCall = (
+const writeGroupFactoryCall = Effect.fnUntraced(function* (
   cbw: CodeBlockWriter,
   node: SpecAssemblyNode,
   groupFactory: string,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    yield* cbw.write(groupFactory);
-    yield* cbw.write("(");
-    yield* cbw.quote(node.segment);
-    yield* cbw.write(")");
+): Effect.fn.Return<void> {
+  yield* cbw.write(groupFactory);
+  yield* cbw.write("(");
+  yield* cbw.quote(node.segment);
+  yield* cbw.write(")");
 
-    yield* Effect.forEach(node.children, (child) =>
-      writeChildAddGroupAt(cbw, child, groupFactory),
-    );
-  });
+  yield* Effect.forEach(node.children, (child) =>
+    writeChildAddGroupAt(cbw, child, groupFactory),
+  );
+});
 
 const writeGroupAssembly: (
   cbw: CodeBlockWriter,
@@ -711,20 +785,19 @@ const writeGroupAssembly: (
       }),
   });
 
-const writeRootAddAt = (
+const writeRootAddAt = Effect.fnUntraced(function* (
   cbw: CodeBlockWriter,
   node: SpecAssemblyNode,
   groupFactory: string,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    yield* cbw.write(".addAt(");
-    yield* cbw.quote(node.segment);
-    yield* cbw.write(", ");
+): Effect.fn.Return<void> {
+  yield* cbw.write(".addAt(");
+  yield* cbw.quote(node.segment);
+  yield* cbw.write(", ");
 
-    yield* writeGroupAssembly(cbw, node, groupFactory);
+  yield* writeGroupAssembly(cbw, node, groupFactory);
 
-    yield* cbw.write(")");
-  });
+  yield* cbw.write(")");
+});
 
 const groupTypeExpr = (node: SpecAssemblyNode): string => {
   const childUnion = Array.map(
@@ -747,53 +820,54 @@ const rootGroupTypeMember = (node: SpecAssemblyNode): string =>
 
 export const assembledSpec = ({
   nodes,
+}: Parameters<typeof assembledSpecEffect>[0]) => assembledSpecEffect({ nodes });
+
+const assembledSpecEffect = Effect.fnUntraced(function* ({
+  nodes,
 }: {
   nodes: ReadonlyArray<SpecAssemblyNode>;
-}) =>
-  Effect.gen(function* () {
-    const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+}) {
+  const cbw = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
 
-    yield* cbw.writeLine(
-      nodes.length > 0
-        ? `import { GroupSpec, Spec } from "@confect/core";`
-        : `import { Spec } from "@confect/core";`,
-    );
+  yield* cbw.writeLine(
+    nodes.length > 0
+      ? `import { GroupSpec, Spec } from "@confect/core";`
+      : `import { Spec } from "@confect/core";`,
+  );
 
-    yield* Effect.forEach(collectImportBindings(nodes), (binding) =>
-      cbw.writeLine(
-        `import ${binding.localName} from "${binding.importPath}";`,
-      ),
-    );
+  yield* Effect.forEach(collectImportBindings(nodes), (binding) =>
+    cbw.writeLine(`import ${binding.localName} from "${binding.importPath}";`),
+  );
 
-    yield* cbw.blankLine();
+  yield* cbw.blankLine();
 
-    yield* cbw.write(`const spec: `);
-    if (nodes.length === 0) {
-      yield* cbw.write(`Spec.Spec`);
-    } else {
-      yield* cbw.write(`Spec.Spec<`);
-      yield* cbw.newLine();
-      yield* cbw.indent(
-        Effect.gen(function* () {
-          for (const node of nodes) {
-            yield* cbw.writeLine(`| ${rootGroupTypeMember(node)}`);
-          }
-        }),
-      );
-      yield* cbw.write(`>`);
-    }
-    // The assembled spec is runtime-agnostic: a Node group's `makeNode()` is
-    // already baked into its imported leaf spec, so the root is always
-    // `Spec.make()` and binding-less container groups always use
-    // `GroupSpec.makeAt` (containers register no functions and carry no runtime).
-    yield* cbw.write(` = Spec.make()`);
-    yield* Effect.forEach(nodes, (node) =>
-      writeRootAddAt(cbw, node, "GroupSpec.makeAt"),
-    );
-    yield* cbw.write(";");
+  yield* cbw.write(`const spec: `);
+  if (nodes.length === 0) {
+    yield* cbw.write(`Spec.Spec`);
+  } else {
+    yield* cbw.write(`Spec.Spec<`);
     yield* cbw.newLine();
-    yield* cbw.blankLine();
-    yield* cbw.writeLine(`export default spec;`);
+    yield* cbw.indent(
+      Effect.gen(function* () {
+        for (const node of nodes) {
+          yield* cbw.writeLine(`| ${rootGroupTypeMember(node)}`);
+        }
+      }),
+    );
+    yield* cbw.write(`>`);
+  }
+  // The assembled spec is runtime-agnostic: a Node group's `makeNode()` is
+  // already baked into its imported leaf spec, so the root is always
+  // `Spec.make()` and binding-less container groups always use
+  // `GroupSpec.makeAt` (containers register no functions and carry no runtime).
+  yield* cbw.write(` = Spec.make()`);
+  yield* Effect.forEach(nodes, (node) =>
+    writeRootAddAt(cbw, node, "GroupSpec.makeAt"),
+  );
+  yield* cbw.write(";");
+  yield* cbw.newLine();
+  yield* cbw.blankLine();
+  yield* cbw.writeLine(`export default spec;`);
 
-    return yield* cbw.toString();
-  });
+  return yield* cbw.toString();
+});

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -39,43 +39,47 @@ const markWritten = Effect.gen(function* () {
   yield* Ref.set(tracker, true);
 });
 
-export const removePathExtension = (pathStr: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
+export const removePathExtension = Effect.fnUntraced(function* (
+  pathStr: string,
+) {
+  const path = yield* Path.Path;
 
-    return String.slice(0, -path.extname(pathStr).length)(pathStr);
-  });
+  return String.slice(0, -path.extname(pathStr).length)(pathStr);
+});
 
 export const toPosixPath = (path: Path.Path, pathStr: string): string =>
   pipe(String.split(pathStr, path.sep), Array.join("/"));
 
 /** Ensures a relative path is a valid ESM/TS module specifier (e.g. `spec` → `./spec`). */
-export const toModuleImportPath = (relativePath: string) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const withoutExt = toPosixPath(
-      path,
-      yield* removePathExtension(relativePath),
-    );
-    return String.startsWith(".")(withoutExt) ? withoutExt : `./${withoutExt}`;
-  });
+export const toModuleImportPath = Effect.fnUntraced(function* (
+  relativePath: string,
+) {
+  const path = yield* Path.Path;
+  const withoutExt = toPosixPath(
+    path,
+    yield* removePathExtension(relativePath),
+  );
+  return String.startsWith(".")(withoutExt) ? withoutExt : `./${withoutExt}`;
+});
 
-export const writeFileStringAndLog = (filePath: string, contents: string) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    if (!(yield* fs.exists(filePath))) {
-      yield* fs.writeFileString(filePath, contents);
-      yield* markWritten;
-      yield* logFileAdded(filePath);
-      return;
-    }
-    const existing = yield* fs.readFileString(filePath);
-    if (existing !== contents) {
-      yield* fs.writeFileString(filePath, contents);
-      yield* markWritten;
-      yield* logFileModified(filePath);
-    }
-  });
+export const writeFileStringAndLog = Effect.fnUntraced(function* (
+  filePath: string,
+  contents: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  if (!(yield* fs.exists(filePath))) {
+    yield* fs.writeFileString(filePath, contents);
+    yield* markWritten;
+    yield* logFileAdded(filePath);
+    return;
+  }
+  const existing = yield* fs.readFileString(filePath);
+  if (existing !== contents) {
+    yield* fs.writeFileString(filePath, contents);
+    yield* markWritten;
+    yield* logFileModified(filePath);
+  }
+});
 
 export const findProjectRoot = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -99,45 +103,43 @@ export const findProjectRoot = Effect.gen(function* () {
 
 export type WriteChange = "Added" | "Modified" | "Unchanged";
 
-export const writeFileString = (
+export const writeFileString = Effect.fnUntraced(function* (
   filePath: string,
   contents: string,
-): Effect.Effect<WriteChange, PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
+): Effect.fn.Return<WriteChange, PlatformError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
 
-    if (!(yield* fs.exists(filePath))) {
-      yield* fs.writeFileString(filePath, contents);
-      yield* markWritten;
-      return "Added";
-    }
-    const existing = yield* fs.readFileString(filePath);
-    if (existing !== contents) {
-      yield* fs.writeFileString(filePath, contents);
-      yield* markWritten;
-      return "Modified";
-    }
-    return "Unchanged";
-  });
+  if (!(yield* fs.exists(filePath))) {
+    yield* fs.writeFileString(filePath, contents);
+    yield* markWritten;
+    return "Added";
+  }
+  const existing = yield* fs.readFileString(filePath);
+  if (existing !== contents) {
+    yield* fs.writeFileString(filePath, contents);
+    yield* markWritten;
+    return "Modified";
+  }
+  return "Unchanged";
+});
 
-export const removePathIfExists = (
+export const removePathIfExists = Effect.fnUntraced(function* (
   filePath: string,
-): Effect.Effect<void, PlatformError, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
+): Effect.fn.Return<void, PlatformError, FileSystem.FileSystem> {
+  const fs = yield* FileSystem.FileSystem;
 
-    if (!(yield* fs.exists(filePath))) {
-      return;
-    }
+  if (!(yield* fs.exists(filePath))) {
+    return;
+  }
 
-    yield* fs
-      .remove(filePath)
-      .pipe(
-        Effect.catchTag("PlatformError", (error) =>
-          error.reason._tag === "NotFound" ? Effect.void : Effect.fail(error),
-        ),
-      );
-  });
+  yield* fs
+    .remove(filePath)
+    .pipe(
+      Effect.catchTag("PlatformError", (error) =>
+        error.reason._tag === "NotFound" ? Effect.void : Effect.fail(error),
+      ),
+    );
+});
 
 /**
  * Bump the mtime of `convex/schema.ts` so the Convex CLI's chokidar watcher
@@ -165,44 +167,56 @@ export const generateGroupModule = ({
   functionNames,
   registeredFunctionsImportPath,
   useNode = false,
+}: Parameters<typeof generateGroupModuleEffect>[0]) =>
+  generateGroupModuleEffect({
+    groupPath,
+    functionNames,
+    registeredFunctionsImportPath,
+    useNode,
+  });
+
+const generateGroupModuleEffect = Effect.fnUntraced(function* ({
+  groupPath,
+  functionNames,
+  registeredFunctionsImportPath,
+  useNode = false,
 }: {
   groupPath: GroupPath.GroupPath;
   functionNames: string[];
   registeredFunctionsImportPath: string;
   useNode?: boolean;
-}) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const convexDirectory = yield* ConvexDirectory.get;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const convexDirectory = yield* ConvexDirectory.get;
 
-    const relativeModulePath = yield* GroupPath.modulePath(groupPath);
-    const modulePath = path.join(convexDirectory, relativeModulePath);
+  const relativeModulePath = yield* GroupPath.modulePath(groupPath);
+  const modulePath = path.join(convexDirectory, relativeModulePath);
 
-    const directoryPath = path.dirname(modulePath);
-    if (!(yield* fs.exists(directoryPath))) {
-      yield* fs.makeDirectory(directoryPath, { recursive: true });
-    }
+  const directoryPath = path.dirname(modulePath);
+  if (!(yield* fs.exists(directoryPath))) {
+    yield* fs.makeDirectory(directoryPath, { recursive: true });
+  }
 
-    const functionsContentsString = yield* templates.functions({
-      functionNames,
-      registeredFunctionsImportPath,
-      useNode,
-    });
-
-    if (!(yield* fs.exists(modulePath))) {
-      yield* fs.writeFileString(modulePath, functionsContentsString);
-      yield* markWritten;
-      return "Added" as const;
-    }
-    const existing = yield* fs.readFileString(modulePath);
-    if (existing !== functionsContentsString) {
-      yield* fs.writeFileString(modulePath, functionsContentsString);
-      yield* markWritten;
-      return "Modified" as const;
-    }
-    return "Unchanged" as const;
+  const functionsContentsString = yield* templates.functions({
+    functionNames,
+    registeredFunctionsImportPath,
+    useNode,
   });
+
+  if (!(yield* fs.exists(modulePath))) {
+    yield* fs.writeFileString(modulePath, functionsContentsString);
+    yield* markWritten;
+    return "Added" as const;
+  }
+  const existing = yield* fs.readFileString(modulePath);
+  if (existing !== functionsContentsString) {
+    yield* fs.writeFileString(modulePath, functionsContentsString);
+    yield* markWritten;
+    return "Modified" as const;
+  }
+  return "Unchanged" as const;
+});
 
 /**
  * Compute the module import specifier (relative to `modulePath`) for a group's
@@ -212,101 +226,100 @@ export const generateGroupModule = ({
  * keeps the "overlapping" and "new" group branches of `generateFunctions` from
  * drifting apart.
  */
-const registeredFunctionsImportPathForGroup = (
+const registeredFunctionsImportPathForGroup = Effect.fnUntraced(function* (
   groupPath: GroupPath.GroupPath,
   modulePath: string,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
+) {
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
 
-    const registeredFunctionsPath =
-      path.join(
-        confectDirectory,
-        "_generated",
-        "registeredFunctions",
-        ...groupPath.pathSegments,
-      ) + ".ts";
+  const registeredFunctionsPath =
+    path.join(
+      confectDirectory,
+      "_generated",
+      "registeredFunctions",
+      ...groupPath.pathSegments,
+    ) + ".ts";
 
-    return yield* toModuleImportPath(
-      path.relative(path.dirname(modulePath), registeredFunctionsPath),
-    );
-  });
+  return yield* toModuleImportPath(
+    path.relative(path.dirname(modulePath), registeredFunctionsPath),
+  );
+});
 
-const logGroupPaths = <R>(
+const logGroupPaths = Effect.fnUntraced(function* <R>(
   groupPaths: GroupPaths.GroupPaths,
   logFn: (fullPath: string) => Effect.Effect<void, never, R>,
-) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const convexDirectory = yield* ConvexDirectory.get;
+): Effect.fn.Return<void, never, R | Path.Path | ConvexDirectory> {
+  const path = yield* Path.Path;
+  const convexDirectory = yield* ConvexDirectory.get;
 
-    yield* Effect.forEach(groupPaths, (gp) =>
-      Effect.gen(function* () {
-        const relativeModulePath = yield* GroupPath.modulePath(gp);
-        yield* logFn(path.join(convexDirectory, relativeModulePath));
-      }),
-    );
-  });
+  yield* Effect.forEach(groupPaths, (gp) =>
+    Effect.gen(function* () {
+      const relativeModulePath = yield* GroupPath.modulePath(gp);
+      yield* logFn(path.join(convexDirectory, relativeModulePath));
+    }),
+  );
+});
 
-export const generateFunctions = (spec: Spec.AnyWithProps) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const convexDirectory = yield* ConvexDirectory.get;
+export const generateFunctions = Effect.fnUntraced(function* (
+  spec: Spec.AnyWithProps,
+) {
+  const path = yield* Path.Path;
+  const convexDirectory = yield* ConvexDirectory.get;
 
-    const groupPathsFromFs = yield* getGroupPathsFromFs;
-    const functionPaths = FunctionPaths.make(spec);
-    const groupPathsFromSpec = FunctionPaths.groupPaths(functionPaths);
+  const groupPathsFromFs = yield* getGroupPathsFromFs;
+  const functionPaths = FunctionPaths.make(spec);
+  const groupPathsFromSpec = FunctionPaths.groupPaths(functionPaths);
 
-    const overlappingGroupPaths = GroupPaths.GroupPaths.make(
-      HashSet.intersection(groupPathsFromFs, groupPathsFromSpec),
-    );
-    yield* Effect.forEach(overlappingGroupPaths, (groupPath) =>
-      Effect.gen(function* () {
-        const group = yield* Effect.fromOption(
-          GroupPath.getGroupSpec(spec, groupPath),
-        );
-        const functionNames = pipe(
-          group.functions,
-          Record.values,
-          Array.sortBy(
-            Order.mapInput(
-              Order.String,
-              (fn: FunctionSpec.AnyWithProps) => fn.name,
-            ),
+  const overlappingGroupPaths = GroupPaths.GroupPaths.make(
+    HashSet.intersection(groupPathsFromFs, groupPathsFromSpec),
+  );
+  yield* Effect.forEach(overlappingGroupPaths, (groupPath) =>
+    Effect.gen(function* () {
+      const group = yield* Effect.fromOption(
+        GroupPath.getGroupSpec(spec, groupPath),
+      );
+      const functionNames = pipe(
+        group.functions,
+        Record.values,
+        Array.sortBy(
+          Order.mapInput(
+            Order.String,
+            (fn: FunctionSpec.AnyWithProps) => fn.name,
           ),
-          Array.map((fn) => fn.name),
-        );
-        const relativeModulePath = yield* GroupPath.modulePath(groupPath);
-        const modulePath = path.join(convexDirectory, relativeModulePath);
-        const registeredFunctionsImportPath =
-          yield* registeredFunctionsImportPathForGroup(groupPath, modulePath);
-        const result = yield* generateGroupModule({
-          groupPath,
-          functionNames,
-          registeredFunctionsImportPath,
-          useNode: group.runtime === "Node",
-        });
-        if (result === "Modified") {
-          yield* logFileModified(modulePath);
-        }
-      }),
-    );
+        ),
+        Array.map((fn) => fn.name),
+      );
+      const relativeModulePath = yield* GroupPath.modulePath(groupPath);
+      const modulePath = path.join(convexDirectory, relativeModulePath);
+      const registeredFunctionsImportPath =
+        yield* registeredFunctionsImportPathForGroup(groupPath, modulePath);
+      const result = yield* generateGroupModule({
+        groupPath,
+        functionNames,
+        registeredFunctionsImportPath,
+        useNode: group.runtime === "Node",
+      });
+      if (result === "Modified") {
+        yield* logFileModified(modulePath);
+      }
+    }),
+  );
 
-    const extinctGroupPaths = GroupPaths.GroupPaths.make(
-      HashSet.difference(groupPathsFromFs, groupPathsFromSpec),
-    );
-    yield* removeGroups(extinctGroupPaths);
-    yield* logGroupPaths(extinctGroupPaths, logFileRemoved);
+  const extinctGroupPaths = GroupPaths.GroupPaths.make(
+    HashSet.difference(groupPathsFromFs, groupPathsFromSpec),
+  );
+  yield* removeGroups(extinctGroupPaths);
+  yield* logGroupPaths(extinctGroupPaths, logFileRemoved);
 
-    const newGroupPaths = GroupPaths.GroupPaths.make(
-      HashSet.difference(groupPathsFromSpec, groupPathsFromFs),
-    );
-    yield* writeGroups(spec, newGroupPaths);
-    yield* logGroupPaths(newGroupPaths, logFileAdded);
+  const newGroupPaths = GroupPaths.GroupPaths.make(
+    HashSet.difference(groupPathsFromSpec, groupPathsFromFs),
+  );
+  yield* writeGroups(spec, newGroupPaths);
+  yield* logGroupPaths(newGroupPaths, logFileAdded);
 
-    return functionPaths;
-  });
+  return functionPaths;
+});
 
 const getGroupPathsFromFs = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -339,26 +352,27 @@ const getGroupPathsFromFs = Effect.gen(function* () {
   return GroupPaths.GroupPaths.make(HashSet.fromIterable(groupPathArray));
 });
 
-export const removeGroups = (groupPaths: GroupPaths.GroupPaths) =>
-  Effect.gen(function* () {
-    const path = yield* Path.Path;
-    const convexDirectory = yield* ConvexDirectory.get;
+export const removeGroups = Effect.fnUntraced(function* (
+  groupPaths: GroupPaths.GroupPaths,
+) {
+  const path = yield* Path.Path;
+  const convexDirectory = yield* ConvexDirectory.get;
 
-    yield* Effect.all(
-      HashSet.map(groupPaths, (groupPath) =>
-        Effect.gen(function* () {
-          const relativeModulePath = yield* GroupPath.modulePath(groupPath);
-          const modulePath = path.join(convexDirectory, relativeModulePath);
+  yield* Effect.all(
+    HashSet.map(groupPaths, (groupPath) =>
+      Effect.gen(function* () {
+        const relativeModulePath = yield* GroupPath.modulePath(groupPath);
+        const modulePath = path.join(convexDirectory, relativeModulePath);
 
-          yield* Effect.logDebug(`Removing group '${relativeModulePath}'...`);
+        yield* Effect.logDebug(`Removing group '${relativeModulePath}'...`);
 
-          yield* removePathIfExists(modulePath);
-          yield* Effect.logDebug(`Group '${relativeModulePath}' removed`);
-        }),
-      ),
-      { concurrency: "unbounded" },
-    );
-  });
+        yield* removePathIfExists(modulePath);
+        yield* Effect.logDebug(`Group '${relativeModulePath}' removed`);
+      }),
+    ),
+    { concurrency: "unbounded" },
+  );
+});
 
 export const writeGroups = (
   spec: Spec.AnyWithProps,
@@ -404,34 +418,33 @@ export const writeGroups = (
     }),
   );
 
-const generateOptionalFile = (
+const generateOptionalFile = Effect.fnUntraced(function* (
   confectFile: string,
   convexFile: string,
   generateContents: (importPath: string) => Effect.Effect<string>,
-) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const confectDirectory = yield* ConfectDirectory.get;
-    const convexDirectory = yield* ConvexDirectory.get;
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const confectDirectory = yield* ConfectDirectory.get;
+  const convexDirectory = yield* ConvexDirectory.get;
 
-    const confectFilePath = path.join(confectDirectory, confectFile);
+  const confectFilePath = path.join(confectDirectory, confectFile);
 
-    if (!(yield* fs.exists(confectFilePath))) {
-      return Option.none();
-    }
+  if (!(yield* fs.exists(confectFilePath))) {
+    return Option.none();
+  }
 
-    const convexFilePath = path.join(convexDirectory, convexFile);
-    const relativeImportPath = path.relative(
-      path.dirname(convexFilePath),
-      confectFilePath,
-    );
-    const contents = yield* generateContents(
-      yield* toModuleImportPath(relativeImportPath),
-    );
-    const change = yield* writeFileString(convexFilePath, contents);
-    return Option.some({ change, convexFilePath });
-  });
+  const convexFilePath = path.join(convexDirectory, convexFile);
+  const relativeImportPath = path.relative(
+    path.dirname(convexFilePath),
+    confectFilePath,
+  );
+  const contents = yield* generateContents(
+    yield* toModuleImportPath(relativeImportPath),
+  );
+  const change = yield* writeFileString(convexFilePath, contents);
+  return Option.some({ change, convexFilePath });
+});
 
 export const generateHttp = generateOptionalFile(
   "http.ts",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -253,8 +253,9 @@ const logGroupPaths = Effect.fnUntraced(function* <R>(
   const path = yield* Path.Path;
   const convexDirectory = yield* ConvexDirectory.get;
 
-  yield* Effect.forEach(groupPaths, (gp) =>
-    Effect.gen(function* () {
+  yield* Effect.forEach(
+    groupPaths,
+    Effect.fnUntraced(function* (gp: GroupPath.GroupPath) {
       const relativeModulePath = yield* GroupPath.modulePath(gp);
       yield* logFn(path.join(convexDirectory, relativeModulePath));
     }),
@@ -274,8 +275,9 @@ export const generateFunctions = Effect.fnUntraced(function* (
   const overlappingGroupPaths = GroupPaths.GroupPaths.make(
     HashSet.intersection(groupPathsFromFs, groupPathsFromSpec),
   );
-  yield* Effect.forEach(overlappingGroupPaths, (groupPath) =>
-    Effect.gen(function* () {
+  yield* Effect.forEach(
+    overlappingGroupPaths,
+    Effect.fnUntraced(function* (groupPath: GroupPath.GroupPath) {
       const group = yield* Effect.fromOption(
         GroupPath.getGroupSpec(spec, groupPath),
       );
@@ -378,8 +380,9 @@ export const writeGroups = (
   spec: Spec.AnyWithProps,
   groupPaths: GroupPaths.GroupPaths,
 ) =>
-  Effect.forEach(groupPaths, (groupPath) =>
-    Effect.gen(function* () {
+  Effect.forEach(
+    groupPaths,
+    Effect.fnUntraced(function* (groupPath: GroupPath.GroupPath) {
       const path = yield* Path.Path;
       const convexDirectory = yield* ConvexDirectory.get;
       const group = yield* Effect.fromOption(

--- a/packages/cli/test/EffectCallbacks.test.ts
+++ b/packages/cli/test/EffectCallbacks.test.ts
@@ -1,0 +1,191 @@
+import type { BuildError, BundlerError } from "@confect/cli/BuildError";
+import type * as CodegenError from "@confect/cli/CodegenError";
+import type { ConfectDirectory } from "@confect/cli/ConfectDirectory";
+import type { ConvexDirectory } from "@confect/cli/ConvexDirectory";
+import type * as FunctionPaths from "@confect/cli/FunctionPaths";
+import type * as GroupPath from "@confect/cli/GroupPath";
+import type * as GroupPaths from "@confect/cli/GroupPaths";
+import type { ProjectRoot } from "@confect/cli/ProjectRoot";
+import * as TableModule from "@confect/cli/TableModule";
+import { codegenHandler } from "@confect/cli/confect/codegen";
+import { dev } from "@confect/cli/confect/dev";
+import { generateFunctions, writeGroups } from "@confect/cli/utils";
+import type { Spec } from "@confect/core";
+import { expect, expectTypeOf, it } from "@effect/vitest";
+import type { NoSuchElementError } from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import type * as FileSystem from "effect/FileSystem";
+import type * as Path from "effect/Path";
+import type { PlatformError } from "effect/PlatformError";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import type * as Command from "effect/unstable/cli/Command";
+
+type FileServices = FileSystem.FileSystem | Path.Path;
+type GenerationServices = FileServices | ConfectDirectory | ConvexDirectory;
+
+it("preserves actual workflow inputs and inferred result, error, and service types", () => {
+  expectTypeOf(TableModule.discover).toEqualTypeOf<
+    Effect.Effect<
+      Array<{ relativePath: string; tableName: string }>,
+      | CodegenError.DuplicateTableNameError
+      | CodegenError.InvalidTableFilenameError
+      | PlatformError,
+      FileServices | ConfectDirectory
+    >
+  >();
+  expectTypeOf(TableModule.validate).parameters.toEqualTypeOf<
+    [tableModules: ReadonlyArray<TableModule.TableModule>]
+  >();
+  expectTypeOf(TableModule.validate).returns.toEqualTypeOf<
+    Effect.Effect<
+      void,
+      BuildError | CodegenError.InvalidTableDefaultExportError,
+      FileServices | ConfectDirectory
+    >
+  >();
+  expectTypeOf(writeGroups).parameters.toEqualTypeOf<
+    [spec: Spec.AnyWithProps, groupPaths: GroupPaths.GroupPaths]
+  >();
+  expectTypeOf(writeGroups).returns.toEqualTypeOf<
+    Effect.Effect<
+      Array<void>,
+      NoSuchElementError | PlatformError,
+      GenerationServices
+    >
+  >();
+  expectTypeOf(generateFunctions).parameters.toEqualTypeOf<
+    [spec: Spec.AnyWithProps]
+  >();
+  expectTypeOf(generateFunctions).returns.toEqualTypeOf<
+    Effect.Effect<
+      FunctionPaths.FunctionPaths,
+      | GroupPath.GroupModulePathIsNotATypeScriptFileError
+      | NoSuchElementError
+      | PlatformError,
+      GenerationServices | ProjectRoot
+    >
+  >();
+  expectTypeOf(codegenHandler).toEqualTypeOf<
+    Effect.Effect<
+      {
+        functionPaths: FunctionPaths.FunctionPaths;
+        anyWritesHappened: boolean;
+      },
+      | CodegenError.CodegenError
+      | BundlerError
+      | GroupPath.GroupModulePathIsNotATypeScriptFileError
+      | NoSuchElementError
+      | PlatformError,
+      GenerationServices | ProjectRoot
+    >
+  >();
+  expectTypeOf(dev).toEqualTypeOf<
+    Command.Command<
+      "dev",
+      {},
+      {},
+      | BundlerError
+      | GroupPath.GroupModulePathIsNotATypeScriptFileError
+      | NoSuchElementError
+      | PlatformError,
+      GenerationServices | ProjectRoot
+    >
+  >();
+});
+
+class Prefix extends Context.Service<Prefix, string>()(
+  "@confect/cli/test/EffectCallbacks.test/Prefix",
+) {}
+
+class Rejected extends Schema.TaggedError<Rejected>()("Rejected", {
+  relativePath: Schema.String,
+}) {}
+
+it.effect(
+  "preserves typed callback arguments, indexes, and channels when passed directly",
+  () =>
+    Effect.gen(function* () {
+      const calls = yield* Ref.make<ReadonlyArray<readonly [string, number]>>(
+        [],
+      );
+      const visit = Effect.fnUntraced(function* (
+        entry: TableModule.TableModule,
+        index: number,
+      ) {
+        const prefix = yield* Prefix;
+        yield* Ref.update(calls, (previous) => [
+          ...previous,
+          [entry.relativePath, index] as const,
+        ]);
+        if (entry.tableName === "rejected") {
+          return yield* new Rejected({ relativePath: entry.relativePath });
+        }
+        return `${prefix}${entry.relativePath}:${index}`;
+      });
+      expectTypeOf(visit).parameters.toEqualTypeOf<
+        [entry: TableModule.TableModule, index: number]
+      >();
+      expectTypeOf(visit).returns.toEqualTypeOf<
+        Effect.Effect<string, Rejected, Prefix>
+      >();
+      expectTypeOf<{ tableName: string; relativePath: number }>().not.toExtend<
+        Parameters<typeof visit>[0]
+      >();
+
+      const entries: ReadonlyArray<TableModule.TableModule> = [
+        { tableName: "first", relativePath: "tables/first.ts" },
+        { tableName: "second", relativePath: "tables/second.ts" },
+      ];
+      const visits = Effect.forEach(entries, visit);
+      expectTypeOf(visits).toEqualTypeOf<
+        Effect.Effect<Array<string>, Rejected, Prefix>
+      >();
+      expectTypeOf<typeof visits>().not.toExtend<
+        Effect.Effect<Array<string>, Rejected>
+      >();
+      expect(yield* Ref.get(calls)).toEqual([]);
+      const supplied = visits.pipe(Effect.provideService(Prefix, "./"));
+      expectTypeOf(supplied).toEqualTypeOf<
+        Effect.Effect<Array<string>, Rejected>
+      >();
+      expect(yield* supplied).toEqual([
+        "./tables/first.ts:0",
+        "./tables/second.ts:1",
+      ]);
+      expect(yield* Ref.get(calls)).toEqual([
+        ["tables/first.ts", 0],
+        ["tables/second.ts", 1],
+      ]);
+
+      const error = yield* Effect.forEach(
+        [{ tableName: "rejected", relativePath: "tables/rejected.ts" }],
+        visit,
+      ).pipe(Effect.provideService(Prefix, "./"), Effect.flip);
+      expect(error).toEqual(
+        new Rejected({ relativePath: "tables/rejected.ts" }),
+      );
+    }),
+);
+
+it.effect("preserves generic callback specialization through forEach", () =>
+  Effect.gen(function* () {
+    const evaluate = Effect.fnUntraced(function* <A, E, R>(
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.fn.Return<A, E, R> {
+      return yield* effect;
+    });
+    const task: Effect.Effect<"value", Rejected, Prefix> = Effect.as(
+      Prefix,
+      "value" as const,
+    );
+    const result = Effect.forEach([task], evaluate);
+    expectTypeOf(result).toEqualTypeOf<
+      Effect.Effect<Array<"value">, Rejected, Prefix>
+    >();
+    expect(yield* result.pipe(Effect.provideService(Prefix, "unused"))).toEqual(
+      ["value"],
+    );
+  }),
+);

--- a/packages/cli/test/EffectHelpers.test.ts
+++ b/packages/cli/test/EffectHelpers.test.ts
@@ -3,6 +3,7 @@ import * as templates from "@confect/cli/templates";
 import { assert, expect, expectTypeOf, it } from "@effect/vitest";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as MutableRef from "effect/MutableRef";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Tracer from "effect/Tracer";
@@ -11,17 +12,17 @@ it.effect(
   "captures template arguments at the call and allocates writers per run",
   () =>
     Effect.gen(function* () {
-      let reads = 0;
+      const reads = MutableRef.make(0);
       const options = {
         functionNames: ["first"],
         registeredFunctionsImportPath: "./original",
         get useNode() {
-          reads += 1;
+          MutableRef.increment(reads);
           return false;
         },
       };
       const render = templates.functions(options);
-      expect(reads).toBe(1);
+      expect(MutableRef.get(reads)).toBe(1);
       options.functionNames = ["replacement"];
       options.registeredFunctionsImportPath = "./replacement";
 
@@ -32,7 +33,7 @@ it.effect(
       expect(first).toContain("export const first");
       expect(first).not.toContain("replacement");
       expect(first).not.toContain('"use node"');
-      expect(reads).toBe(1);
+      expect(MutableRef.get(reads)).toBe(1);
       const defaultOptions: Parameters<typeof templates.functions>[0] = {
         functionNames: ["defaulted"],
         registeredFunctionsImportPath: "./defaulted",
@@ -88,9 +89,9 @@ it.effect(
       const first = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
       const second = new CodeBlockWriter({ indentNumberOfSpaces: 4 });
       const receiver = CodeBlockWriter.prototype.indent.bind(second);
-      let runs = 0;
+      const runs = MutableRef.make(0);
       const line = Effect.andThen(Line, (text) => {
-        runs += 1;
+        MutableRef.increment(runs);
         return text === "fail"
           ? Effect.fail("failure" as const)
           : second.writeLine(text);
@@ -100,7 +101,7 @@ it.effect(
         Effect.Effect<void, "failure", Line>
       >();
       expect(Object.hasOwn(second, "indent")).toBe(false);
-      expect(runs).toBe(0);
+      expect(MutableRef.get(runs)).toBe(0);
       expect(yield* second.toString()).toBe("");
 
       yield* indented.pipe(Effect.provideService(Line, "line"));
@@ -111,7 +112,7 @@ it.effect(
       expect(yield* second.toString()).toBe(
         "    line\n    again\n    bound\noutside\n",
       );
-      expect(runs).toBe(2);
+      expect(MutableRef.get(runs)).toBe(2);
 
       const failed = yield* indented.pipe(
         Effect.provideService(Line, "fail"),

--- a/packages/cli/test/EffectHelpers.test.ts
+++ b/packages/cli/test/EffectHelpers.test.ts
@@ -1,0 +1,151 @@
+import { CodeBlockWriter } from "@confect/cli/CodeBlockWriter";
+import * as templates from "@confect/cli/templates";
+import { assert, expect, expectTypeOf, it } from "@effect/vitest";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import * as Tracer from "effect/Tracer";
+
+it.effect(
+  "captures template arguments at the call and allocates writers per run",
+  () =>
+    Effect.gen(function* () {
+      let reads = 0;
+      const options = {
+        functionNames: ["first"],
+        registeredFunctionsImportPath: "./original",
+        get useNode() {
+          reads += 1;
+          return false;
+        },
+      };
+      const render = templates.functions(options);
+      expect(reads).toBe(1);
+      options.functionNames = ["replacement"];
+      options.registeredFunctionsImportPath = "./replacement";
+
+      const first = yield* render;
+      const second = yield* render;
+      expect(first).toBe(second);
+      expect(first).toContain('from "./original"');
+      expect(first).toContain("export const first");
+      expect(first).not.toContain("replacement");
+      expect(first).not.toContain('"use node"');
+      expect(reads).toBe(1);
+      const defaultOptions: Parameters<typeof templates.functions>[0] = {
+        functionNames: ["defaulted"],
+        registeredFunctionsImportPath: "./defaulted",
+      };
+      const defaultRender = templates.functions(defaultOptions);
+      defaultOptions.useNode = true;
+      expect(yield* defaultRender).not.toContain('"use node"');
+      expect(
+        yield* templates.functions({
+          functionNames: ["next"],
+          registeredFunctionsImportPath: "./next",
+          useNode: true,
+        }),
+      ).toContain('"use node"');
+    }),
+);
+
+it.effect(
+  "renders nested assembly repeatedly without accumulating writer state",
+  () =>
+    Effect.gen(function* () {
+      const render = templates.assembledSpec({
+        nodes: [
+          {
+            segment: "parent",
+            importBinding: Option.none(),
+            children: [
+              {
+                segment: "child",
+                importBinding: Option.none(),
+                children: [],
+              },
+            ],
+          },
+        ],
+      });
+      const first = yield* render;
+      expect(yield* render).toBe(first);
+      expect(first).toContain(
+        '.addGroupAt("child", GroupSpec.makeAt("child"))',
+      );
+    }),
+);
+
+class Line extends Context.Service<Line, string>()(
+  "@confect/cli/test/EffectHelpers.test/Line",
+) {}
+
+it.effect(
+  "preserves the indent prototype method, receiver, and generic channels",
+  () =>
+    Effect.gen(function* () {
+      const first = new CodeBlockWriter({ indentNumberOfSpaces: 2 });
+      const second = new CodeBlockWriter({ indentNumberOfSpaces: 4 });
+      const receiver = CodeBlockWriter.prototype.indent.bind(second);
+      let runs = 0;
+      const line = Effect.andThen(Line, (text) => {
+        runs += 1;
+        return text === "fail"
+          ? Effect.fail("failure" as const)
+          : second.writeLine(text);
+      });
+      const indented = second.indent(line);
+      expectTypeOf(indented).toEqualTypeOf<
+        Effect.Effect<void, "failure", Line>
+      >();
+      expect(Object.hasOwn(second, "indent")).toBe(false);
+      expect(runs).toBe(0);
+      expect(yield* second.toString()).toBe("");
+
+      yield* indented.pipe(Effect.provideService(Line, "line"));
+      yield* indented.pipe(Effect.provideService(Line, "again"));
+      yield* receiver(second.writeLine("bound"));
+      yield* second.writeLine("outside");
+      expect(yield* first.toString()).toBe("");
+      expect(yield* second.toString()).toBe(
+        "    line\n    again\n    bound\noutside\n",
+      );
+      expect(runs).toBe(2);
+
+      const failed = yield* indented.pipe(
+        Effect.provideService(Line, "fail"),
+        Effect.result,
+      );
+      assert(Result.isFailure(failed));
+      expect(failed.failure).toBe("failure");
+    }),
+);
+
+it.effect("keeps internal helpers within their caller's span", () =>
+  Effect.gen(function* () {
+    const spans: Array<Tracer.Span> = [];
+    const tracer = Tracer.make({
+      span(options) {
+        const span = new Tracer.NativeSpan(options);
+        spans.push(span);
+        return span;
+      },
+    });
+    const writer = new CodeBlockWriter();
+    const parentName = yield* writer
+      .indent(
+        Effect.gen(function* () {
+          expect((yield* Effect.currentSpan).name).toBe("caller");
+          yield* templates.services({ schemaImportPath: "./schema" });
+        }),
+      )
+      .pipe(
+        Effect.andThen(Effect.map(Effect.currentSpan, (span) => span.name)),
+        Effect.withSpan("caller"),
+        Effect.provideService(Tracer.Tracer, tracer),
+      );
+    expect(parentName).toBe("caller");
+    expect(spans.map((span) => span.name)).toEqual(["caller"]);
+  }),
+);

--- a/packages/cli/test/EffectTracing.test.ts
+++ b/packages/cli/test/EffectTracing.test.ts
@@ -1,0 +1,185 @@
+import * as Bundler from "@confect/cli/Bundler";
+import * as CodegenError from "@confect/cli/CodegenError";
+import { ConfectDirectory } from "@confect/cli/ConfectDirectory";
+import { ConvexDirectory } from "@confect/cli/ConvexDirectory";
+import { ProjectRoot } from "@confect/cli/ProjectRoot";
+import { codegenHandler } from "@confect/cli/confect/codegen";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import { assert, expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Tracer from "effect/Tracer";
+
+const makeRecordingTracer = () => {
+  const spans: Array<Tracer.Span> = [];
+  const tracer = Tracer.make({
+    span(options) {
+      const span = new Tracer.NativeSpan(options);
+      spans.push(span);
+      return span;
+    },
+  });
+  return { spans, tracer };
+};
+
+const makeProject = Effect.fnUntraced(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectoryScoped({
+    directory: import.meta.dirname,
+    prefix: "tracing-",
+  });
+  const confect = path.join(root, "confect");
+  const convex = path.join(root, "convex");
+  yield* fs.makeDirectory(confect);
+  yield* fs.makeDirectory(convex);
+  yield* fs.writeFileString(
+    path.join(confect, "notes.spec.ts"),
+    'import { GroupSpec } from "@confect/core";\nexport default GroupSpec.make();\n',
+  );
+  yield* fs.writeFileString(
+    path.join(confect, "notes.impl.ts"),
+    [
+      'import { GroupImpl } from "@confect/server";',
+      'import databaseSchema from "./_generated/schema";',
+      'import notes from "./notes.spec";',
+      "export default GroupImpl.make(databaseSchema, notes).pipe(GroupImpl.finalize);",
+      "",
+    ].join("\n"),
+  );
+  yield* fs.writeFileString(
+    path.join(convex, "convex.config.ts"),
+    'import { defineApp } from "convex/server";\nexport default defineApp();\n',
+  );
+  return {
+    confect,
+    convex,
+    directories: Layer.mergeAll(
+      Layer.succeed(ProjectRoot, { get: Effect.succeed(root) }),
+      Layer.succeed(ConfectDirectory, { get: Effect.succeed(confect) }),
+      Layer.succeed(ConvexDirectory, { get: Effect.succeed(convex) }),
+    ),
+  };
+});
+
+layer(Layer.mergeAll(NodePath.layer, NodeFileSystem.layer))(
+  "CLI operation tracing",
+  (it) => {
+    it.effect(
+      "creates a fresh operation hierarchy for each codegen execution",
+      () =>
+        Effect.gen(function* () {
+          const { directories } = yield* makeProject();
+          const { spans, tracer } = makeRecordingTracer();
+          const pass = codegenHandler.pipe(
+            Effect.provide(directories),
+            Effect.provideService(Tracer.Tracer, tracer),
+          );
+
+          expect(spans).toEqual([]);
+          const first = yield* pass;
+          const second = yield* pass;
+          expect(first.anyWritesHappened).toBe(true);
+          expect(second.anyWritesHappened).toBe(false);
+
+          const passes = spans.filter((span) => span.name === "Cli.codegen");
+          expect(passes).toHaveLength(2);
+          expect(passes[0]).not.toBe(passes[1]);
+          for (const name of [
+            "LeafModule.validateSpec",
+            "LeafModule.validateImpl",
+            "ConvexConfig.discoverInstalledComponents",
+          ]) {
+            const operations = spans.filter((span) => span.name === name);
+            expect(operations).toHaveLength(2);
+            for (const operation of operations) {
+              expect(passes).toContain(Option.getOrUndefined(operation.parent));
+            }
+          }
+          const bundles = spans.filter(
+            (span) => span.name === "Bundler.bundle",
+          );
+          expect(bundles.length).toBeGreaterThan(0);
+          for (const bundle of bundles) {
+            const parent = Option.getOrUndefined(bundle.parent);
+            assert(parent?._tag === "Span");
+            expect([
+              "Cli.codegen",
+              "LeafModule.validateSpec",
+              "LeafModule.validateImpl",
+              "ConvexConfig.discoverInstalledComponents",
+            ]).toContain(parent.name);
+          }
+          for (const span of spans) {
+            assert(span.status._tag === "Ended");
+            expect(Exit.isSuccess(span.status.exit)).toBe(true);
+          }
+        }),
+    );
+
+    it.effect.each([
+      { kind: "spec", name: "LeafModule.validateSpec" },
+      { kind: "impl", name: "LeafModule.validateImpl" },
+      { kind: "config", name: "ConvexConfig.discoverInstalledComponents" },
+    ] as const)(
+      "retains a failed $kind operation when the caller recovers",
+      ({ kind, name }) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const { confect, convex, directories } = yield* makeProject();
+          const file =
+            kind === "config"
+              ? path.join(convex, "convex.config.ts")
+              : path.join(confect, `notes.${kind}.ts`);
+          yield* fs.writeFileString(file, "export default {};\n");
+          const { spans, tracer } = makeRecordingTracer();
+
+          const result = yield* codegenHandler.pipe(
+            CodegenError.catchAndLog,
+            Effect.provide(directories),
+            Effect.provideService(Tracer.Tracer, tracer),
+          );
+
+          expect(Option.isNone(result)).toBe(true);
+          for (const operationName of ["Cli.codegen", name]) {
+            const span = spans.find(
+              (candidate) => candidate.name === operationName,
+            );
+            assert(span !== undefined);
+            assert(span.status._tag === "Ended");
+            expect(Exit.isFailure(span.status.exit)).toBe(true);
+          }
+        }),
+    );
+
+    it.effect("defers bundling until execution and closes failure spans", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const directory = yield* fs.makeTempDirectoryScoped();
+        const entry = path.join(directory, "entry.ts");
+        const { spans, tracer } = makeRecordingTracer();
+        const bundle = Bundler.bundle(entry).pipe(
+          Effect.provideService(Tracer.Tracer, tracer),
+        );
+
+        expect(spans).toEqual([]);
+        yield* fs.writeFileString(entry, "export default 42;\n");
+        expect((yield* bundle).module.default).toBe(42);
+        yield* fs.remove(entry);
+        expect(Exit.isFailure(yield* Effect.exit(bundle))).toBe(true);
+        expect(spans).toHaveLength(2);
+        assert(spans[0]?.status._tag === "Ended");
+        assert(spans[1]?.status._tag === "Ended");
+        expect(Exit.isSuccess(spans[0].status.exit)).toBe(true);
+        expect(Exit.isFailure(spans[1].status.exit)).toBe(true);
+      }),
+    );
+  },
+);

--- a/packages/cli/test/EffectTracing.test.ts
+++ b/packages/cli/test/EffectTracing.test.ts
@@ -3,6 +3,7 @@ import * as CodegenError from "@confect/cli/CodegenError";
 import { ConfectDirectory } from "@confect/cli/ConfectDirectory";
 import { ConvexDirectory } from "@confect/cli/ConvexDirectory";
 import { ProjectRoot } from "@confect/cli/ProjectRoot";
+import * as TableModule from "@confect/cli/TableModule";
 import { codegenHandler } from "@confect/cli/confect/codegen";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
@@ -11,6 +12,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as MutableRef from "effect/MutableRef";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Tracer from "effect/Tracer";
@@ -70,6 +72,45 @@ const makeProject = Effect.fnUntraced(function* () {
 layer(Layer.mergeAll(NodePath.layer, NodeFileSystem.layer))(
   "CLI operation tracing",
   (it) => {
+    it.effect(
+      "captures each table path once per execution without reading it eagerly",
+      () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const { confect, directories } = yield* makeProject();
+          yield* fs.writeFileString(
+            path.join(confect, "table.ts"),
+            'import { Table } from "@confect/core";\nimport * as Schema from "effect/Schema";\nexport default Table.make(() => Schema.Struct({}));\n',
+          );
+          yield* fs.writeFileString(
+            path.join(confect, "invalid.ts"),
+            "export default {};\n",
+          );
+          const reads = MutableRef.make(0);
+          const relativePath = MutableRef.make("table.ts");
+          const table: TableModule.TableModule = {
+            tableName: "notes",
+            get relativePath() {
+              MutableRef.increment(reads);
+              return MutableRef.get(relativePath);
+            },
+          };
+          const validate = TableModule.validate([table]).pipe(
+            Effect.provide(directories),
+          );
+          expect(MutableRef.get(reads)).toBe(0);
+          yield* validate;
+          expect(MutableRef.get(reads)).toBe(1);
+
+          MutableRef.set(relativePath, "invalid.ts");
+          const error = yield* Effect.flip(validate);
+          assert(error._tag === "InvalidTableDefaultExportError");
+          expect(error.tablePath).toBe("invalid.ts");
+          expect(MutableRef.get(reads)).toBe(2);
+        }),
+    );
+
     it.effect(
       "creates a fresh operation hierarchy for each codegen execution",
       () =>

--- a/packages/cli/test/LeafModule.test.ts
+++ b/packages/cli/test/LeafModule.test.ts
@@ -1,5 +1,6 @@
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import type { PlatformError } from "effect/PlatformError";
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 import * as NodePath from "@effect/platform-node/NodePath";
 import { assert, expect, layer } from "@effect/vitest";
@@ -42,37 +43,44 @@ interface TempFile {
   readonly contents: string;
 }
 
-const withTempFiles = <A>(
-  files: ReadonlyArray<TempFile>,
-  use: Effect.Effect<
+const withTempFiles = Effect.fnUntraced(
+  function* <A>(
+    files: ReadonlyArray<TempFile>,
+    use: Effect.Effect<
+      A,
+      CodegenError,
+      ConfectDirectory | Path.Path | FileSystem.FileSystem
+    >,
+  ): Effect.fn.Return<
     A,
-    CodegenError,
+    CodegenError | PlatformError,
     ConfectDirectory | Path.Path | FileSystem.FileSystem
-  >,
-) =>
-  Effect.gen(function* () {
+  > {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     yield* Effect.forEach(files, ({ relativePath, contents }) =>
       fs.writeFileString(path.join(fixtureConfect, relativePath), contents),
     );
     return yield* use;
-  }).pipe(
-    Effect.ensuring(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const path = yield* Path.Path;
-        yield* Effect.forEach(files, ({ relativePath }) =>
-          Effect.gen(function* () {
-            const absolutePath = path.join(fixtureConfect, relativePath);
-            if (yield* fs.exists(absolutePath)) {
-              yield* fs.remove(absolutePath);
-            }
-          }),
-        );
-      }).pipe(Effect.orDie),
+  },
+  (effect, files) =>
+    effect.pipe(
+      Effect.ensuring(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          yield* Effect.forEach(files, ({ relativePath }) =>
+            Effect.gen(function* () {
+              const absolutePath = path.join(fixtureConfect, relativePath);
+              if (yield* fs.exists(absolutePath)) {
+                yield* fs.remove(absolutePath);
+              }
+            }),
+          );
+        }).pipe(Effect.orDie),
+      ),
     ),
-  );
+);
 
 const withTempFile = <A>(
   relativePath: string,
@@ -90,7 +98,7 @@ const withTempFile = <A>(
  * re-exports `./notes.spec`'s GroupSpec by default so impl contents that
  * reference `notes` continue to typecheck against the real notes GroupSpec.
  */
-const withTempLeaf = (
+const withTempLeaf = Effect.fnUntraced(function* (
   stem: string,
   implContents: string,
   use: (
@@ -101,17 +109,16 @@ const withTempLeaf = (
     ConfectDirectory | Path.Path | FileSystem.FileSystem
   >,
   specContents = `export { default } from "./notes.spec";\n`,
-) =>
-  Effect.gen(function* () {
-    const leaf = yield* toLeafModule(`groups/${stem}.spec.ts`);
-    yield* withTempFiles(
-      [
-        { relativePath: `groups/${stem}.spec.ts`, contents: specContents },
-        { relativePath: `groups/${stem}.impl.ts`, contents: implContents },
-      ],
-      use(leaf),
-    );
-  });
+) {
+  const leaf = yield* toLeafModule(`groups/${stem}.spec.ts`);
+  yield* withTempFiles(
+    [
+      { relativePath: `groups/${stem}.spec.ts`, contents: specContents },
+      { relativePath: `groups/${stem}.impl.ts`, contents: implContents },
+    ],
+    use(leaf),
+  );
+});
 
 const PLATFORMS = [
   { name: "posix", pathLayer: NodePath.layerPosix, sep: "/" },

--- a/packages/cli/test/codegen.test.ts
+++ b/packages/cli/test/codegen.test.ts
@@ -311,18 +311,20 @@ layer(Layer.empty)("validateNoParentChildNameCollisions", (it) => {
   );
 });
 
-const leafFor = (relativePath: string, pathSegments: [string, ...string[]]) =>
-  Effect.gen(function* () {
-    const specImportPath = yield* specImportPathFromGenerated(relativePath);
-    return {
-      relativePath,
-      pathSegments,
-      groupPathDot: Array.join(pathSegments, "."),
-      exportName: pathSegments[pathSegments.length - 1]!,
-      runtime: Option.none(),
-      specImportPath,
-    } satisfies LeafModule;
-  });
+const leafFor = Effect.fnUntraced(function* (
+  relativePath: string,
+  pathSegments: [string, ...string[]],
+) {
+  const specImportPath = yield* specImportPathFromGenerated(relativePath);
+  return {
+    relativePath,
+    pathSegments,
+    groupPathDot: Array.join(pathSegments, "."),
+    exportName: pathSegments[pathSegments.length - 1]!,
+    runtime: Option.none(),
+    specImportPath,
+  } satisfies LeafModule;
+});
 
 for (const { name, pathLayer, sep } of [
   { name: "posix", pathLayer: NodePath.layerPosix, sep: "/" },

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -80,54 +80,64 @@ const runGenerateForNodeGroup = ({
   spec,
   moduleRelativePath,
   registryRelativePath,
+}: Parameters<typeof runGenerateForNodeGroupEffect>[0]) =>
+  runGenerateForNodeGroupEffect({
+    spec,
+    moduleRelativePath,
+    registryRelativePath,
+  });
+
+const runGenerateForNodeGroupEffect = Effect.fnUntraced(function* ({
+  spec,
+  moduleRelativePath,
+  registryRelativePath,
 }: {
   spec: Spec.AnyWithProps;
   moduleRelativePath: string;
   registryRelativePath: string;
-}) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
 
-    const root = yield* fs.makeTempDirectoryScoped();
-    const convexDir = path.join(root, "convex");
-    const confectDir = path.join(root, "confect");
-    yield* fs.makeDirectory(convexDir, { recursive: true });
+  const root = yield* fs.makeTempDirectoryScoped();
+  const convexDir = path.join(root, "convex");
+  const confectDir = path.join(root, "confect");
+  yield* fs.makeDirectory(convexDir, { recursive: true });
 
-    const registryPath = path.join(
-      confectDir,
-      "_generated",
-      "registeredFunctions",
-      registryRelativePath,
-    );
-    yield* fs.makeDirectory(path.dirname(registryPath), { recursive: true });
-    yield* fs.writeFileString(registryPath, "export default {};\n");
+  const registryPath = path.join(
+    confectDir,
+    "_generated",
+    "registeredFunctions",
+    registryRelativePath,
+  );
+  yield* fs.makeDirectory(path.dirname(registryPath), { recursive: true });
+  yield* fs.writeFileString(registryPath, "export default {};\n");
 
-    const TempDirsLayer = Layer.mergeAll(
-      Layer.succeed(ProjectRoot, ProjectRoot.of({ get: Effect.succeed(root) })),
-      Layer.succeed(
-        ConvexDirectory,
-        ConvexDirectory.of({ get: Effect.succeed(convexDir) }),
-      ),
-      Layer.succeed(
-        ConfectDirectory,
-        ConfectDirectory.of({ get: Effect.succeed(confectDir) }),
-      ),
-    );
+  const TempDirsLayer = Layer.mergeAll(
+    Layer.succeed(ProjectRoot, ProjectRoot.of({ get: Effect.succeed(root) })),
+    Layer.succeed(
+      ConvexDirectory,
+      ConvexDirectory.of({ get: Effect.succeed(convexDir) }),
+    ),
+    Layer.succeed(
+      ConfectDirectory,
+      ConfectDirectory.of({ get: Effect.succeed(confectDir) }),
+    ),
+  );
 
-    yield* generateFunctions(spec).pipe(Effect.provide(TempDirsLayer));
+  yield* generateFunctions(spec).pipe(Effect.provide(TempDirsLayer));
 
-    const modulePath = path.join(convexDir, moduleRelativePath);
-    const contents = yield* fs.readFileString(modulePath);
+  const modulePath = path.join(convexDir, moduleRelativePath);
+  const contents = yield* fs.readFileString(modulePath);
 
-    const importMatch = contents.match(/from "([^"]+)"/);
-    assert(importMatch !== null, "expected a registry import in the module");
-    const resolved =
-      path.resolve(path.dirname(modulePath), importMatch[1]!) + ".ts";
-    const resolves = yield* fs.exists(resolved);
+  const importMatch = contents.match(/from "([^"]+)"/);
+  assert(importMatch !== null, "expected a registry import in the module");
+  const resolved =
+    path.resolve(path.dirname(modulePath), importMatch[1]!) + ".ts";
+  const resolves = yield* fs.exists(resolved);
 
-    return { contents, resolves };
-  }).pipe(Effect.scoped);
+  return { contents, resolves };
+}, Effect.scoped);
 
 layer(GenerateFunctionsLayer)("generateFunctions", (it) => {
   // A Node group declared with `GroupSpec.makeNode()` generates `convex/<path>.ts`

--- a/packages/core/src/Ref.ts
+++ b/packages/core/src/Ref.ts
@@ -630,7 +630,10 @@ export const decodePaginationPageSync = <Ref_ extends AnyPublicPaginatedQuery>(
  * `mapUnknownError` to be turned into a typed `E`, or surfaced as a defect when
  * no handler is provided.
  */
-export const runWithCodec = <Ref_ extends Any, E = never>(
+export const runWithCodec = Effect.fnUntraced(function* <
+  Ref_ extends Any,
+  E = never,
+>(
   ref: Ref_,
   args: Args<Ref_>,
   call: (
@@ -638,29 +641,28 @@ export const runWithCodec = <Ref_ extends Any, E = never>(
     encodedArgs: unknown,
   ) => PromiseLike<unknown>,
   mapUnknownError?: (error: unknown) => E,
-): Effect.Effect<Returns<Ref_>, E | Error<Ref_> | Schema.SchemaError> =>
-  Effect.gen(function* () {
-    const functionReference = getFunctionReference(ref);
-    const invoke = (
-      encodedArgs: unknown,
-    ): Effect.Effect<unknown, Error<Ref_> | E> =>
-      Effect.tryPromise({
-        try: () => Promise.resolve(call(functionReference, encodedArgs)),
-        catch: (error): Error<Ref_> | E => {
-          if (isConvexError(error)) {
-            const decoded = decodeErrorOption(ref, error.data);
-            if (Option.isSome(decoded)) {
-              return decoded.value;
-            }
+): Effect.fn.Return<Returns<Ref_>, E | Error<Ref_> | Schema.SchemaError> {
+  const functionReference = getFunctionReference(ref);
+  const invoke = (
+    encodedArgs: unknown,
+  ): Effect.Effect<unknown, Error<Ref_> | E> =>
+    Effect.tryPromise({
+      try: () => Promise.resolve(call(functionReference, encodedArgs)),
+      catch: (error): Error<Ref_> | E => {
+        if (isConvexError(error)) {
+          const decoded = decodeErrorOption(ref, error.data);
+          if (Option.isSome(decoded)) {
+            return decoded.value;
           }
-          if (mapUnknownError !== undefined) {
-            return mapUnknownError(error);
-          }
-          throw error;
-        },
-      });
+        }
+        if (mapUnknownError !== undefined) {
+          return mapUnknownError(error);
+        }
+        throw error;
+      },
+    });
 
-    const encodedArgs = yield* encodeArgs(ref, args);
-    const encodedReturns = yield* invoke(encodedArgs);
-    return yield* decodeReturns(ref, encodedReturns);
-  });
+  const encodedArgs = yield* encodeArgs(ref, args);
+  const encodedReturns = yield* invoke(encodedArgs);
+  return yield* decodeReturns(ref, encodedReturns);
+});

--- a/packages/core/src/SchemaToValidator.ts
+++ b/packages/core/src/SchemaToValidator.ts
@@ -384,23 +384,27 @@ export const compileAst = (
 const handleUnion = (
   { types }: SchemaAST.Union,
   isOptionalPropertyOfTypeLiteral: boolean,
-) =>
-  Effect.gen(function* () {
-    const members = isOptionalPropertyOfTypeLiteral
-      ? Array.filter(types, Predicate.not(SchemaAST.isUndefined))
-      : types;
+) => handleUnionTypes(types, isOptionalPropertyOfTypeLiteral);
 
-    const [firstValidator, secondValidator, ...restValidators] =
-      yield* Effect.all(Array.map(members, (type) => compileAst(type)));
+const handleUnionTypes = Effect.fnUntraced(function* (
+  types: SchemaAST.Union["types"],
+  isOptionalPropertyOfTypeLiteral: boolean,
+) {
+  const members = isOptionalPropertyOfTypeLiteral
+    ? Array.filter(types, Predicate.not(SchemaAST.isUndefined))
+    : types;
 
-    if (firstValidator === undefined) {
-      return yield* new EmptyUnionIsNotSupportedError();
-    } else if (secondValidator === undefined) {
-      return firstValidator;
-    } else {
-      return v.union(firstValidator, secondValidator, ...restValidators);
-    }
-  });
+  const [firstValidator, secondValidator, ...restValidators] =
+    yield* Effect.all(Array.map(members, (type) => compileAst(type)));
+
+  if (firstValidator === undefined) {
+    return yield* new EmptyUnionIsNotSupportedError();
+  } else if (secondValidator === undefined) {
+    return firstValidator;
+  } else {
+    return v.union(firstValidator, secondValidator, ...restValidators);
+  }
+});
 
 const handleObjects = (objectsAst: SchemaAST.Objects) =>
   pipe(
@@ -431,35 +435,40 @@ const handleObjects = (objectsAst: SchemaAST.Objects) =>
   );
 
 const handleArrays = ({ elements, rest }: SchemaAST.Arrays) =>
-  Effect.gen(function* () {
-    const [f, s, ...r] = elements;
+  handleArrayElements(elements, rest);
 
-    const elementToValidator = (element: SchemaAST.AST) =>
-      SchemaAST.isOptional(element)
-        ? Effect.fail(new OptionalTupleElementsAreNotSupportedError())
-        : compileAst(element);
+const handleArrayElements = Effect.fnUntraced(function* (
+  elements: SchemaAST.Arrays["elements"],
+  rest: SchemaAST.Arrays["rest"],
+) {
+  const [f, s, ...r] = elements;
 
-    const arrayItemsValidator = yield* f === undefined
-      ? pipe(
-          rest,
-          Array.head,
-          Option.match({
-            onNone: () => Effect.fail(new EmptyTupleIsNotSupportedError()),
-            onSome: (type) => compileAst(type),
-          }),
-        )
-      : s === undefined
-        ? elementToValidator(f)
-        : Effect.gen(function* () {
-            const firstValidator = yield* elementToValidator(f);
-            const secondValidator = yield* elementToValidator(s);
-            const restValidators = yield* Effect.forEach(r, elementToValidator);
+  const elementToValidator = (element: SchemaAST.AST) =>
+    SchemaAST.isOptional(element)
+      ? Effect.fail(new OptionalTupleElementsAreNotSupportedError())
+      : compileAst(element);
 
-            return v.union(firstValidator, secondValidator, ...restValidators);
-          });
+  const arrayItemsValidator = yield* f === undefined
+    ? pipe(
+        rest,
+        Array.head,
+        Option.match({
+          onNone: () => Effect.fail(new EmptyTupleIsNotSupportedError()),
+          onSome: (type) => compileAst(type),
+        }),
+      )
+    : s === undefined
+      ? elementToValidator(f)
+      : Effect.gen(function* () {
+          const firstValidator = yield* elementToValidator(f);
+          const secondValidator = yield* elementToValidator(s);
+          const restValidators = yield* Effect.forEach(r, elementToValidator);
 
-    return v.array(arrayItemsValidator);
-  });
+          return v.union(firstValidator, secondValidator, ...restValidators);
+        });
+
+  return v.array(arrayItemsValidator);
+});
 
 const handlePropertySignatures = (objectsAst: SchemaAST.Objects) =>
   pipe(

--- a/packages/core/test/Lazy.test.ts
+++ b/packages/core/test/Lazy.test.ts
@@ -1,35 +1,36 @@
 import { describe, expect, test } from "@effect/vitest";
 import * as Lazy from "@confect/core/Lazy";
+import * as MutableRef from "effect/MutableRef";
 
 describe("Lazy.defineProperty", () => {
   test("does not run compute until the property is first accessed", () => {
     const target = {} as { value: number };
-    let calls = 0;
+    const calls = MutableRef.make(0);
     Lazy.defineProperty(target, "value", () => {
-      calls += 1;
+      MutableRef.increment(calls);
       return 42;
     });
 
-    expect(calls).toBe(0);
+    expect(MutableRef.get(calls)).toBe(0);
   });
 
   test("first access runs compute exactly once and returns its value", () => {
     const target = {} as { value: number };
-    let calls = 0;
+    const calls = MutableRef.make(0);
     Lazy.defineProperty(target, "value", () => {
-      calls += 1;
+      MutableRef.increment(calls);
       return 42;
     });
 
     expect(target.value).toBe(42);
-    expect(calls).toBe(1);
+    expect(MutableRef.get(calls)).toBe(1);
   });
 
   test("second access returns the same reference without re-running compute", () => {
     const target = {} as { value: { id: number } };
-    let calls = 0;
+    const calls = MutableRef.make(0);
     Lazy.defineProperty(target, "value", () => {
-      calls += 1;
+      MutableRef.increment(calls);
       return { id: 1 };
     });
 
@@ -37,7 +38,7 @@ describe("Lazy.defineProperty", () => {
     const second = target.value;
 
     expect(first).toBe(second);
-    expect(calls).toBe(1);
+    expect(MutableRef.get(calls)).toBe(1);
   });
 
   test("computed property is enumerable after materialisation", () => {

--- a/packages/core/test/Ref.test.ts
+++ b/packages/core/test/Ref.test.ts
@@ -13,6 +13,7 @@ import * as MutableRef from "effect/MutableRef";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { describe, expect, expectTypeOf, test } from "@effect/vitest";
+import { vi } from "vitest";
 
 import * as FunctionSpec from "@confect/core/FunctionSpec";
 import * as MiddlewareSpec from "@confect/core/MiddlewareSpec";
@@ -20,6 +21,94 @@ import * as PaginationOptions from "@confect/core/PaginationOptions";
 import * as PaginationResult from "@confect/core/PaginationResult";
 import * as Ref from "@confect/core/Ref";
 import type * as RuntimeAndFunctionType from "@confect/core/RuntimeAndFunctionType";
+
+describe("runWithCodec", () => {
+  class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
+    id: Schema.String,
+  }) {}
+
+  class TransportFailure extends Schema.TaggedError<TransportFailure>()(
+    "TransportFailure",
+    {
+      cause: Schema.Unknown,
+    },
+  ) {}
+
+  const ref = Ref.make(
+    "notes",
+    FunctionSpec.publicQuery({
+      name: "count",
+      args: () => ({ count: Schema.FiniteFromString }),
+      returns: () => Schema.FiniteFromString,
+      error: () => NotFound,
+    }),
+  );
+
+  it.effect(
+    "defers encoding and invocation and repeats the codec workflow",
+    () =>
+      Effect.gen(function* () {
+        const readCount = vi.fn(() => 1);
+        const invoke = vi.fn(() => Promise.resolve("2"));
+        const effect = Ref.runWithCodec(
+          ref,
+          {
+            get count() {
+              return readCount();
+            },
+          },
+          invoke,
+        );
+
+        expectTypeOf(effect).toEqualTypeOf<
+          Effect.Effect<number, NotFound | Schema.SchemaError>
+        >();
+        expect(readCount).not.toHaveBeenCalled();
+        expect(invoke).not.toHaveBeenCalled();
+
+        expect(yield* effect).toBe(2);
+        readCount.mockReturnValue(3);
+        expect(yield* effect).toBe(2);
+        expect(invoke).toHaveBeenNthCalledWith(
+          1,
+          Ref.getFunctionReference(ref),
+          { count: "1" },
+        );
+        expect(invoke).toHaveBeenNthCalledWith(
+          2,
+          Ref.getFunctionReference(ref),
+          { count: "3" },
+        );
+      }),
+  );
+
+  it.effect("preserves typed Convex failures", () =>
+    Effect.gen(function* () {
+      const effect = Ref.runWithCodec(ref, { count: 1 }, () =>
+        Promise.reject(new ConvexError({ _tag: "NotFound", id: "abc" })),
+      );
+      const error = yield* Effect.flip(effect);
+      expect(error).toEqual(new NotFound({ id: "abc" }));
+    }),
+  );
+
+  it.effect("infers and preserves the caller's unknown-error mapping", () =>
+    Effect.gen(function* () {
+      const rejection = new Error("offline");
+      const effect = Ref.runWithCodec(
+        ref,
+        { count: 1 },
+        () => Promise.reject(rejection),
+        (cause) => new TransportFailure({ cause }),
+      );
+      expectTypeOf(effect).toEqualTypeOf<
+        Effect.Effect<number, NotFound | TransportFailure | Schema.SchemaError>
+      >();
+      const error = yield* Effect.flip(effect);
+      expect(error).toEqual(new TransportFailure({ cause: rejection }));
+    }),
+  );
+});
 
 describe("FunctionReference", () => {
   test("public query", () => {

--- a/packages/core/test/SchemaToValidator.test.ts
+++ b/packages/core/test/SchemaToValidator.test.ts
@@ -1,0 +1,47 @@
+import { compileAst } from "@confect/core/SchemaToValidator";
+import { describe, expect, it } from "@effect/vitest";
+import { v } from "convex/values";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+describe("compiler preprocessing", () => {
+  it.effect("captures union members before executing the compiler effect", () =>
+    Effect.gen(function* () {
+      const ast = Schema.Union([Schema.String, Schema.Boolean]).ast;
+      const effect = compileAst(ast);
+      Object.defineProperty(ast, "types", { value: [Schema.Null.ast] });
+
+      expect(yield* effect).toEqual(v.union(v.string(), v.boolean()));
+      expect(yield* effect).toEqual(v.union(v.string(), v.boolean()));
+      expect(yield* compileAst(ast)).toEqual(v.null());
+    }),
+  );
+
+  it.effect(
+    "captures tuple elements before executing the compiler effect",
+    () =>
+      Effect.gen(function* () {
+        const ast = Schema.Tuple([Schema.String]).ast;
+        const effect = compileAst(ast);
+        Object.defineProperty(ast, "elements", { value: [Schema.Boolean.ast] });
+
+        expect(yield* effect).toEqual(v.array(v.string()));
+        expect(yield* effect).toEqual(v.array(v.string()));
+        expect(yield* compileAst(ast)).toEqual(v.array(v.boolean()));
+      }),
+  );
+
+  it.effect(
+    "captures array rest elements before executing the compiler effect",
+    () =>
+      Effect.gen(function* () {
+        const ast = Schema.Array(Schema.String).ast;
+        const effect = compileAst(ast);
+        Object.defineProperty(ast, "rest", { value: [Schema.Boolean.ast] });
+
+        expect(yield* effect).toEqual(v.array(v.string()));
+        expect(yield* effect).toEqual(v.array(v.string()));
+        expect(yield* compileAst(ast)).toEqual(v.array(v.boolean()));
+      }),
+  );
+});

--- a/packages/js/src/internal/HttpClient.ts
+++ b/packages/js/src/internal/HttpClient.ts
@@ -27,6 +27,18 @@ export interface Transport {
   ) => PromiseLike<unknown>;
 }
 
+const runQuery = Effect.fn("HttpClient.query")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
+
+const runMutation = Effect.fn("HttpClient.mutation")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
+
+const runAction = Effect.fn("HttpClient.action")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
+
 export const make = (client: Transport) => {
   const setAuth = (token: string) =>
     Effect.sync(() => {
@@ -47,12 +59,14 @@ export const make = (client: Transport) => {
     Ref.Error<Query> | HttpClientError | Schema.SchemaError
   > => {
     const args = (rest[0] ?? {}) as Ref.Args<Query>;
-    return Ref.runWithCodec(
-      ref,
-      args,
-      (functionReference, encodedArgs) =>
-        client.query(functionReference, encodedArgs),
-      mapUnknownError,
+    return runQuery(
+      Ref.runWithCodec(
+        ref,
+        args,
+        (functionReference, encodedArgs) =>
+          client.query(functionReference, encodedArgs),
+        mapUnknownError,
+      ),
     );
   };
 
@@ -64,12 +78,14 @@ export const make = (client: Transport) => {
     Ref.Error<Mutation> | HttpClientError | Schema.SchemaError
   > => {
     const args = (rest[0] ?? {}) as Ref.Args<Mutation>;
-    return Ref.runWithCodec(
-      ref,
-      args,
-      (functionReference, encodedArgs) =>
-        client.mutation(functionReference, encodedArgs),
-      mapUnknownError,
+    return runMutation(
+      Ref.runWithCodec(
+        ref,
+        args,
+        (functionReference, encodedArgs) =>
+          client.mutation(functionReference, encodedArgs),
+        mapUnknownError,
+      ),
     );
   };
 
@@ -81,12 +97,14 @@ export const make = (client: Transport) => {
     Ref.Error<Action> | HttpClientError | Schema.SchemaError
   > => {
     const args = (rest[0] ?? {}) as Ref.Args<Action>;
-    return Ref.runWithCodec(
-      ref,
-      args,
-      (functionReference, encodedArgs) =>
-        client.action(functionReference, encodedArgs),
-      mapUnknownError,
+    return runAction(
+      Ref.runWithCodec(
+        ref,
+        args,
+        (functionReference, encodedArgs) =>
+          client.action(functionReference, encodedArgs),
+        mapUnknownError,
+      ),
     );
   };
 

--- a/packages/js/src/internal/WebSocketClient.ts
+++ b/packages/js/src/internal/WebSocketClient.ts
@@ -40,6 +40,18 @@ export interface Transport {
   ) => () => void;
 }
 
+const runQuery = Effect.fn("WebSocketClient.query")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
+
+const runMutation = Effect.fn("WebSocketClient.mutation")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
+
+const runAction = Effect.fn("WebSocketClient.action")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
+
 export const make = (address: string, convexClient: Transport) => {
   const setAuth = (
     fetchToken: (args: {
@@ -70,12 +82,14 @@ export const make = (address: string, convexClient: Transport) => {
     Ref.Error<Query> | WebSocketClientError | Schema.SchemaError
   > => {
     const args = (rest[0] ?? {}) as Ref.Args<Query>;
-    return Ref.runWithCodec(
-      ref,
-      args,
-      (functionReference, encodedArgs) =>
-        convexClient.query(functionReference, encodedArgs),
-      mapUnknownError,
+    return runQuery(
+      Ref.runWithCodec(
+        ref,
+        args,
+        (functionReference, encodedArgs) =>
+          convexClient.query(functionReference, encodedArgs),
+        mapUnknownError,
+      ),
     );
   };
 
@@ -87,12 +101,14 @@ export const make = (address: string, convexClient: Transport) => {
     Ref.Error<Mutation> | WebSocketClientError | Schema.SchemaError
   > => {
     const args = (rest[0] ?? {}) as Ref.Args<Mutation>;
-    return Ref.runWithCodec(
-      ref,
-      args,
-      (functionReference, encodedArgs) =>
-        convexClient.mutation(functionReference, encodedArgs),
-      mapUnknownError,
+    return runMutation(
+      Ref.runWithCodec(
+        ref,
+        args,
+        (functionReference, encodedArgs) =>
+          convexClient.mutation(functionReference, encodedArgs),
+        mapUnknownError,
+      ),
     );
   };
 
@@ -104,12 +120,14 @@ export const make = (address: string, convexClient: Transport) => {
     Ref.Error<Action> | WebSocketClientError | Schema.SchemaError
   > => {
     const args = (rest[0] ?? {}) as Ref.Args<Action>;
-    return Ref.runWithCodec(
-      ref,
-      args,
-      (functionReference, encodedArgs) =>
-        convexClient.action(functionReference, encodedArgs),
-      mapUnknownError,
+    return runAction(
+      Ref.runWithCodec(
+        ref,
+        args,
+        (functionReference, encodedArgs) =>
+          convexClient.action(functionReference, encodedArgs),
+        mapUnknownError,
+      ),
     );
   };
 

--- a/packages/js/test/HttpClient.test.ts
+++ b/packages/js/test/HttpClient.test.ts
@@ -1,5 +1,5 @@
 import { FunctionSpec, Ref } from "@confect/core";
-import { assert, describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { getFunctionName, type FunctionType } from "convex/server";
 import { ConvexError } from "convex/values";
 import * as Context from "effect/Context";
@@ -52,28 +52,34 @@ const TestHttpClientLayer = Layer.effectContext(
     });
     const auth = yield* EffectRef.make<Option.Option<string>>(Option.none());
 
+    const invokeEffect = Effect.fnUntraced(function* (
+      operation: Operation,
+      functionReference: Parameters<InternalHttpClient.Transport[Operation]>[0],
+      args: unknown,
+    ) {
+      yield* EffectRef.update(calls, (current) => ({
+        ...current,
+        [operation]: [
+          ...current[operation],
+          { name: getFunctionName(functionReference), args },
+        ],
+      }));
+      const rejection = yield* EffectRef.modify(rejections, (current) => [
+        current[operation],
+        { ...current, [operation]: Option.none() },
+      ]);
+      if (Option.isSome(rejection)) {
+        throw rejection.value;
+      }
+      return {};
+    });
+
     const invoke = (
       operation: Operation,
       functionReference: Parameters<InternalHttpClient.Transport[Operation]>[0],
       args: unknown,
     ): Promise<unknown> =>
-      Effect.gen(function* () {
-        yield* EffectRef.update(calls, (current) => ({
-          ...current,
-          [operation]: [
-            ...current[operation],
-            { name: getFunctionName(functionReference), args },
-          ],
-        }));
-        const rejection = yield* EffectRef.modify(rejections, (current) => [
-          current[operation],
-          { ...current, [operation]: Option.none() },
-        ]);
-        if (Option.isSome(rejection)) {
-          throw rejection.value;
-        }
-        return {};
-      }).pipe(runPromise);
+      runPromise(invokeEffect(operation, functionReference, args));
 
     const service = TestHttpTransport.of({
       url: "https://test.convex.cloud",
@@ -285,6 +291,62 @@ const actionWithError = Ref.make(
 );
 
 describe("HttpClient error decoding", () => {
+  it.effect(
+    "preserves generic argument tuples, results, and error channels",
+    () =>
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        expectTypeOf(
+          client.query<typeof noArgsQueryRef>,
+        ).parameters.toEqualTypeOf<[ref: typeof noArgsQueryRef, args?: {}]>();
+        expectTypeOf(
+          client.query<typeof argsQueryRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof argsQueryRef, args: { readonly id: string }]
+        >();
+        expectTypeOf(
+          client.mutation<typeof noArgsMutationRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof noArgsMutationRef, args?: {}]
+        >();
+        expectTypeOf(
+          client.mutation<typeof argsMutationRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof argsMutationRef, args: { readonly text: string }]
+        >();
+        expectTypeOf(
+          client.action<typeof noArgsActionRef>,
+        ).parameters.toEqualTypeOf<[ref: typeof noArgsActionRef, args?: {}]>();
+        expectTypeOf(
+          client.action<typeof argsActionRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof argsActionRef, args: { readonly to: string }]
+        >();
+        expectTypeOf(client.query(queryWithError, { id: "abc" })).toEqualTypeOf<
+          Effect.Effect<
+            { readonly text: string },
+            NotFound | HttpClient.HttpClientError | Schema.SchemaError
+          >
+        >();
+        expectTypeOf(
+          client.mutation(mutationWithError, { id: "abc" }),
+        ).toEqualTypeOf<
+          Effect.Effect<
+            null,
+            NotFound | HttpClient.HttpClientError | Schema.SchemaError
+          >
+        >();
+        expectTypeOf(
+          client.action(actionWithError, { id: "abc" }),
+        ).toEqualTypeOf<
+          Effect.Effect<
+            null,
+            NotFound | HttpClient.HttpClientError | Schema.SchemaError
+          >
+        >();
+      }).pipe(Effect.provide(TestHttpClientLayer)),
+  );
+
   it.effect("decodes a query ConvexError", () =>
     Effect.gen(function* () {
       const transport = yield* TestHttpTransport;

--- a/packages/js/test/OperationBoundaries.test.ts
+++ b/packages/js/test/OperationBoundaries.test.ts
@@ -1,0 +1,188 @@
+import { FunctionSpec, Ref } from "@confect/core";
+import { assert, describe, expect, it } from "@effect/vitest";
+import type { RegisteredQuery } from "convex/server";
+import { ConvexError } from "convex/values";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import * as Tracer from "effect/Tracer";
+import { vi } from "vitest";
+import * as HttpClient from "../src/internal/HttpClient";
+import * as WebSocketClient from "../src/internal/WebSocketClient";
+
+class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
+  id: Schema.String,
+}) {}
+
+const definition = {
+  name: "get",
+  args: () => ({ id: Schema.String }),
+  returns: () => Schema.String,
+  error: () => NotFound,
+};
+
+const queryRef = Ref.make("notes", FunctionSpec.publicQuery(definition));
+const mutationRef = Ref.make("notes", FunctionSpec.publicMutation(definition));
+const actionRef = Ref.make("notes", FunctionSpec.publicAction(definition));
+
+type Client =
+  | ReturnType<typeof HttpClient.make>
+  | ReturnType<typeof WebSocketClient.make>;
+
+const operations: ReadonlyArray<{
+  readonly name: string;
+  readonly run: (
+    client: Client,
+  ) => Effect.Effect<
+    string,
+    | NotFound
+    | Schema.SchemaError
+    | HttpClient.HttpClientError
+    | WebSocketClient.WebSocketClientError
+  >;
+}> = [
+  {
+    name: "query",
+    run: (client: Client) => client.query(queryRef, { id: "abc" }),
+  },
+  {
+    name: "mutation",
+    run: (client: Client) => client.mutation(mutationRef, { id: "abc" }),
+  },
+  {
+    name: "action",
+    run: (client: Client) => client.action(actionRef, { id: "abc" }),
+  },
+];
+
+const clients = [
+  {
+    name: "HttpClient",
+    make: (invoke: (args: unknown) => Promise<unknown>) =>
+      HttpClient.make({
+        url: "https://test.convex.cloud",
+        setAuth: () => {},
+        clearAuth: () => {},
+        query: (_, args) => invoke(args),
+        mutation: (_, args) => invoke(args),
+        action: (_, args) => invoke(args),
+      }),
+  },
+  {
+    name: "WebSocketClient",
+    make: (invoke: (args: unknown) => Promise<unknown>) =>
+      WebSocketClient.make("https://test.convex.cloud", {
+        setAuth: () => {},
+        close: () => Promise.resolve(),
+        query: (_, args) => invoke(args),
+        mutation: (_, args) => invoke(args),
+        action: (_, args) => invoke(args),
+        onUpdate: () => () => {},
+      }),
+  },
+];
+
+describe.each(clients)("$name operation boundaries", ({ name, make }) => {
+  for (const operation of operations) {
+    it.effect(
+      `${operation.name} stays lazy and creates one child span per execution`,
+      () =>
+        Effect.gen(function* () {
+          const invoke = vi.fn(() => Promise.resolve("found"));
+          const tracer = yield* Tracer.Tracer;
+          const span = vi.fn(tracer.span.bind(tracer));
+          const client = make(invoke);
+          const effect = operation.run(client);
+
+          expect(invoke).not.toHaveBeenCalled();
+          expect(span).not.toHaveBeenCalled();
+
+          const results = yield* Effect.all([effect, effect]).pipe(
+            Effect.withSpan("caller"),
+            Effect.withTracer(Tracer.make({ span })),
+          );
+
+          expect(results).toEqual(["found", "found"]);
+          expect(invoke).toHaveBeenCalledTimes(2);
+          expect(span.mock.calls.map(([options]) => options.name)).toEqual([
+            "caller",
+            `${name}.${operation.name}`,
+            `${name}.${operation.name}`,
+          ]);
+
+          const [parent, ...children] = span.mock.results.map(
+            (result) => result.value,
+          );
+          for (const child of children) {
+            expect(Option.getOrThrow(child.parent)).toBe(parent);
+            expect(child.traceId).toBe(parent.traceId);
+            expect(child.status._tag).toBe("Ended");
+            assert(child.status._tag === "Ended");
+            expect(Exit.isSuccess(child.status.exit)).toBe(true);
+          }
+          expect(children[0]).not.toBe(children[1]);
+        }),
+    );
+
+    it.effect(
+      `${operation.name} preserves typed errors and ends its span with failure`,
+      () =>
+        Effect.gen(function* () {
+          const tracer = yield* Tracer.Tracer;
+          const span = vi.fn(tracer.span.bind(tracer));
+          const client = make(() =>
+            Promise.reject(new ConvexError({ _tag: "NotFound", id: "abc" })),
+          );
+          const result = yield* operation
+            .run(client)
+            .pipe(
+              Effect.result,
+              Effect.withSpan("caller"),
+              Effect.withTracer(Tracer.make({ span })),
+            );
+
+          assert(Result.isFailure(result));
+          expect(result.failure).toEqual(new NotFound({ id: "abc" }));
+          expect(span.mock.calls.map(([options]) => options.name)).toEqual([
+            "caller",
+            `${name}.${operation.name}`,
+          ]);
+          const child = span.mock.results[1]?.value;
+          assert(child !== undefined);
+          assert(child.status._tag === "Ended");
+          assert(Exit.isFailure(child.status.exit));
+          expect(
+            Option.getOrThrow(Cause.findErrorOption(child.status.exit.cause)),
+          ).toBe(result.failure);
+        }),
+    );
+  }
+
+  it.effect(
+    "normalizes omitted args once when constructing the operation",
+    () =>
+      Effect.gen(function* () {
+        const ref = Ref.make(
+          "notes",
+          FunctionSpec.convexPublicQuery<
+            RegisteredQuery<"public", Record<string, never>, string>
+          >()("list"),
+        );
+        const invoke = vi.fn((_args: unknown) => Promise.resolve("found"));
+        const client = make(invoke);
+        const effect = client.query(ref);
+
+        expect(invoke).not.toHaveBeenCalled();
+        yield* effect;
+        yield* effect;
+        expect(invoke.mock.calls[0]?.[0]).toEqual({});
+        expect(invoke.mock.calls[0]?.[0]).toBe(invoke.mock.calls[1]?.[0]);
+
+        yield* client.query(ref);
+        expect(invoke.mock.calls[2]?.[0]).not.toBe(invoke.mock.calls[0]?.[0]);
+      }),
+  );
+});

--- a/packages/js/test/WebSocketClient.test.ts
+++ b/packages/js/test/WebSocketClient.test.ts
@@ -1,5 +1,5 @@
 import { FunctionSpec, Ref } from "@confect/core";
-import { assert, describe, expect, it } from "@effect/vitest";
+import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
 import { getFunctionName, type FunctionType } from "convex/server";
 import { ConvexError } from "convex/values";
 import * as Context from "effect/Context";
@@ -80,6 +80,24 @@ const TestWebSocketClientLayer = Layer.effectContext(
         ],
       }));
 
+    const invokeEffect = Effect.fnUntraced(function* (
+      operation: RequestOperation,
+      functionReference: Parameters<
+        InternalWebSocketClient.Transport[RequestOperation]
+      >[0],
+      args: unknown,
+    ) {
+      yield* recordCall(operation, functionReference, args);
+      const rejection = yield* EffectRef.modify(rejections, (current) => [
+        current[operation],
+        { ...current, [operation]: Option.none() },
+      ]);
+      if (Option.isSome(rejection)) {
+        throw rejection.value;
+      }
+      return {};
+    });
+
     const invoke = (
       operation: RequestOperation,
       functionReference: Parameters<
@@ -87,17 +105,7 @@ const TestWebSocketClientLayer = Layer.effectContext(
       >[0],
       args: unknown,
     ): Promise<unknown> =>
-      Effect.gen(function* () {
-        yield* recordCall(operation, functionReference, args);
-        const rejection = yield* EffectRef.modify(rejections, (current) => [
-          current[operation],
-          { ...current, [operation]: Option.none() },
-        ]);
-        if (Option.isSome(rejection)) {
-          throw rejection.value;
-        }
-        return {};
-      }).pipe(runPromise);
+      runPromise(invokeEffect(operation, functionReference, args));
 
     const service = TestWebSocketTransport.of({
       setAuth: () => {},
@@ -376,6 +384,62 @@ const actionWithError = Ref.make(
 );
 
 describe("WebSocketClient error decoding", () => {
+  it.effect(
+    "preserves generic argument tuples, results, and error channels",
+    () =>
+      Effect.gen(function* () {
+        const client = yield* WebSocketClient.WebSocketClient;
+        expectTypeOf(
+          client.query<typeof noArgsQueryRef>,
+        ).parameters.toEqualTypeOf<[ref: typeof noArgsQueryRef, args?: {}]>();
+        expectTypeOf(
+          client.query<typeof argsQueryRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof argsQueryRef, args: { readonly id: string }]
+        >();
+        expectTypeOf(
+          client.mutation<typeof noArgsMutationRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof noArgsMutationRef, args?: {}]
+        >();
+        expectTypeOf(
+          client.mutation<typeof argsMutationRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof argsMutationRef, args: { readonly text: string }]
+        >();
+        expectTypeOf(
+          client.action<typeof argsActionRef>,
+        ).parameters.toEqualTypeOf<
+          [ref: typeof argsActionRef, args: { readonly to: string }]
+        >();
+        expectTypeOf(
+          client.action<typeof noArgsActionRef>,
+        ).parameters.toEqualTypeOf<[ref: typeof noArgsActionRef, args?: {}]>();
+        expectTypeOf(client.query(queryWithError, { id: "abc" })).toEqualTypeOf<
+          Effect.Effect<
+            { readonly text: string },
+            NotFound | WebSocketClient.WebSocketClientError | Schema.SchemaError
+          >
+        >();
+        expectTypeOf(
+          client.mutation(mutationWithError, { id: "abc" }),
+        ).toEqualTypeOf<
+          Effect.Effect<
+            null,
+            NotFound | WebSocketClient.WebSocketClientError | Schema.SchemaError
+          >
+        >();
+        expectTypeOf(
+          client.action(actionWithError, { id: "abc" }),
+        ).toEqualTypeOf<
+          Effect.Effect<
+            null,
+            NotFound | WebSocketClient.WebSocketClientError | Schema.SchemaError
+          >
+        >();
+      }).pipe(Effect.provide(TestWebSocketClientLayer)),
+  );
+
   it.effect("decodes a query ConvexError", () =>
     Effect.gen(function* () {
       const transport = yield* TestWebSocketTransport;

--- a/packages/react/test/useStreamPaginatedQuery.test.ts
+++ b/packages/react/test/useStreamPaginatedQuery.test.ts
@@ -2,6 +2,7 @@ import { FunctionSpec, Ref } from "@confect/core";
 import { act, renderHook } from "@testing-library/react";
 import { ConvexError } from "convex/values";
 import * as Schema from "effect/Schema";
+import * as MutableRef from "effect/MutableRef";
 import { assert, beforeEach, describe, expect, test } from "@effect/vitest";
 import { vi } from "vitest";
 import { useStreamPaginatedQuery } from "@confect/react";
@@ -56,10 +57,10 @@ const listOrFail = Ref.make(
  * page's `paginationOpts` — so tests observe exactly which page ranges the
  * hook subscribes, and control when each loads.
  */
-let responses: Map<string, unknown>;
+const responses = MutableRef.make(new Map<string, unknown>());
 
 const respond = (paginationOpts: object, result: unknown) => {
-  responses.set(JSON.stringify(paginationOpts), result);
+  MutableRef.get(responses).set(JSON.stringify(paginationOpts), result);
 };
 
 const subscribedOpts = () =>
@@ -78,14 +79,16 @@ const subscribedOpts = () =>
 const current = <A>(result: { readonly current: A }): A => result.current;
 
 beforeEach(() => {
-  responses = new Map();
+  MutableRef.set(responses, new Map());
   useQueriesMock.mockReset();
   useQueriesMock.mockImplementation(
     (queries: Record<string, { args: { paginationOpts: unknown } }>) =>
       Object.fromEntries(
         Object.entries(queries).map(([key, request]) => [
           key,
-          responses.get(JSON.stringify(request.args.paginationOpts)),
+          MutableRef.get(responses).get(
+            JSON.stringify(request.args.paginationOpts),
+          ),
         ]),
       ),
   );

--- a/packages/server/src/ActionRunner.ts
+++ b/packages/server/src/ActionRunner.ts
@@ -1,9 +1,13 @@
 import * as Ref from "@confect/core/Ref";
 import { type GenericActionCtx } from "convex/server";
-import type { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import * as Context from "effect/Context";
 import * as Layer from "effect/Layer";
 import type * as Schema from "effect/Schema";
+
+const run = Effect.fn("ActionRunner.run")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
 
 const make =
   (runAction: GenericActionCtx<any>["runAction"]) =>
@@ -14,11 +18,13 @@ const make =
     Ref.Returns<Action>,
     Ref.Error<Action> | Schema.SchemaError
   > =>
-    Ref.runWithCodec(
-      action,
-      (args[0] ?? {}) as Ref.Args<Action>,
-      (functionReference, encodedArgs) =>
-        runAction(functionReference, encodedArgs),
+    run(
+      Ref.runWithCodec(
+        action,
+        (args[0] ?? {}) as Ref.Args<Action>,
+        (functionReference, encodedArgs) =>
+          runAction(functionReference, encodedArgs),
+      ),
     );
 
 export const ActionRunner = Context.Service<ReturnType<typeof make>>(

--- a/packages/server/src/DatabaseWriter.ts
+++ b/packages/server/src/DatabaseWriter.ts
@@ -105,95 +105,92 @@ export const make = <DatabaseSchema_ extends DatabaseSchema.AnyWithProps>(
       TableName
     >;
 
-    const insert = (
+    const insert = Effect.fn("DatabaseWriter.insert")(function* (
       document: Document.WithoutSystemFields<
         DocumentByName_<DataModel_, TableName>
       >,
-    ) =>
-      Effect.gen(function* () {
-        const encodedDocument = yield* Document.encode(
-          document,
+    ) {
+      const encodedDocument = yield* Document.encode(
+        document,
+        tableName,
+        tableDef.Fields,
+      );
+
+      const id = yield* Effect.promise(() =>
+        convexDatabaseWriter.insert(
           tableName,
-          tableDef.Fields,
-        );
+          encodedDocument as WithoutSystemFields<
+            DocumentByName<DataModel.ToConvex<DataModel_>, TableName>
+          >,
+        ),
+      );
 
-        const id = yield* Effect.promise(() =>
-          convexDatabaseWriter.insert(
-            tableName,
-            encodedDocument as WithoutSystemFields<
-              DocumentByName<DataModel.ToConvex<DataModel_>, TableName>
-            >,
-          ),
-        );
+      return id;
+    });
 
-        return id;
-      });
-
-    const patch = (
+    const patch = Effect.fn("DatabaseWriter.patch")(function* (
       id: GenericId<TableName>,
       patchedValues: PatchValue<
         Document.WithoutSystemFields<DocumentByName_<DataModel_, TableName>>
       >,
-    ) =>
-      Effect.gen(function* () {
-        const tableSchema = tableDef.Fields as TableInfo.TableSchema<
-          DataModel.TableInfoWithName_<DataModel_, TableName>
-        >;
+    ) {
+      const tableSchema = tableDef.Fields as TableInfo.TableSchema<
+        DataModel.TableInfoWithName_<DataModel_, TableName>
+      >;
 
-        const originalDecodedDoc = yield* QueryInitializer.getById(
-          tableName,
-          convexDatabaseWriter as any,
-          tableDef,
-        )(id);
+      const originalDecodedDoc = yield* QueryInitializer.getById(
+        tableName,
+        convexDatabaseWriter as any,
+        tableDef,
+      )(id);
 
-        const updatedEncodedDoc = yield* pipe(
-          patchedValues,
-          Record.reduce(originalDecodedDoc, (acc, value, key) =>
-            value === undefined
-              ? Record.remove(acc, key)
-              : Record.set(acc, key, value),
-          ),
-          Document.encode(tableName, tableSchema),
-        );
+      const updatedEncodedDoc = yield* pipe(
+        patchedValues,
+        Record.reduce(originalDecodedDoc, (acc, value, key) =>
+          value === undefined
+            ? Record.remove(acc, key)
+            : Record.set(acc, key, value),
+        ),
+        Document.encode(tableName, tableSchema),
+      );
 
-        yield* Effect.promise(() =>
-          convexDatabaseWriter.replace(
-            id,
-            updatedEncodedDoc as Expand<
-              BetterOmit<
-                DocumentByName<DataModel.ToConvex<DataModel_>, TableName>,
-                "_creationTime" | "_id"
-              >
-            >,
-          ),
-        );
-      });
+      yield* Effect.promise(() =>
+        convexDatabaseWriter.replace(
+          id,
+          updatedEncodedDoc as Expand<
+            BetterOmit<
+              DocumentByName<DataModel.ToConvex<DataModel_>, TableName>,
+              "_creationTime" | "_id"
+            >
+          >,
+        ),
+      );
+    });
 
-    const replace = (
+    const replace = Effect.fn("DatabaseWriter.replace")(function* (
       id: GenericId<TableName>,
       value: Document.WithoutSystemFields<
         DocumentByName_<DataModel_, TableName>
       >,
-    ) =>
-      Effect.gen(function* () {
-        const updatedEncodedDoc = yield* Document.encode(
-          value,
-          tableName,
-          tableDef.Fields,
-        );
+    ) {
+      const updatedEncodedDoc = yield* Document.encode(
+        value,
+        tableName,
+        tableDef.Fields,
+      );
 
-        yield* Effect.promise(() =>
-          convexDatabaseWriter.replace(
-            id,
-            updatedEncodedDoc as Expand<
-              BetterOmit<
-                DocumentByName<DataModel.ToConvex<DataModel_>, TableName>,
-                "_creationTime" | "_id"
-              >
-            >,
-          ),
-        );
-      });
+      yield* Effect.promise(() =>
+        convexDatabaseWriter.replace(
+          id,
+          updatedEncodedDoc as Expand<
+            BetterOmit<
+              DocumentByName<DataModel.ToConvex<DataModel_>, TableName>,
+              "_creationTime" | "_id"
+            >
+          >,
+        ),
+      );
+    });
 
     const delete_ = (id: GenericId<TableName>) =>
       Effect.promise(() => convexDatabaseWriter.delete(id));

--- a/packages/server/src/MutationRunner.ts
+++ b/packages/server/src/MutationRunner.ts
@@ -1,9 +1,13 @@
 import * as Ref from "@confect/core/Ref";
 import { type GenericActionCtx } from "convex/server";
-import type { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import * as Context from "effect/Context";
 import * as Layer from "effect/Layer";
 import type * as Schema from "effect/Schema";
+
+const run = Effect.fn("MutationRunner.run")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
 
 const make =
   (runMutation: GenericActionCtx<any>["runMutation"]) =>
@@ -14,11 +18,13 @@ const make =
     Ref.Returns<Mutation>,
     Ref.Error<Mutation> | Schema.SchemaError
   > =>
-    Ref.runWithCodec(
-      mutation,
-      (args[0] ?? {}) as Ref.Args<Mutation>,
-      (functionReference, encodedArgs) =>
-        runMutation(functionReference, encodedArgs),
+    run(
+      Ref.runWithCodec(
+        mutation,
+        (args[0] ?? {}) as Ref.Args<Mutation>,
+        (functionReference, encodedArgs) =>
+          runMutation(functionReference, encodedArgs),
+      ),
     );
 
 export const MutationRunner = Context.Service<ReturnType<typeof make>>(

--- a/packages/server/src/OrderedQuery.ts
+++ b/packages/server/src/OrderedQuery.ts
@@ -67,33 +67,34 @@ export const make = <
   const collect: OrderedQueryFunction<"collect"> = () =>
     pipe(stream(), Stream.runCollect);
 
-  const paginate: OrderedQueryFunction<"paginate"> = (options, filter) =>
-    Effect.gen(function* () {
-      const filteredQuery = filter !== undefined ? query.filter(filter) : query;
+  const paginate: OrderedQueryFunction<"paginate"> = Effect.fn(
+    "OrderedQuery.paginate",
+  )(function* (options, filter) {
+    const filteredQuery = filter !== undefined ? query.filter(filter) : query;
 
-      const paginationResult = yield* Effect.promise(() =>
-        filteredQuery.paginate(options),
-      );
+    const paginationResult = yield* Effect.promise(() =>
+      filteredQuery.paginate(options),
+    );
 
-      const parsedPage = yield* Effect.forEach(
-        paginationResult.page,
-        Document.decode(tableName, tableSchema),
-      );
+    const parsedPage = yield* Effect.forEach(
+      paginationResult.page,
+      Document.decode(tableName, tableSchema),
+    );
 
-      return {
-        page: parsedPage,
-        isDone: paginationResult.isDone,
-        continueCursor: paginationResult.continueCursor,
-        /* v8 ignore start */
-        ...(paginationResult.splitCursor
-          ? { splitCursor: paginationResult.splitCursor }
-          : {}),
-        ...(paginationResult.pageStatus
-          ? { pageStatus: paginationResult.pageStatus }
-          : {}),
-        /* v8 ignore stop */
-      };
-    });
+    return {
+      page: parsedPage,
+      isDone: paginationResult.isDone,
+      continueCursor: paginationResult.continueCursor,
+      /* v8 ignore start */
+      ...(paginationResult.splitCursor
+        ? { splitCursor: paginationResult.splitCursor }
+        : {}),
+      ...(paginationResult.pageStatus
+        ? { pageStatus: paginationResult.pageStatus }
+        : {}),
+      /* v8 ignore stop */
+    };
+  });
 
   return {
     first,

--- a/packages/server/src/QueryRunner.ts
+++ b/packages/server/src/QueryRunner.ts
@@ -1,9 +1,13 @@
 import * as Ref from "@confect/core/Ref";
 import { type GenericActionCtx } from "convex/server";
-import type { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import * as Context from "effect/Context";
 import * as Layer from "effect/Layer";
 import type * as Schema from "effect/Schema";
+
+const run = Effect.fn("QueryRunner.run")(
+  <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> => effect,
+);
 
 const make =
   (runQuery: GenericActionCtx<any>["runQuery"]) =>
@@ -11,11 +15,13 @@ const make =
     query: Query,
     ...args: Ref.OptionalArgs<Query>
   ): Effect.Effect<Ref.Returns<Query>, Ref.Error<Query> | Schema.SchemaError> =>
-    Ref.runWithCodec(
-      query,
-      (args[0] ?? {}) as Ref.Args<Query>,
-      (functionReference, encodedArgs) =>
-        runQuery(functionReference, encodedArgs),
+    run(
+      Ref.runWithCodec(
+        query,
+        (args[0] ?? {}) as Ref.Args<Query>,
+        (functionReference, encodedArgs) =>
+          runQuery(functionReference, encodedArgs),
+      ),
     );
 
 export const QueryRunner = Context.Service<ReturnType<typeof make>>(

--- a/packages/server/test/AiGatewayLanguageModel.test.ts
+++ b/packages/server/test/AiGatewayLanguageModel.test.ts
@@ -263,12 +263,13 @@ const RequestBody = Schema.fromJsonString(
   }),
 );
 
-const requestBody = (request: HttpClientRequest.HttpClientRequest) =>
-  Effect.gen(function* () {
-    if (request.body._tag !== "Uint8Array") {
-      return yield* Effect.die(new Error("Expected a Uint8Array request body"));
-    }
-    return yield* Schema.decodeEffect(RequestBody)(
-      new TextDecoder().decode(request.body.body),
-    );
-  });
+const requestBody = Effect.fnUntraced(function* (
+  request: HttpClientRequest.HttpClientRequest,
+) {
+  if (request.body._tag !== "Uint8Array") {
+    return yield* Effect.die(new Error("Expected a Uint8Array request body"));
+  }
+  return yield* Schema.decodeEffect(RequestBody)(
+    new TextDecoder().decode(request.body.body),
+  );
+});

--- a/packages/server/test/FunctionImpl.test.ts
+++ b/packages/server/test/FunctionImpl.test.ts
@@ -28,17 +28,16 @@ const handler = (() => Effect.succeed(null)) as never;
  * `RegisteredFunctions.buildForGroup` and the CLI's `validateImpl` build a
  * group's impl layer) and return the resulting `RegistryItems` tree.
  */
-const collectRegistry = <RIn>(
+const collectRegistry = Effect.fnUntraced(function* <RIn>(
   layer: Layer.Layer<RIn, never, never>,
-): Effect.Effect<RegistryItems.RegistryItems> =>
-  Effect.gen(function* () {
-    const ref = yield* Ref.make<RegistryItems.RegistryItems>({});
-    yield* Layer.build(layer).pipe(
-      Effect.scoped,
-      Effect.provideService(Registry.Registry, ref),
-    );
-    return yield* Ref.get(ref);
-  });
+): Effect.fn.Return<RegistryItems.RegistryItems> {
+  const ref = yield* Ref.make<RegistryItems.RegistryItems>({});
+  yield* Layer.build(layer).pipe(
+    Effect.scoped,
+    Effect.provideService(Registry.Registry, ref),
+  );
+  return yield* Ref.get(ref);
+});
 
 describe("FunctionImpl.make", () => {
   it.effect(

--- a/packages/server/test/internal/utils.test.ts
+++ b/packages/server/test/internal/utils.test.ts
@@ -16,19 +16,18 @@ interface BranchLeaves<T> {
   readonly values: Record<string, T>;
 }
 
-const collectLeaves = <T>(
+const collectLeaves = Effect.fnUntraced(function* <T>(
   obj: NestedObject<T>,
   refinement: Predicate.Refinement<unknown, T>,
-) =>
-  Effect.gen(function* () {
-    const results = yield* Ref.make<ReadonlyArray<BranchLeaves<T>>>([]);
+) {
+  const results = yield* Ref.make<ReadonlyArray<BranchLeaves<T>>>([]);
 
-    yield* forEachBranchLeaves(obj, refinement, (branch) =>
-      Ref.update(results, (previous) => [...previous, branch]),
-    );
+  yield* forEachBranchLeaves(obj, refinement, (branch) =>
+    Ref.update(results, (previous) => [...previous, branch]),
+  );
 
-    return yield* Ref.get(results);
-  });
+  return yield* Ref.get(results);
+});
 
 describe("setNestedProperty", () => {
   describe("single-level path", () => {

--- a/packages/server/test/local-backend/convexQueryCacheBehavior.test.ts
+++ b/packages/server/test/local-backend/convexQueryCacheBehavior.test.ts
@@ -43,17 +43,15 @@ const SLEEP_PAST_CACHE = Duration.sum(
   Duration.seconds(1),
 );
 
-const captureAcrossEvictionWindow = <PublicQueryRef extends Ref.AnyPublicQuery>(
-  ref: PublicQueryRef,
-  ...args: Ref.OptionalArgs<PublicQueryRef>
-) =>
-  Effect.gen(function* () {
-    const { client } = yield* LocalBackend.LocalBackend;
-    const initial = yield* queryOnce(client, ref, ...args);
-    yield* Effect.sleep(SLEEP_PAST_CACHE);
-    const afterMaxCacheAge = yield* queryOnce(client, ref, ...args);
-    return { initial, afterMaxCacheAge };
-  });
+const captureAcrossEvictionWindow = Effect.fnUntraced(function* <
+  PublicQueryRef extends Ref.AnyPublicQuery,
+>(ref: PublicQueryRef, ...args: Ref.OptionalArgs<PublicQueryRef>) {
+  const { client } = yield* LocalBackend.LocalBackend;
+  const initial = yield* queryOnce(client, ref, ...args);
+  yield* Effect.sleep(SLEEP_PAST_CACHE);
+  const afterMaxCacheAge = yield* queryOnce(client, ref, ...args);
+  return { initial, afterMaxCacheAge };
+});
 
 // `excludeTestServices: true` opts out of `TestClock` so `Effect.sleep`
 // waits real wall-clock time and actually crosses the eviction window.

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.impl.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.impl.ts
@@ -9,18 +9,19 @@
 import { FunctionImpl, GroupImpl } from "@confect/server";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as MutableRef from "effect/MutableRef";
 import databaseSchema from "../_generated/schema";
 import scheduling from "./scheduling.spec";
 
 const sumToN = Effect.fnUntraced(function* (n: number) {
-  let sum = 0;
+  const sum = MutableRef.make(0);
   for (let i = 1; i <= n; i++) {
     // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
     // unwraps without touching the op counter) charges the fiber's op
     // budget on every iteration.
-    sum += yield* Effect.sync(() => i);
+    MutableRef.set(sum, MutableRef.get(sum) + (yield* Effect.sync(() => i)));
   }
-  return sum;
+  return MutableRef.get(sum);
 });
 
 const manyOpsQuery = FunctionImpl.make(

--- a/packages/server/test/local-backend/fixtures/confect/groups/scheduling.impl.ts
+++ b/packages/server/test/local-backend/fixtures/confect/groups/scheduling.impl.ts
@@ -12,17 +12,16 @@ import * as Layer from "effect/Layer";
 import databaseSchema from "../_generated/schema";
 import scheduling from "./scheduling.spec";
 
-const sumToN = (n: number) =>
-  Effect.gen(function* () {
-    let sum = 0;
-    for (let i = 1; i <= n; i++) {
-      // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
-      // unwraps without touching the op counter) charges the fiber's op
-      // budget on every iteration.
-      sum += yield* Effect.sync(() => i);
-    }
-    return sum;
-  });
+const sumToN = Effect.fnUntraced(function* (n: number) {
+  let sum = 0;
+  for (let i = 1; i <= n; i++) {
+    // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
+    // unwraps without touching the op counter) charges the fiber's op
+    // budget on every iteration.
+    sum += yield* Effect.sync(() => i);
+  }
+  return sum;
+});
 
 const manyOpsQuery = FunctionImpl.make(
   databaseSchema,

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.impl.ts
@@ -9,18 +9,19 @@
 import { FunctionImpl, GroupImpl } from "@confect/server";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as MutableRef from "effect/MutableRef";
 import databaseSchema from "../_generated/schema";
 import scheduling from "./scheduling.spec";
 
 const sumToN = Effect.fnUntraced(function* (n: number) {
-  let sum = 0;
+  const sum = MutableRef.make(0);
   for (let i = 1; i <= n; i++) {
     // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
     // unwraps without touching the op counter) charges the fiber's op
     // budget on every iteration.
-    sum += yield* Effect.sync(() => i);
+    MutableRef.set(sum, MutableRef.get(sum) + (yield* Effect.sync(() => i)));
   }
-  return sum;
+  return MutableRef.get(sum);
 });
 
 const manyOpsQuery = FunctionImpl.make(

--- a/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.impl.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/groups/scheduling.impl.ts
@@ -12,17 +12,16 @@ import * as Layer from "effect/Layer";
 import databaseSchema from "../_generated/schema";
 import scheduling from "./scheduling.spec";
 
-const sumToN = (n: number) =>
-  Effect.gen(function* () {
-    let sum = 0;
-    for (let i = 1; i <= n; i++) {
-      // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
-      // unwraps without touching the op counter) charges the fiber's op
-      // budget on every iteration.
-      sum += yield* Effect.sync(() => i);
-    }
-    return sum;
-  });
+const sumToN = Effect.fnUntraced(function* (n: number) {
+  let sum = 0;
+  for (let i = 1; i <= n; i++) {
+    // `Effect.sync` (unlike `Effect.succeed`, which the generator runtime
+    // unwraps without touching the op counter) charges the fiber's op
+    // budget on every iteration.
+    sum += yield* Effect.sync(() => i);
+  }
+  return sum;
+});
 
 const manyOpsQuery = FunctionImpl.make(
   databaseSchema,

--- a/packages/server/test/mock-backend/fixtures/confect/middleware/insertMarker.ts
+++ b/packages/server/test/mock-backend/fixtures/confect/middleware/insertMarker.ts
@@ -6,9 +6,8 @@ import { DatabaseWriter } from "../_generated/services";
  * in by appending to the `notes` table. Server-only, and imported only by
  * `*.impl.ts` modules — a `*.spec.ts` may not reach it.
  */
-export const insertMarker = (text: string) =>
-  Effect.gen(function* () {
-    const writer = yield* DatabaseWriter;
+export const insertMarker = Effect.fnUntraced(function* (text: string) {
+  const writer = yield* DatabaseWriter;
 
-    yield* writer.table("notes").insert({ text });
-  }).pipe(Effect.orDie);
+  yield* writer.table("notes").insert({ text });
+}, Effect.orDie);

--- a/packages/server/test/mock-backend/middleware.test.ts
+++ b/packages/server/test/mock-backend/middleware.test.ts
@@ -21,16 +21,15 @@ const expectFailure = <A, E>(result: Result.Result<A, E>): E => {
   return result.failure;
 };
 
-const insertUser = (username: string) =>
-  Effect.gen(function* () {
-    const c = yield* TestConfect.TestConfect;
-    yield* c.run(
-      Effect.gen(function* () {
-        const writer = yield* DatabaseWriter;
-        yield* writer.table("users").insert({ username });
-      }),
-    );
-  }).pipe(Effect.orDie);
+const insertUser = Effect.fnUntraced(function* (username: string) {
+  const c = yield* TestConfect.TestConfect;
+  yield* c.run(
+    Effect.gen(function* () {
+      const writer = yield* DatabaseWriter;
+      yield* writer.table("users").insert({ username });
+    }),
+  );
+}, Effect.orDie);
 
 const listNoteTexts = Effect.gen(function* () {
   const c = yield* TestConfect.TestConfect;

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -44,14 +44,13 @@ const paginateAll = <Doc, Key extends ReadonlyArray<string>, E, R>(
   return go(null, []);
 };
 
-const insertNotes = (texts: ReadonlyArray<string>) =>
-  Effect.gen(function* () {
-    const writer = yield* DatabaseWriter;
+const insertNotes = Effect.fnUntraced(function* (texts: ReadonlyArray<string>) {
+  const writer = yield* DatabaseWriter;
 
-    yield* Effect.forEach(texts, (text) =>
-      writer.table("notes").insert({ text }),
-    );
-  });
+  yield* Effect.forEach(texts, (text) =>
+    writer.table("notes").insert({ text }),
+  );
+});
 
 describe("QueryStream", () => {
   it.effect("emits documents in index order", () =>

--- a/packages/server/test/tracing.test.ts
+++ b/packages/server/test/tracing.test.ts
@@ -1,0 +1,305 @@
+import { FunctionSpec, Ref, Table } from "@confect/core";
+import * as ActionRunner from "@confect/server/ActionRunner";
+import type * as DataModel from "@confect/server/DataModel";
+import * as DatabaseSchema from "@confect/server/DatabaseSchema";
+import * as DatabaseWriter from "@confect/server/DatabaseWriter";
+import * as Document from "@confect/server/Document";
+import * as MutationRunner from "@confect/server/MutationRunner";
+import * as OrderedQuery from "@confect/server/OrderedQuery";
+import * as QueryRunner from "@confect/server/QueryRunner";
+import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
+import type {
+  GenericActionCtx,
+  GenericDatabaseWriter,
+  GenericDataModel,
+  OrderedQuery as ConvexOrderedQuery,
+} from "convex/server";
+import { ConvexError, type GenericId } from "convex/values";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Tracer from "effect/Tracer";
+import { vi } from "vitest";
+
+class OperationFailure extends Schema.TaggedError<OperationFailure>()(
+  "OperationFailure",
+  { reason: Schema.String },
+) {}
+
+const queryRef = Ref.make(
+  "operations",
+  FunctionSpec.internalQuery({
+    name: "query",
+    args: () => ({ value: Schema.FiniteFromString }),
+    returns: () => Schema.FiniteFromString,
+    error: () => OperationFailure,
+  }),
+);
+const mutationRef = Ref.make(
+  "operations",
+  FunctionSpec.internalMutation({
+    name: "mutation",
+    args: () => ({ value: Schema.FiniteFromString }),
+    returns: () => Schema.FiniteFromString,
+    error: () => OperationFailure,
+  }),
+);
+const actionRef = Ref.make(
+  "operations",
+  FunctionSpec.internalAction({
+    name: "action",
+    args: () => ({ value: Schema.FiniteFromString }),
+    returns: () => Schema.FiniteFromString,
+    error: () => OperationFailure,
+  }),
+);
+
+const makeRecorder = Effect.gen(function* () {
+  const baseTracer = yield* Effect.service(Tracer.Tracer);
+  const spans: Array<Tracer.Span> = [];
+  const tracer = Tracer.make({
+    span(options) {
+      const span = baseTracer.span(options);
+      spans.push(span);
+      return span;
+    },
+  });
+  return { spans, tracer };
+});
+
+const notes = Table.make(() =>
+  Schema.Struct({ value: Schema.FiniteFromString }),
+)("notes");
+const databaseSchema = DatabaseSchema.make({ notes });
+type ConvexDataModel = DataModel.ToConvex<
+  DataModel.FromSchema<typeof databaseSchema>
+>;
+const noteId = "note-id" as GenericId<"notes">;
+
+describe("server operation tracing", () => {
+  it.effect(
+    "traces lazy, repeatable RPC calls without a codec child span",
+    () =>
+      Effect.gen(function* () {
+        const recorder = yield* makeRecorder;
+        const invoke = vi
+          .fn<(ref: unknown, args: unknown) => Promise<unknown>>()
+          .mockResolvedValue("7");
+
+        yield* Effect.gen(function* () {
+          const runQuery = yield* QueryRunner.QueryRunner;
+          const runMutation = yield* MutationRunner.MutationRunner;
+          const runAction = yield* ActionRunner.ActionRunner;
+          const query = runQuery(queryRef, { value: 2 });
+          const mutation = runMutation(mutationRef, { value: 3 });
+          const action = runAction(actionRef, { value: 4 });
+
+          expectTypeOf(query).toEqualTypeOf<
+            Effect.Effect<number, OperationFailure | Schema.SchemaError>
+          >();
+          expectTypeOf(mutation).toEqualTypeOf<typeof query>();
+          expectTypeOf(action).toEqualTypeOf<typeof query>();
+          expect(invoke).not.toHaveBeenCalled();
+          expect(recorder.spans).toEqual([]);
+
+          const result = yield* Effect.all([
+            query,
+            mutation,
+            action,
+            query,
+          ]).pipe(
+            Effect.withSpan("caller"),
+            Effect.withTracer(recorder.tracer),
+          );
+          expect(result).toEqual([7, 7, 7, 7]);
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              QueryRunner.layer(
+                invoke as GenericActionCtx<GenericDataModel>["runQuery"],
+              ),
+              MutationRunner.layer(
+                invoke as GenericActionCtx<GenericDataModel>["runMutation"],
+              ),
+              ActionRunner.layer(
+                invoke as GenericActionCtx<GenericDataModel>["runAction"],
+              ),
+            ),
+          ),
+        );
+
+        expect(invoke.mock.calls.map(([, args]) => args)).toEqual([
+          { value: "2" },
+          { value: "3" },
+          { value: "4" },
+          { value: "2" },
+        ]);
+        expect(recorder.spans.map((span) => span.name)).toEqual([
+          "caller",
+          "QueryRunner.run",
+          "MutationRunner.run",
+          "ActionRunner.run",
+          "QueryRunner.run",
+        ]);
+        for (const span of recorder.spans.slice(1)) {
+          expect(Option.getOrThrow(span.parent)).toBe(recorder.spans[0]);
+          assert(span.status._tag === "Ended");
+          assert.isTrue(Exit.isSuccess(span.status.exit));
+        }
+      }),
+  );
+
+  it.effect(
+    "records RPC failure before caller recovery and preserves typed errors",
+    () =>
+      Effect.gen(function* () {
+        const recorder = yield* makeRecorder;
+        const invoke = vi
+          .fn<(ref: unknown, args: unknown) => Promise<unknown>>()
+          .mockRejectedValue(
+            new ConvexError({ _tag: "OperationFailure", reason: "rejected" }),
+          );
+        const error = yield* Effect.gen(function* () {
+          const runQuery = yield* QueryRunner.QueryRunner;
+          return yield* Effect.flip(runQuery(queryRef, { value: 2 }));
+        }).pipe(
+          Effect.provide(
+            QueryRunner.layer(
+              invoke as GenericActionCtx<GenericDataModel>["runQuery"],
+            ),
+          ),
+          Effect.withTracer(recorder.tracer),
+        );
+
+        assert.instanceOf(error, OperationFailure);
+        expect(error.reason).toBe("rejected");
+        expect(recorder.spans).toHaveLength(1);
+        const span = recorder.spans[0]!;
+        expect(span.name).toBe("QueryRunner.run");
+        assert(span.status._tag === "Ended");
+        assert.isTrue(Exit.isFailure(span.status.exit));
+      }),
+  );
+
+  it.effect(
+    "traces complete database writes and keeps encoding and reads lazy",
+    () =>
+      Effect.gen(function* () {
+        const recorder = yield* makeRecorder;
+        const insert = vi
+          .fn<GenericDatabaseWriter<ConvexDataModel>["insert"]>()
+          .mockResolvedValue(noteId);
+        const replace = vi
+          .fn<GenericDatabaseWriter<ConvexDataModel>["replace"]>()
+          .mockResolvedValue(undefined);
+        const get = vi
+          .fn<GenericDatabaseWriter<ConvexDataModel>["get"]>()
+          .mockResolvedValue({ _id: noteId, _creationTime: 1, value: "1" });
+        const writer = DatabaseWriter.make(databaseSchema, {
+          insert,
+          replace,
+          get,
+        } as unknown as GenericDatabaseWriter<ConvexDataModel>).table("notes");
+        const insertEffect = writer.insert({ value: 2 });
+        const patchEffect = writer.patch(noteId, { value: 3 });
+        const replaceEffect = writer.replace(noteId, { value: 4 });
+
+        expect(insert).not.toHaveBeenCalled();
+        expect(replace).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalled();
+        expect(recorder.spans).toEqual([]);
+
+        yield* Effect.all([
+          insertEffect,
+          patchEffect,
+          replaceEffect,
+          insertEffect,
+        ]).pipe(Effect.withTracer(recorder.tracer));
+
+        expect(insert.mock.calls).toEqual([
+          ["notes", { value: "2" }],
+          ["notes", { value: "2" }],
+        ]);
+        expect(get).toHaveBeenCalledExactlyOnceWith(noteId);
+        expect(replace.mock.calls).toEqual([
+          [noteId, { value: "3" }],
+          [noteId, { value: "4" }],
+        ]);
+        expect(recorder.spans.map((span) => span.name)).toEqual([
+          "DatabaseWriter.insert",
+          "DatabaseWriter.patch",
+          "DatabaseWriter.replace",
+          "DatabaseWriter.insert",
+        ]);
+      }),
+  );
+
+  it.effect("keeps document encoding failures inside the write span", () =>
+    Effect.gen(function* () {
+      const recorder = yield* makeRecorder;
+      const replace =
+        vi.fn<GenericDatabaseWriter<ConvexDataModel>["replace"]>();
+      const get = vi
+        .fn<GenericDatabaseWriter<ConvexDataModel>["get"]>()
+        .mockResolvedValue({ _id: noteId, _creationTime: 1, value: "1" });
+      const writer = DatabaseWriter.make(databaseSchema, {
+        replace,
+        get,
+      } as unknown as GenericDatabaseWriter<ConvexDataModel>).table("notes");
+      const error = yield* writer
+        .patch(noteId, { value: "invalid" as never })
+        .pipe(Effect.flip, Effect.withTracer(recorder.tracer));
+
+      assert.instanceOf(error, Document.DocumentEncodeError);
+      expect(replace).not.toHaveBeenCalled();
+      expect(recorder.spans).toHaveLength(1);
+      const span = recorder.spans[0]!;
+      expect(span.name).toBe("DatabaseWriter.patch");
+      assert(span.status._tag === "Ended");
+      assert.isTrue(Exit.isFailure(span.status.exit));
+    }),
+  );
+
+  it.effect(
+    "traces pagination through decoding and preserves lazy filter execution",
+    () =>
+      Effect.gen(function* () {
+        const recorder = yield* makeRecorder;
+        const paginate = vi
+          .fn<ConvexOrderedQuery<ConvexDataModel["notes"]>["paginate"]>()
+          .mockResolvedValue({
+            page: [{ _id: noteId, _creationTime: 1, value: "7" }],
+            isDone: true,
+            continueCursor: "done",
+          });
+        const filter = vi.fn();
+        const query = { paginate, filter } as unknown as ConvexOrderedQuery<
+          ConvexDataModel["notes"]
+        >;
+        filter.mockReturnValue(query);
+        const operation = OrderedQuery.make(query, "notes", notes.Fields);
+        const predicate: Parameters<typeof operation.paginate>[1] = (q) =>
+          q.eq(q.field("value"), "7");
+        const options = { numItems: 1, cursor: null };
+        const page = operation.paginate(options, predicate);
+
+        expect(filter).not.toHaveBeenCalled();
+        expect(paginate).not.toHaveBeenCalled();
+        const results = yield* Effect.all([page, page]).pipe(
+          Effect.withTracer(recorder.tracer),
+        );
+        expect(results[0]?.page).toEqual([
+          { _id: noteId, _creationTime: 1, value: 7 },
+        ]);
+        expect(results[1]).toEqual(results[0]);
+        expect(filter.mock.calls).toEqual([[predicate], [predicate]]);
+        expect(paginate.mock.calls).toEqual([[options], [options]]);
+        expect(recorder.spans.map((span) => span.name)).toEqual([
+          "OrderedQuery.paginate",
+          "OrderedQuery.paginate",
+        ]);
+      }),
+  );
+});

--- a/scripts/streamDiagrams.ts
+++ b/scripts/streamDiagrams.ts
@@ -297,34 +297,33 @@ const MARKED_BLOCK =
   /\{\/\* stream-diagram: ([a-z-]+) \*\/\}\n\n?```text\n[\s\S]*?\n```/g;
 
 /** The page with every marked diagram block regenerated. */
-export const renderDiagrams = (
+export const renderDiagrams = Effect.fnUntraced(function* (
   source: string,
-): Effect.Effect<string, StreamDiagramsError> =>
-  Effect.gen(function* () {
-    const seen = new Set<string>();
-    let unknown: string | undefined;
-    const rendered = source.replace(MARKED_BLOCK, (match, name: string) => {
-      const diagram = diagrams[name];
-      if (diagram === undefined) {
-        unknown ??= name;
-        return match;
-      }
-      seen.add(name);
-      return `{/* stream-diagram: ${name} */}\n\n\`\`\`text\n${diagram}\n\`\`\``;
-    });
-    if (unknown !== undefined) {
-      return yield* new StreamDiagramsError({
-        reason: `${PAGE} references an unknown diagram: ${unknown}`,
-      });
+): Effect.fn.Return<string, StreamDiagramsError> {
+  const seen = new Set<string>();
+  let unknown: string | undefined;
+  const rendered = source.replace(MARKED_BLOCK, (match, name: string) => {
+    const diagram = diagrams[name];
+    if (diagram === undefined) {
+      unknown ??= name;
+      return match;
     }
-    const unused = Object.keys(diagrams).filter((name) => !seen.has(name));
-    if (unused.length > 0) {
-      return yield* new StreamDiagramsError({
-        reason: `${PAGE} has no block for: ${unused.join(", ")}`,
-      });
-    }
-    return rendered;
+    seen.add(name);
+    return `{/* stream-diagram: ${name} */}\n\n\`\`\`text\n${diagram}\n\`\`\``;
   });
+  if (unknown !== undefined) {
+    return yield* new StreamDiagramsError({
+      reason: `${PAGE} references an unknown diagram: ${unknown}`,
+    });
+  }
+  const unused = Object.keys(diagrams).filter((name) => !seen.has(name));
+  if (unused.length > 0) {
+    return yield* new StreamDiagramsError({
+      reason: `${PAGE} has no block for: ${unused.join(", ")}`,
+    });
+  }
+  return rendered;
+});
 
 export interface SyncOptions {
   readonly check?: boolean;

--- a/scripts/syncSkillIgnore.ts
+++ b/scripts/syncSkillIgnore.ts
@@ -42,9 +42,9 @@ export const installedDirectoryName = (name: string): string =>
     .replace(/^[.-]+|[.-]+$/g, "")
     .slice(0, 255) || "unnamed-skill";
 
-export const vendoredSkillDirectories = Effect.fn(
-  "SkillIgnore.vendoredSkillDirectories",
-)(function* (lockText: string) {
+export const vendoredSkillDirectories = Effect.fnUntraced(function* (
+  lockText: string,
+) {
   const lock = yield* Schema.decodeEffect(
     Schema.fromJsonString(Schema.Unknown),
   )(lockText).pipe(
@@ -92,51 +92,50 @@ export const renderManagedBlock = (
     END_MARKER,
   ].join("\n");
 
-export const updateManagedBlock = Effect.fn("SkillIgnore.updateManagedBlock")(
-  function* (ignoreText: string, managedBlock: string) {
-    const lines = ignoreText.replaceAll("\r\n", "\n").split("\n");
-    if (lines.at(-1) === "") lines.pop();
-
-    const startIndexes = lines.flatMap((line, index) =>
-      line === START_MARKER ? [index] : [],
-    );
-    const endIndexes = lines.flatMap((line, index) =>
-      line === END_MARKER ? [index] : [],
-    );
-
-    if (startIndexes.length !== endIndexes.length) {
-      return yield* new SkillIgnoreError({
-        reason: `${IGNORE_FILE} has an incomplete skills-lock block`,
-      });
-    }
-    if (startIndexes.length > 1) {
-      return yield* new SkillIgnoreError({
-        reason: `${IGNORE_FILE} has multiple skills-lock blocks`,
-      });
-    }
-
-    const managedLines = managedBlock.split("\n");
-    if (startIndexes.length === 0) {
-      if (lines.length > 0 && lines.at(-1) !== "") lines.push("");
-      lines.push(...managedLines);
-    } else {
-      const start = startIndexes[0];
-      const end = endIndexes[0];
-      if (start > end) {
-        return yield* new SkillIgnoreError({
-          reason: `${IGNORE_FILE} has an invalid skills-lock block`,
-        });
-      }
-      lines.splice(start, end - start + 1, ...managedLines);
-    }
-
-    return `${lines.join("\n")}\n`;
-  },
-);
-
-const readIgnoreFile = Effect.fn("SkillIgnore.readIgnoreFile")(function* (
-  path: string,
+export const updateManagedBlock = Effect.fnUntraced(function* (
+  ignoreText: string,
+  managedBlock: string,
 ) {
+  const lines = ignoreText.replaceAll("\r\n", "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+
+  const startIndexes = lines.flatMap((line, index) =>
+    line === START_MARKER ? [index] : [],
+  );
+  const endIndexes = lines.flatMap((line, index) =>
+    line === END_MARKER ? [index] : [],
+  );
+
+  if (startIndexes.length !== endIndexes.length) {
+    return yield* new SkillIgnoreError({
+      reason: `${IGNORE_FILE} has an incomplete skills-lock block`,
+    });
+  }
+  if (startIndexes.length > 1) {
+    return yield* new SkillIgnoreError({
+      reason: `${IGNORE_FILE} has multiple skills-lock blocks`,
+    });
+  }
+
+  const managedLines = managedBlock.split("\n");
+  if (startIndexes.length === 0) {
+    if (lines.length > 0 && lines.at(-1) !== "") lines.push("");
+    lines.push(...managedLines);
+  } else {
+    const start = startIndexes[0];
+    const end = endIndexes[0];
+    if (start > end) {
+      return yield* new SkillIgnoreError({
+        reason: `${IGNORE_FILE} has an invalid skills-lock block`,
+      });
+    }
+    lines.splice(start, end - start + 1, ...managedLines);
+  }
+
+  return `${lines.join("\n")}\n`;
+});
+
+const readIgnoreFile = Effect.fnUntraced(function* (path: string) {
   const fs = yield* FileSystem.FileSystem;
   return (yield* fs.exists(path)) ? yield* fs.readFileString(path) : "";
 });


### PR DESCRIPTION
Reusable helpers should express an intentional diagnostic policy rather than defaulting to a fresh `Effect.gen` wrapper, while the operations consumers actually diagnose should expose meaningful boundaries.

- Use `Effect.fnUntraced` for the inventoried internal codec/compiler, CLI/template, maintenance, hook, and test helpers, including CLI per-element callbacks with explicit input types. Preserve eager argument/property capture, generic signatures, receiver behavior, scoped transforms, and per-execution mutable state. Keep standalone effects, initialization, simple Effect compositions, and stream lifetimes unchanged.
- Add named boundaries for the six JavaScript client RPC methods, three server runners, database insert/patch/replace and ordered pagination, and CLI bundling/spec/impl/component validation. Keep the shared codec untraced and give the effect-valued codegen pass a `Cli.codegen` span before caller recovery. Remove the three incidental skill-ignore helper spans while retaining its synchronization boundary.
- Add regression coverage for span hierarchy and success/failure exits, lazy and repeated execution, generic argument/result/error/environment inference, call-time defaults and AST property capture, template reuse, and the writer method's receiver contract. Pin the affected CLI workflow contracts and test direct callback input rejection, index forwarding, required services, generic specialization, and per-execution table path capture. Include a patch changeset for the affected consumer diagnostics.

This implements the approved helper and operation-boundary passes on v10 at `4e5ca7c`. Central request spans, application-handler naming, broader SDK/subscription instrumentation, and unrelated Effect cleanup remain out of scope. No generated files change and no performance improvement is claimed.

Validated:
- `pnpm build` and `pnpm typecheck`
- Affected core, JS, server, CLI, React, and Foldkit Vitest projects passed; latest CLI rerun: 142 passed, no type errors
- All 25 CLI source declaration contracts match the pre-callback-conversion versions; the only textual difference is an equivalent import alias in `dev.d.ts`
- `pnpm test:server:mock-backend`: 265 passed, no type errors
- `pnpm test:server:local-backend`: 9 passed, including cache and scheduler regressions
- Maintenance script tests: 10 passed
- `pnpm lint` and `pnpm format:check`: clean
- Fresh example and both backend fixture codegen outputs match their committed versions