### PR TITLE
Support explicit QueryStream range endpoints

### DIFF
--- a/.changeset/add-query-stream-bounds.md
+++ b/.changeset/add-query-stream-bounds.md
@@ -1,22 +1,5 @@
 ---
-"@confect/server": major
+"@confect/server": minor
 ---
 
-Allow inclusive or exclusive endpoints on either side of an experimental `QueryStream.narrow` range, supporting time windows and selections that include or exclude their boundary items.
-
-Replace `after` and `until` with `start` and `end` objects, providing at least one endpoint. Each endpoint requires a `key` and an `inclusive` flag; both follow stream order, including on descending streams. Pagination retains its exclusive-start, inclusive-end behavior.
-
-**Before:**
-
-```ts
-QueryStream.narrow(stream, { after: startKey, until: endKey });
-```
-
-**After:**
-
-```ts
-QueryStream.narrow(stream, {
-  start: { key: startKey, inclusive: false },
-  end: { key: endKey, inclusive: true },
-});
-```
+Allow inclusive or exclusive endpoints on either side of an experimental `QueryStream.narrow` range, supporting time windows and selections that include or exclude their boundary items. Provide at least one of `start` or `end`, each containing a `key` and an `inclusive` flag; endpoints follow stream order, including on descending streams.

--- a/.changeset/add-query-stream-bounds.md
+++ b/.changeset/add-query-stream-bounds.md
@@ -1,0 +1,22 @@
+---
+"@confect/server": major
+---
+
+Allow inclusive or exclusive endpoints on either side of an experimental `QueryStream.narrow` range, supporting time windows and selections that include or exclude their boundary items.
+
+Replace `after` and `until` with `start` and `end` objects. Each endpoint requires a `key` and an `inclusive` flag; both follow stream order, including on descending streams. Pagination retains its exclusive-start, inclusive-end behavior.
+
+**Before:**
+
+```ts
+QueryStream.narrow(stream, { after: startKey, until: endKey });
+```
+
+**After:**
+
+```ts
+QueryStream.narrow(stream, {
+  start: { key: startKey, inclusive: false },
+  end: { key: endKey, inclusive: true },
+});
+```

--- a/.changeset/add-query-stream-bounds.md
+++ b/.changeset/add-query-stream-bounds.md
@@ -4,7 +4,7 @@
 
 Allow inclusive or exclusive endpoints on either side of an experimental `QueryStream.narrow` range, supporting time windows and selections that include or exclude their boundary items.
 
-Replace `after` and `until` with `start` and `end` objects. Each endpoint requires a `key` and an `inclusive` flag; both follow stream order, including on descending streams. Pagination retains its exclusive-start, inclusive-end behavior.
+Replace `after` and `until` with `start` and `end` objects, providing at least one endpoint. Each endpoint requires a `key` and an `inclusive` flag; both follow stream order, including on descending streams. Pagination retains its exclusive-start, inclusive-end behavior.
 
 **Before:**
 

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -449,7 +449,7 @@ The fields must be a prefix of the stream's order key, which is enforced at the 
 
 ### Narrow to a key range
 
-`QueryStream.narrow` restricts a stream to the order keys between `start` and `end`. Each endpoint has a `key` and a required `inclusive` flag, so you can choose any combination of inclusive and exclusive bounds. Omit either endpoint to leave that side unbounded.
+`QueryStream.narrow` restricts a stream to the order keys between `start` and `end`. Each endpoint has a `key` and a required `inclusive` flag, so you can choose any combination of inclusive and exclusive bounds. Provide at least one endpoint; omit the other to leave that side unbounded.
 
 Endpoints follow **stream order**: on an ascending stream, `start` is the lower key; on a descending stream, it is the upper key. Narrowing intersects existing bounds, so repeated calls can only restrict the range further.
 

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -449,16 +449,18 @@ The fields must be a prefix of the stream's order key, which is enforced at the 
 
 ### Narrow to a key range
 
-`QueryStream.narrow` restricts a stream to the order keys strictly after `after` and at or before `until`, in stream order. `paginate` uses it to resume from a cursor; call it yourself to bound a composed stream by key.
+`QueryStream.narrow` restricts a stream to the order keys between `start` and `end`. Each endpoint has a `key` and a required `inclusive` flag, so you can choose any combination of inclusive and exclusive bounds. Omit either endpoint to leave that side unbounded.
 
-In SQL terms, it adds keyset predicates on the `ORDER BY` columns, `WHERE (text, _creationTime) > (:after) AND (text, _creationTime) <= (:until)`, to every query in the composition. The bounds are pushed down through every combinator into the index ranges of the underlying queries, so the skipped keys are never read.
+Endpoints follow **stream order**: on an ascending stream, `start` is the lower key; on a descending stream, it is the upper key. Narrowing intersects existing bounds, so repeated calls can only restrict the range further.
 
 ```ts
 const between = QueryStream.narrow(reader.table("notes").stream("by_text"), {
-  after: ["banana", 2],
-  until: ["cherry", 4],
+  start: { key: ["banana", 2], inclusive: false },
+  end: { key: ["cherry", 4], inclusive: true },
 });
 ```
+
+For this ascending, start-exclusive, end-inclusive range, the SQL equivalent is `WHERE (text, _creationTime) > (:start) AND (text, _creationTime) <= (:end)`. The bounds are pushed down through every combinator into the index ranges of the underlying queries, so the skipped keys are never read.
 
 The bounds become index-range predicates on the leaf, so the elements outside them are not read at all:
 
@@ -468,16 +470,43 @@ The bounds become index-range predicates on the leaf, so the elements outside th
 by_text
 ╰─ n1 ──────── n3 ──────── n2 ──────── n5 ──────── n4 ──────── n6 ───────┤
    [apple,1]   [apple,3]   [banana,2]  [banana,5]  [cherry,4]  [date,6]
-                                     ╎ after                 ╎ until
+                                     ╎ start                 ╎ end
 
-╞═ narrow({ after: [banana, 2], until: [cherry, 4] }) ═╡
+╞═ narrow: start exclusive, end inclusive ═╡
 
 narrowed
 ╰───────────────────────────────────── n5 ──────── n4 ───────┤
                                        [banana,5]  [cherry,4]
 ```
 
-Cursors are serialized keys: `QueryStream.deserializeCursor(page.continueCursor)` turns a page's cursor into an `after` bound.
+A key can be a prefix of the full order key. An inclusive prefix includes all keys extending it; an exclusive prefix excludes that whole group. For example, an ascending creation-time stream can select a time window without supplying the trailing `_id`:
+
+```ts
+const startTime = Date.UTC(2026, 0, 1);
+const endTime = Date.UTC(2026, 0, 2);
+
+const duringDay = reader
+  .table("notes")
+  .stream("by_creation_time")
+  .pipe(
+    QueryStream.narrow({
+      start: { key: [startTime], inclusive: true },
+      end: { key: [endTime], inclusive: false },
+    }),
+  );
+```
+
+This includes every note at `startTime` and excludes every note at `endTime`. Adjacent windows can share an endpoint without overlapping. Apply the same bounds to a merged stream when its leading order-key field is also creation time.
+
+When both endpoints use the same key, the range is empty unless both are inclusive. Two inclusive endpoints select that key, or the entire group for a prefix key. On a `distinct` stream, bounds are truncated to the grouping prefix: an inclusive bound reselects the group's representative, and an exclusive bound skips the group.
+
+`paginate` uses an exclusive start and an inclusive end. To resume manually from a page's cursor, pass `{ start: { key: QueryStream.deserializeCursor(page.continueCursor), inclusive: false } }` to `narrow`.
+
+<Note>
+  The previous experimental `after` and `until` options have been replaced. Migrate
+  `after: key` to `start: { key, inclusive: false }` and `until: key` to
+  `end: { key, inclusive: true }`.
+</Note>
 
 ### Flat-map
 

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -502,12 +502,6 @@ When both endpoints use the same key, the range is empty unless both are inclusi
 
 `paginate` uses an exclusive start and an inclusive end. To resume manually from a page's cursor, pass `{ start: { key: QueryStream.deserializeCursor(page.continueCursor), inclusive: false } }` to `narrow`.
 
-<Note>
-  The previous experimental `after` and `until` options have been replaced. Migrate
-  `after: key` to `start: { key, inclusive: false }` and `until: key` to
-  `end: { key, inclusive: true }`.
-</Note>
-
 ### Flat-map
 
 `QueryStream.flatMap` runs an inner stream for each document of an outer stream and concatenates the results, ordered by the outer key and then the inner key.

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -2041,19 +2041,28 @@ export const reverse = <
   return self.reverseWith();
 };
 
-/** Endpoints in stream order. Omit an endpoint to leave that side unbounded. */
-export interface NarrowBounds {
-  readonly start?: KeyBound | undefined;
-  readonly end?: KeyBound | undefined;
-}
+/**
+ * At least one endpoint in stream order. Omit the other to leave that side
+ * unbounded.
+ */
+export type NarrowBounds =
+  | {
+      readonly start: KeyBound;
+      readonly end?: KeyBound | undefined;
+    }
+  | {
+      readonly start?: KeyBound | undefined;
+      readonly end: KeyBound;
+    };
 
 /**
  * Restrict a stream to the order keys between `start` and `end` (in stream
  * order), including each endpoint only when its `inclusive` flag is true.
  * For descending streams, `start` is the upper key and `end` the lower key.
- * Omitted endpoints are unbounded. A prefix key includes or excludes the
- * whole group of keys extending it; `distinct` truncates bounds to its
- * grouping prefix. Narrowing intersects the stream's existing bounds.
+ * At least one endpoint is required; the other can be left unbounded.
+ * A prefix key includes or excludes the whole group of keys extending it;
+ * `distinct` truncates bounds to its grouping prefix. Narrowing intersects
+ * the stream's existing bounds.
  *
  * In SQL terms: keyset predicates on the `ORDER BY` columns — `WHERE (k1,
  * k2) >= (:start) AND (k1, k2) < (:end)` for an ascending, start-inclusive,
@@ -2413,14 +2422,18 @@ export const paginate = dual<
       const until = Option.map(pinnedEnd, (cursor) =>
         deserializeCursorChecked(cursor, self.keyFields.length),
       );
-      const narrowed = narrow(self, {
-        start: Option.getOrUndefined(
-          Option.map(after, (key) => ({ key, inclusive: false })),
-        ),
-        end: Option.getOrUndefined(
-          Option.map(until, (key) => ({ key, inclusive: true })),
-        ),
-      });
+      const start = Option.getOrUndefined(
+        Option.map(after, (key) => ({ key, inclusive: false })),
+      );
+      const end = Option.getOrUndefined(
+        Option.map(until, (key) => ({ key, inclusive: true })),
+      );
+      const narrowed =
+        start !== undefined
+          ? narrow(self, { start, end })
+          : end !== undefined
+            ? narrow(self, { end })
+            : self;
       // With an endCursor the page runs to it, however many items that is.
       const maxRows = Option.isSome(endCursor) ? undefined : options.numItems;
       const maximumRowsRead = options.maximumRowsRead;

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -2041,12 +2041,23 @@ export const reverse = <
   return self.reverseWith();
 };
 
+/** Endpoints in stream order. Omit an endpoint to leave that side unbounded. */
+export interface NarrowBounds {
+  readonly start?: KeyBound | undefined;
+  readonly end?: KeyBound | undefined;
+}
+
 /**
- * Restrict a stream to order keys strictly after `after` and at-or-before
- * `until` (in stream order).
+ * Restrict a stream to the order keys between `start` and `end` (in stream
+ * order), including each endpoint only when its `inclusive` flag is true.
+ * For descending streams, `start` is the upper key and `end` the lower key.
+ * Omitted endpoints are unbounded. A prefix key includes or excludes the
+ * whole group of keys extending it; `distinct` truncates bounds to its
+ * grouping prefix. Narrowing intersects the stream's existing bounds.
  *
  * In SQL terms: keyset predicates on the `ORDER BY` columns — `WHERE (k1,
- * k2) > (:after) AND (k1, k2) <= (:until)` — added to every query in the
+ * k2) >= (:start) AND (k1, k2) < (:end)` for an ascending, start-inclusive,
+ * end-exclusive range — added to every query in the
  * composition. The bounds are pushed down through the stream's structure
  * via `narrowWith`, so the skipped keys are never read: leaves rebuild
  * their Convex queries with the bounds decomposed into `withIndex` ranges
@@ -2054,10 +2065,9 @@ export const reverse = <
  * their combinator. Streams without a `narrowWith` (constructed externally)
  * fall back to filtering the annotated stream in memory. */
 export const narrow = dual<
-  (bounds: {
-    readonly after?: OrderKey | undefined;
-    readonly until?: OrderKey | undefined;
-  }) => <
+  (
+    bounds: NarrowBounds,
+  ) => <
     Doc,
     Key extends ReadonlyArray<string>,
     E,
@@ -2074,10 +2084,7 @@ export const narrow = dual<
     Direction extends OrderDirection,
   >(
     self: QueryStream<Doc, Key, E, R, Direction>,
-    bounds: {
-      readonly after?: OrderKey | undefined;
-      readonly until?: OrderKey | undefined;
-    },
+    bounds: NarrowBounds,
   ) => QueryStream<Doc, Key, E, R, Direction>
 >(
   2,
@@ -2089,25 +2096,16 @@ export const narrow = dual<
     Direction extends OrderDirection,
   >(
     self: QueryStream<Doc, Key, E, R, Direction>,
-    bounds: {
-      readonly after?: OrderKey | undefined;
-      readonly until?: OrderKey | undefined;
-    },
+    bounds: NarrowBounds,
   ) => {
-    const after = Option.map(
-      Option.fromUndefinedOr(bounds.after),
-      (key): KeyBound => ({ key, inclusive: false }),
-    );
-    const until = Option.map(
-      Option.fromUndefinedOr(bounds.until),
-      (key): KeyBound => ({ key, inclusive: true }),
-    );
-    // Stream space → ascending key space: for `desc`, "after" bounds from
-    // above and "until" from below.
+    const start = Option.fromUndefinedOr(bounds.start);
+    const end = Option.fromUndefinedOr(bounds.end);
+    // Stream space → ascending key space: for `desc`, "start" bounds from
+    // above and "end" from below. Inclusion stays attached to its key.
     const keyBounds: KeyBounds =
       self.order === "asc"
-        ? { lower: after, upper: until }
-        : { lower: until, upper: after };
+        ? { lower: start, upper: end }
+        : { lower: end, upper: start };
     return narrowByKeyBounds(self, keyBounds);
   },
 );
@@ -2416,8 +2414,12 @@ export const paginate = dual<
         deserializeCursorChecked(cursor, self.keyFields.length),
       );
       const narrowed = narrow(self, {
-        after: Option.getOrUndefined(after),
-        until: Option.getOrUndefined(until),
+        start: Option.getOrUndefined(
+          Option.map(after, (key) => ({ key, inclusive: false })),
+        ),
+        end: Option.getOrUndefined(
+          Option.map(until, (key) => ({ key, inclusive: true })),
+        ),
       });
       // With an endCursor the page runs to it, however many items that is.
       const maxRows = Option.isSome(endCursor) ? undefined : options.numItems;

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -730,10 +730,6 @@ describe("QueryStream", () => {
                 key: [Array.getUnsafe(texts, 3)],
                 inclusive: false,
               };
-              expect(QueryStream.narrow(leaf, {})).toBe(leaf);
-              expect(
-                QueryStream.narrow(leaf, { start: undefined, end: undefined }),
-              ).toBe(leaf);
               expect(
                 yield* collectTexts(QueryStream.narrow(leaf, { start })),
               ).toEqual(texts.slice(1));
@@ -1682,6 +1678,32 @@ describe("QueryStream types", () => {
       expectTypeOf<typeof degraded>().toEqualTypeOf<
         Stream.Stream<string, Document.DocumentDecodeError>
       >();
+
+      // Narrowing requires at least one defined endpoint in either call form.
+      const start = { key: ["a"], inclusive: true };
+      const end = { key: ["z"], inclusive: false };
+      const startOnly = QueryStream.narrow(full, { start });
+      const endOnly = full.pipe(QueryStream.narrow({ end }));
+      const between = QueryStream.narrow(full, { start, end });
+      expectTypeOf<typeof startOnly>().toEqualTypeOf<typeof full>();
+      expectTypeOf<typeof endOnly>().toEqualTypeOf<typeof full>();
+      expectTypeOf<typeof between>().toEqualTypeOf<typeof full>();
+
+      // @ts-expect-error — empty bounds do not narrow a stream.
+      const emptyBounds = QueryStream.narrow(full, {});
+      void emptyBounds;
+      // @ts-expect-error — the data-last form also requires an endpoint.
+      QueryStream.narrow({});
+      // @ts-expect-error — explicitly undefined endpoints are still absent.
+      const absentBounds = QueryStream.narrow(full, {
+        start: undefined,
+        end: undefined,
+      });
+      void absentBounds;
+      // @ts-expect-error — an undefined start alone is not a bound.
+      QueryStream.narrow({ start: undefined });
+      // @ts-expect-error — an undefined end alone is not a bound.
+      QueryStream.narrow({ end: undefined });
 
       // Streams pinned the same way merge; the pinned values may differ.
       const mergedPinned = QueryStream.merge([pinned, pinned]);

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -540,7 +540,9 @@ describe("QueryStream", () => {
           });
           const afterKey = QueryStream.deserializeCursor(page1.continueCursor);
 
-          const narrowed = QueryStream.narrow(leaf, { after: afterKey });
+          const narrowed = QueryStream.narrow(leaf, {
+            start: { key: afterKey, inclusive: false },
+          });
 
           // The narrowed stream is a rebuilt *leaf* — not an in-memory
           // fallback — whose lower bound is the pinned prefix plus the
@@ -588,13 +590,254 @@ describe("QueryStream", () => {
           // still reach the leaf rather than falling back to in-memory
           // key filtering.
           expect(derived.narrowWith).toBeDefined();
-          const narrowed = QueryStream.narrow(derived, { after: afterKey });
+          const narrowed = QueryStream.narrow(derived, {
+            start: { key: afterKey, inclusive: false },
+          });
 
           expect(yield* collectTexts(narrowed)).toEqual(["B", "D"]);
         }),
       );
     }).pipe(Effect.provide(TestConfect.layer)),
   );
+
+  describe.each(["asc", "desc"] as const)("narrow (%s)", (order) => {
+    const cases = [
+      { startInclusive: false, endInclusive: true },
+      { startInclusive: true, endInclusive: false },
+      { startInclusive: true, endInclusive: true },
+      { startInclusive: false, endInclusive: false },
+    ];
+
+    it.effect.each(cases)(
+      "includes start=$startInclusive and end=$endInclusive for keys and prefixes",
+      ({ startInclusive, endInclusive }) =>
+        Effect.gen(function* () {
+          const c = yield* TestConfect.TestConfect;
+          yield* c.run(
+            Effect.gen(function* () {
+              yield* insertNotes(["a", "b", "b", "c", "d", "d", "e"]);
+              const reader = yield* DatabaseReader;
+              const leaf = reader.table("notes").stream("by_text", order);
+              const elements = yield* Stream.runCollect(leaf.annotated);
+              const texts = yield* collectTexts(leaf);
+              const start = {
+                key: Array.getUnsafe(elements, 1)[1],
+                inclusive: startInclusive,
+              };
+              const end = {
+                key: Array.getUnsafe(elements, 5)[1],
+                inclusive: endInclusive,
+              };
+              const bounds = { start, end };
+              const prefixBounds = {
+                start: { ...start, key: [Array.getUnsafe(texts, 1)] },
+                end: { ...end, key: [Array.getUnsafe(texts, 5)] },
+              };
+              const expected = texts.slice(
+                startInclusive ? 1 : 2,
+                endInclusive ? 6 : 5,
+              );
+              const expectedPrefixes = texts.slice(
+                startInclusive ? 1 : 3,
+                endInclusive ? 6 : 4,
+              );
+              const narrowed = QueryStream.narrow(leaf, bounds);
+              expect(narrowed.reflection?.bounds).toEqual({
+                lower: order === "asc" ? start : end,
+                upper: order === "asc" ? end : start,
+              });
+
+              const fallback: typeof leaf = new QueryStream.QueryStream(
+                leaf.order,
+                leaf.keyFields,
+                leaf.annotated,
+              );
+              const composed = QueryStream.merge([
+                reader
+                  .table("notes")
+                  .stream("by_text", (q) => q.lt("text", "c"), order),
+                reader
+                  .table("notes")
+                  .stream("by_text", (q) => q.gte("text", "c"), order),
+              ]).pipe(
+                QueryStream.filter(
+                  (note) => note.text !== "a" && note.text !== "e",
+                ),
+                QueryStream.map((note) => ({ ...note })),
+              );
+              for (const stream of [leaf, fallback, composed]) {
+                expect(
+                  yield* collectTexts(stream.pipe(QueryStream.narrow(bounds))),
+                ).toEqual(expected);
+                expect(
+                  yield* collectTexts(QueryStream.narrow(stream, prefixBounds)),
+                ).toEqual(expectedPrefixes);
+                expect(
+                  yield* collectTexts(
+                    QueryStream.narrow(stream, {
+                      start,
+                      end: { key: start.key, inclusive: endInclusive },
+                    }),
+                  ),
+                ).toEqual(startInclusive && endInclusive ? [texts[1]] : []);
+                expect(
+                  yield* collectTexts(
+                    QueryStream.narrow(stream, {
+                      start: prefixBounds.start,
+                      end: { ...prefixBounds.start, inclusive: endInclusive },
+                    }),
+                  ),
+                ).toEqual(
+                  startInclusive && endInclusive ? texts.slice(1, 3) : [],
+                );
+              }
+
+              const distinct = leaf.pipe(QueryStream.distinct(["text"]));
+              expect(
+                yield* collectTexts(QueryStream.narrow(distinct, bounds)),
+              ).toEqual([...new Set(expectedPrefixes)]);
+              expect(
+                yield* collectTexts(QueryStream.reverse(narrowed)),
+              ).toEqual(
+                yield* collectTexts(
+                  QueryStream.narrow(QueryStream.reverse(leaf), {
+                    start: end,
+                    end: start,
+                  }),
+                ),
+              );
+            }),
+          );
+        }).pipe(Effect.provide(TestConfect.layer)),
+    );
+
+    it.effect(
+      "keeps omitted sides unbounded and intersects repeated bounds",
+      () =>
+        Effect.gen(function* () {
+          const c = yield* TestConfect.TestConfect;
+          yield* c.run(
+            Effect.gen(function* () {
+              yield* insertNotes(["a", "b", "c", "d", "e"]);
+              const reader = yield* DatabaseReader;
+              const leaf = reader.table("notes").stream("by_text", order);
+              const texts = yield* collectTexts(leaf);
+              const start = {
+                key: [Array.getUnsafe(texts, 1)],
+                inclusive: true,
+              };
+              const end = {
+                key: [Array.getUnsafe(texts, 3)],
+                inclusive: false,
+              };
+              expect(QueryStream.narrow(leaf, {})).toBe(leaf);
+              expect(
+                QueryStream.narrow(leaf, { start: undefined, end: undefined }),
+              ).toBe(leaf);
+              expect(
+                yield* collectTexts(QueryStream.narrow(leaf, { start })),
+              ).toEqual(texts.slice(1));
+              expect(
+                yield* collectTexts(QueryStream.narrow(leaf, { end })),
+              ).toEqual(texts.slice(0, 3));
+              const bounded = leaf.pipe(
+                QueryStream.narrow({ start }),
+                QueryStream.narrow({ end }),
+              );
+              expect(yield* collectTexts(bounded)).toEqual(texts.slice(1, 3));
+              expect(
+                yield* collectTexts(
+                  QueryStream.narrow(bounded, {
+                    start: {
+                      key: [Array.getUnsafe(texts, 0)],
+                      inclusive: true,
+                    },
+                    end: { key: [Array.getUnsafe(texts, 4)], inclusive: true },
+                  }),
+                ),
+              ).toEqual(texts.slice(1, 3));
+              expect(
+                yield* collectTexts(
+                  QueryStream.narrow(bounded, {
+                    start: { ...start, inclusive: false },
+                  }),
+                ),
+              ).toEqual(texts.slice(2, 3));
+              expect(
+                yield* collectTexts(
+                  QueryStream.narrow(leaf, {
+                    start: end,
+                    end: start,
+                  }),
+                ),
+              ).toEqual([]);
+            }),
+          );
+        }).pipe(Effect.provide(TestConfect.layer)),
+    );
+
+    it.effect.each(cases)(
+      "narrows joined boundary rows with start=$startInclusive and end=$endInclusive",
+      ({ startInclusive, endInclusive }) =>
+        Effect.gen(function* () {
+          const c = yield* TestConfect.TestConfect;
+          yield* c.run(
+            Effect.gen(function* () {
+              const writer = yield* DatabaseWriter;
+              const reader = yield* DatabaseReader;
+              for (const [text, tag] of [
+                ["b", "b1"],
+                ["b", "b2"],
+                ["a", "a1"],
+                ["a", "a2"],
+                ["x1", "a"],
+                ["x2", "b"],
+              ] as const) {
+                yield* writer.table("notes").insert({ text, tag });
+              }
+              const joined = reader
+                .table("notes")
+                .stream("by_text", (q) => q.gte("text", "x"), order)
+                .pipe(
+                  QueryStream.flatMap(
+                    (note) =>
+                      reader
+                        .table("notes")
+                        .stream(
+                          "by_text",
+                          (q) => q.eq("text", note.tag ?? ""),
+                          order,
+                        ),
+                    { innerKey: ["_creationTime"] },
+                  ),
+                );
+              const elements = yield* Stream.runCollect(joined.annotated);
+              // Exercise endpoints within one outer row and across two rows.
+              for (const endIndex of [1, 3]) {
+                const result = yield* Stream.runCollect(
+                  QueryStream.narrow(joined, {
+                    start: {
+                      key: Array.getUnsafe(elements, 0)[1],
+                      inclusive: startInclusive,
+                    },
+                    end: {
+                      key: Array.getUnsafe(elements, endIndex)[1],
+                      inclusive: endInclusive,
+                    },
+                  }).annotated,
+                );
+                expect(result).toEqual(
+                  elements.slice(
+                    startInclusive ? 0 : 1,
+                    endIndex + (endInclusive ? 1 : 0),
+                  ),
+                );
+              }
+            }),
+          );
+        }).pipe(Effect.provide(TestConfect.layer)),
+    );
+  });
 
   it.effect("paginates through duplicate index values", () =>
     Effect.gen(function* () {

--- a/scripts/streamDiagrams.ts
+++ b/scripts/streamDiagrams.ts
@@ -257,9 +257,9 @@ export const diagrams: Readonly<Record<string, string>> = {
   narrow: lines(
     track("by_text", BY_TEXT),
     keys(BY_TEXT_KEYS),
-    `${cursorAt(3)} after${" ".repeat(COLUMN_WIDTH * 2 - 7)}╎ until`,
+    `${cursorAt(3)} start${" ".repeat(COLUMN_WIDTH * 2 - 7)}╎ end`,
     "",
-    op("narrow({ after: [banana, 2], until: [cherry, 4] })"),
+    op("narrow: start exclusive, end inclusive"),
     "",
     track("narrowed", [undefined, undefined, undefined, "n5", "n4"]),
     keys([undefined, undefined, undefined, "[banana,5]", "[cherry,4]"]),


### PR DESCRIPTION
The unshipped `QueryStream.narrow` API fixes ranges to an exclusive start and inclusive end. Allow each endpoint to choose its inclusion behavior so composed streams can express time windows such as `[startTime, endTime)` and selections that include or exclude either anchor.

Use `start` and `end` endpoints, each containing `{ key, inclusive }`. At least one defined endpoint is required. Endpoints follow stream order, including for descending streams, and prefix bounds include or exclude the entire matching group. Pagination retains its exclusive-start, inclusive-end behavior and handles unbounded pages directly.

```ts
QueryStream.narrow(stream, {
  start: { key: [startTime], inclusive: true },
  end: { key: [endTime], inclusive: false },
});
```

Includes a minor changeset, updated documentation and diagrams, and tests for all four inclusion combinations in both directions across leaves, fallback streams, merged transforms, distinct groups, and joins. Type tests reject empty and undefined-only bounds. Since `QueryStream` has not shipped, this refinement does not break a released API or require consumer migration.

Validation passed: `pnpm build`, `pnpm typecheck`, `pnpm format:check`, workspace lint plus `pnpm oxlint --fix` on the final edited TypeScript files, the QueryStream mock-backend suite, and stream-diagram tests. The release-note correction also passed targeted formatting and diagram consistency checks.
