### PR TITLE
Mark QueryStream exports as experimental

### DIFF
--- a/.changeset/mark-query-stream-experimental.md
+++ b/.changeset/mark-query-stream-experimental.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": patch
+---
+
+Mark all `QueryStream` exports as experimental in their JSDoc, warning that they may change or be removed without a major version bump.

--- a/.changeset/mark-query-stream-experimental.md
+++ b/.changeset/mark-query-stream-experimental.md
@@ -2,4 +2,4 @@
 "@confect/server": patch
 ---
 
-Mark all `QueryStream` exports as experimental in their JSDoc, warning that they may change or be removed without a major version bump.
+Mark all `QueryStream` exports as experimental in their JSDoc.

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -64,12 +64,10 @@ import * as Document from "./Document";
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const TypeId = "~@confect/server/QueryStream";
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type TypeId = typeof TypeId;
 
@@ -83,7 +81,6 @@ export type TypeId = typeof TypeId;
  * appears for optional fields that are absent.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type OrderKey = ReadonlyArray<Value | undefined>;
 
@@ -98,7 +95,6 @@ export type OrderKey = ReadonlyArray<Value | undefined>;
  * combined, `flatMap` fails when the join runs).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type OrderDirection = "asc" | "desc";
 
@@ -106,7 +102,6 @@ export type OrderDirection = "asc" | "desc";
  * The opposite of a direction; a runtime-chosen direction stays the union.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type Flip<Direction extends OrderDirection> = Direction extends "asc"
   ? "desc"
@@ -122,7 +117,6 @@ const flipDirection = <Direction extends OrderDirection>(
  * its order key.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type Element<Doc> = readonly [Option.Option<Doc>, OrderKey];
 
@@ -137,18 +131,15 @@ export type Element<Doc> = readonly [Option.Option<Doc>, OrderKey];
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const RangeSpecTypeId = "~@confect/server/QueryStream/IndexRangeSpec";
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type RangeSpecTypeId = typeof RangeSpecTypeId;
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type RangeOp = {
   readonly _tag: "eq" | "gt" | "gte" | "lt" | "lte";
@@ -161,7 +152,6 @@ export type RangeOp = {
  * phantom `Remaining` — the index fields not consumed by `eq` pinning.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface IndexRangeSpec<out Fields extends ReadonlyArray<string>> {
   readonly [RangeSpecTypeId]: {
@@ -173,13 +163,11 @@ export interface IndexRangeSpec<out Fields extends ReadonlyArray<string>> {
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type AnyIndexRangeSpec = IndexRangeSpec<ReadonlyArray<string>>;
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type Remaining<Spec> = Spec extends IndexRangeSpec<infer R> ? R : never;
 
@@ -203,7 +191,6 @@ type Tail<Fields extends ReadonlyArray<string>> = Fields extends readonly [
  * consuming it (bounded fields still vary within the range).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface RangeBuilder<
   ConvexDoc extends GenericDocument,
@@ -235,7 +222,6 @@ export interface RangeBuilder<
  * After `gt`/`gte`, only an upper bound on the same field may follow.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface LowerBoundedRange<
   ConvexDoc extends GenericDocument,
@@ -281,7 +267,6 @@ const makeRangeBuilder = (
  * The initial builder handed to a range callback.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const rangeBuilder = <
   ConvexDoc extends GenericDocument,
@@ -297,7 +282,6 @@ const applyOps = (ops: ReadonlyArray<RangeOp>, q: any): any =>
  * Replay a recorded range spec onto Convex's real `IndexRangeBuilder`.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const applyRange = (spec: AnyIndexRangeSpec, q: any): any =>
   applyOps(spec.ops, q);
@@ -374,7 +358,6 @@ const runtimePrefixLength = (
  * bit-level ordering).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const ValueOrder: Order.Order<Value | undefined> = Order.make(
   (self, that) => Math.sign(compareValues(self, that)) as -1 | 0 | 1,
@@ -385,7 +368,6 @@ export const ValueOrder: Order.Order<Value | undefined> = Order.make(
  * also the ordering of Convex array values.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const OrderKeyOrder: Order.Order<OrderKey> = Order.Array(ValueOrder);
 
@@ -404,7 +386,6 @@ export const OrderKeyOrder: Order.Order<OrderKey> = Order.Array(ValueOrder);
  * One side of a range: a (possibly prefix) key and whether it's included.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface KeyBound {
   readonly key: OrderKey;
@@ -416,7 +397,6 @@ export interface KeyBound {
  * converts from stream space, where `desc` reverses which end is which).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface KeyBounds {
   readonly lower: Option.Option<KeyBound>;
@@ -429,7 +409,6 @@ export interface KeyBounds {
  * An empty key bounds nothing.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface IndexBounds {
   readonly lower: KeyBound;
@@ -659,7 +638,6 @@ const splitRange = (
  * accounting, so the result is consumable but no longer paginable.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export class QueryStream<
   out Doc,
@@ -772,7 +750,6 @@ Object.defineProperties(queryStreamPrototype, {
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type Any = QueryStream<any, any, any, any, any>;
 
@@ -783,7 +760,6 @@ export type Any = QueryStream<any, any, any, any, any>;
  * paginated).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const isQueryStream = (u: unknown): u is Any =>
   Predicate.hasProperty(u, TypeId);
@@ -803,7 +779,6 @@ export const isQueryStream = (u: unknown): u is Any =>
  * (the index fields that still vary, tiebreaker included).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const empty =
   <Doc>(): {
@@ -846,7 +821,6 @@ export const empty =
  * strongly-typed readers Confect holds assign to it structurally.)
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface ReflectionReader {
   query(tableName: string): {
@@ -869,7 +843,6 @@ export interface ReflectionReader {
  * leaf with tighter index bounds instead of filtering in memory.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface Reflection<Direction extends OrderDirection = OrderDirection> {
   readonly reader: ReflectionReader;
@@ -952,7 +925,6 @@ const intersectIndexBounds = (
  * decoding.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const fromReflection = <
   Doc,
@@ -1227,7 +1199,6 @@ const mergeStep =
  * throws here, when the streams are combined.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const merge = <
   Doc,
@@ -1383,7 +1354,6 @@ const transformEffect = <
  * Options for the effectful transforms (`filterEffect`, `mapEffect`).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export interface EffectOptions {
   /**
@@ -1405,7 +1375,6 @@ export interface EffectOptions {
  * another service.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const filter = dual<
   <Doc>(
@@ -1441,7 +1410,6 @@ export const filter = dual<
  * still advance cursors, as with `filter`.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const filterEffect = dual<
   <Doc, E2, R2>(
@@ -1492,7 +1460,6 @@ export const filterEffect = dual<
  * the mapper needs to read the database or another service.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const map = dual<
   <Doc, Doc2>(
@@ -1529,7 +1496,6 @@ export const map = dual<
  * The mapper must not change the ordering semantics.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const mapEffect = dual<
   <Doc, Doc2, E2, R2>(
@@ -1606,7 +1572,6 @@ export const mapEffect = dual<
  * A mismatch the types can't see fails when the join runs.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const flatMap = dual<
   <
@@ -1919,7 +1884,6 @@ const makeFlatMap = <
  * first present document resumes at the next group.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const distinct = dual<
   <const Fields extends ReadonlyArray<string>>(
@@ -1983,7 +1947,6 @@ export const distinct = dual<
  * interior one — keep their names and positions.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const renameKey = dual<
   <const NewKey extends ReadonlyArray<string>>(
@@ -2157,7 +2120,6 @@ const makeDistinct = <
  * `reverseWith`) throw too.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const reverse = <
   Doc,
@@ -2181,7 +2143,6 @@ export const reverse = <
  * unbounded.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type NarrowBounds =
   | {
@@ -2213,7 +2174,6 @@ export type NarrowBounds =
  * fall back to filtering the annotated stream in memory.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const narrow = dual<
   (
@@ -2338,7 +2298,6 @@ const narrowInMemory = <
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
   "NotUniqueError",
@@ -2356,7 +2315,6 @@ export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
  * `.unique()`) — `LIMIT 2` followed by a check.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const unique = <Doc, Key extends ReadonlyArray<string>, E, R>(
   self: QueryStream<Doc, Key, E, R>,
@@ -2386,7 +2344,6 @@ const UNDEFINED_SENTINEL = { $undefined: true } as const;
  * paginate over them publicly, until cursors are made opaque.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const serializeCursor = (key: OrderKey): string =>
   JSON.stringify(
@@ -2397,7 +2354,6 @@ export const serializeCursor = (key: OrderKey): string =>
 
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const deserializeCursor = (cursor: string): OrderKey =>
   Array.map(JSON.parse(cursor) as ReadonlyArray<unknown>, (value) =>
@@ -2450,7 +2406,6 @@ const deserializeCursorChecked = (
  * The cursor denoting the end of the stream.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const END_CURSOR = "[]";
 
@@ -2467,7 +2422,6 @@ const SOFT_MAX_SCAN_LENGTH = 16000;
  * shape).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type PaginateOptions = ConvexPaginationOptions;
 
@@ -2477,7 +2431,6 @@ export type PaginateOptions = ConvexPaginationOptions;
  * handlers can return this value where Convex expects its result shape).
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export type PaginationResult<Doc> = ConvexPaginationResult<Doc>;
 
@@ -2540,7 +2493,6 @@ const midpointCursor = (readKeys: Chunk.Chunk<OrderKey>): string =>
  *   hitting either budget ends the page with `SplitRequired`.
  *
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export const paginate = dual<
   (

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -62,7 +62,15 @@ import * as String from "effect/String";
 import type * as Types from "effect/Types";
 import * as Document from "./Document";
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const TypeId = "~@confect/server/QueryStream";
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type TypeId = typeof TypeId;
 
 // -----------------------------------------------------------------------------
@@ -73,6 +81,9 @@ export type TypeId = typeof TypeId;
  * The values of a document's order-key fields: the index fields that still
  * vary after equality pinning, plus the trailing `_id` tiebreaker. `undefined`
  * appears for optional fields that are absent.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export type OrderKey = ReadonlyArray<Value | undefined>;
 
@@ -85,10 +96,18 @@ export type OrderKey = ReadonlyArray<Value | undefined>;
  * direction chosen at runtime types as the union, and the runtime check
  * catches what the types can't see (`merge` throws when the streams are
  * combined, `flatMap` fails when the join runs).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export type OrderDirection = "asc" | "desc";
 
-/** The opposite of a direction; a runtime-chosen direction stays the union. */
+/**
+ * The opposite of a direction; a runtime-chosen direction stays the union.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type Flip<Direction extends OrderDirection> = Direction extends "asc"
   ? "desc"
   : "asc";
@@ -101,6 +120,9 @@ const flipDirection = <Direction extends OrderDirection>(
  * An element of the annotated stream: the decoded document (`None` when the
  * element was read but filtered out — it still advances cursors) paired with
  * its order key.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export type Element<Doc> = readonly [Option.Option<Doc>, OrderKey];
 
@@ -113,9 +135,21 @@ export type Element<Doc> = readonly [Option.Option<Doc>, OrderKey];
 // tuple becomes the resulting stream's order key, which is what `merge`
 // checks for compatibility.
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const RangeSpecTypeId = "~@confect/server/QueryStream/IndexRangeSpec";
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type RangeSpecTypeId = typeof RangeSpecTypeId;
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type RangeOp = {
   readonly _tag: "eq" | "gt" | "gte" | "lt" | "lte";
   readonly field: string;
@@ -125,6 +159,9 @@ export type RangeOp = {
 /**
  * The result of applying a range callback: the recorded operations, plus a
  * phantom `Remaining` — the index fields not consumed by `eq` pinning.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export interface IndexRangeSpec<out Fields extends ReadonlyArray<string>> {
   readonly [RangeSpecTypeId]: {
@@ -134,8 +171,16 @@ export interface IndexRangeSpec<out Fields extends ReadonlyArray<string>> {
   readonly ops: ReadonlyArray<RangeOp>;
 }
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type AnyIndexRangeSpec = IndexRangeSpec<ReadonlyArray<string>>;
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type Remaining<Spec> = Spec extends IndexRangeSpec<infer R> ? R : never;
 
 type Head<Fields extends ReadonlyArray<string>> = Fields extends readonly [
@@ -156,6 +201,9 @@ type Tail<Fields extends ReadonlyArray<string>> = Fields extends readonly [
  * A typed index-range builder. `eq` must target the next unpinned index
  * field, and consumes it; `gt`/`gte`/`lt`/`lte` bound the next field without
  * consuming it (bounded fields still vary within the range).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export interface RangeBuilder<
   ConvexDoc extends GenericDocument,
@@ -183,7 +231,12 @@ export interface RangeBuilder<
   ) => IndexRangeSpec<Fields>;
 }
 
-/** After `gt`/`gte`, only an upper bound on the same field may follow. */
+/**
+ * After `gt`/`gte`, only an upper bound on the same field may follow.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export interface LowerBoundedRange<
   ConvexDoc extends GenericDocument,
   Fields extends ReadonlyArray<string>,
@@ -224,7 +277,12 @@ const makeRangeBuilder = (
   };
 };
 
-/** The initial builder handed to a range callback. */
+/**
+ * The initial builder handed to a range callback.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const rangeBuilder = <
   ConvexDoc extends GenericDocument,
   Fields extends ReadonlyArray<string>,
@@ -235,7 +293,12 @@ export const rangeBuilder = <
 const applyOps = (ops: ReadonlyArray<RangeOp>, q: any): any =>
   Array.reduce(ops, q, (builder, op) => builder[op._tag](op.field, op.value));
 
-/** Replay a recorded range spec onto Convex's real `IndexRangeBuilder`. */
+/**
+ * Replay a recorded range spec onto Convex's real `IndexRangeBuilder`.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const applyRange = (spec: AnyIndexRangeSpec, q: any): any =>
   applyOps(spec.ops, q);
 
@@ -309,6 +372,9 @@ const runtimePrefixLength = (
  * around the canonical `compareValues` from `convex/values` (type rank
  * first, then within the type, including UTF-8 string order and NaN
  * bit-level ordering).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const ValueOrder: Order.Order<Value | undefined> = Order.make(
   (self, that) => Math.sign(compareValues(self, that)) as -1 | 0 | 1,
@@ -317,6 +383,9 @@ export const ValueOrder: Order.Order<Value | undefined> = Order.make(
 /**
  * `Order` over order keys: lexicographic by `ValueOrder`, then by length —
  * also the ordering of Convex array values.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const OrderKeyOrder: Order.Order<OrderKey> = Order.Array(ValueOrder);
 
@@ -331,7 +400,12 @@ export const OrderKeyOrder: Order.Order<OrderKey> = Order.Array(ValueOrder);
 // key extending it, the `successor` cut just after, and an `exact` cut is a
 // full key itself. (This is `convex-helpers`' `compareKeys` model.)
 
-/** One side of a range: a (possibly prefix) key and whether it's included. */
+/**
+ * One side of a range: a (possibly prefix) key and whether it's included.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export interface KeyBound {
   readonly key: OrderKey;
   readonly inclusive: boolean;
@@ -340,6 +414,9 @@ export interface KeyBound {
 /**
  * Bounds over a stream's order key, in *ascending key space* (`narrow`
  * converts from stream space, where `desc` reverses which end is which).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export interface KeyBounds {
   readonly lower: Option.Option<KeyBound>;
@@ -350,6 +427,9 @@ export interface KeyBounds {
  * Bounds in *full index-key space*: `eq`-pinned values appear as a shared
  * prefix of both keys (`splitRange` re-derives them as `eq` constraints).
  * An empty key bounds nothing.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export interface IndexBounds {
   readonly lower: KeyBound;
@@ -577,6 +657,9 @@ const splitRange = (
  * applying a generic `Stream` combinator degrades a `QueryStream` to a plain
  * `Stream` — which is honest: generic combinators can't maintain cursor
  * accounting, so the result is consumable but no longer paginable.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export class QueryStream<
   out Doc,
@@ -687,6 +770,10 @@ Object.defineProperties(queryStreamPrototype, {
   },
 });
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export type Any = QueryStream<any, any, any, any, any>;
 
 /**
@@ -694,6 +781,9 @@ export type Any = QueryStream<any, any, any, any, any>;
  * generic `Stream.*` combinator turns one into (in SQL terms: whether the
  * value still knows its `ORDER BY`, and so can still be combined and
  * paginated).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const isQueryStream = (u: unknown): u is Any =>
   Predicate.hasProperty(u, TypeId);
@@ -711,6 +801,9 @@ export const isQueryStream = (u: unknown): u is Any =>
  * `QueryStream.empty<NotesDoc>()(["text", "_creationTime"], "desc")`. The
  * key is the type-level order key of the streams it will be merged with
  * (the index fields that still vary, tiebreaker included).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const empty =
   <Doc>(): {
@@ -751,6 +844,9 @@ export const empty =
  * The subset of a Convex database reader a leaf stream needs to (re)build
  * its query. (Method syntax keeps the parameter types bivariant, so the
  * strongly-typed readers Confect holds assign to it structurally.)
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export interface ReflectionReader {
   query(tableName: string): {
@@ -771,6 +867,9 @@ export interface ReflectionReader {
  * the Effect formulation of `convex-helpers`' `reflect()`. It is also the
  * data a future `splitRange`-style `narrow` needs in order to rebuild the
  * leaf with tighter index bounds instead of filtering in memory.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export interface Reflection<Direction extends OrderDirection = OrderDirection> {
   readonly reader: ReflectionReader;
@@ -851,6 +950,9 @@ const intersectIndexBounds = (
  * bounds decomposed into Convex-expressible index ranges via `splitRange`
  * — and order keys are extracted from the *encoded* document before schema
  * decoding.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const fromReflection = <
   Doc,
@@ -1123,6 +1225,9 @@ const mergeStep =
  * direction and each later one must be assignable to it. A mismatch the
  * types can't see — a runtime-chosen direction, or an untyped call site —
  * throws here, when the streams are combined.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const merge = <
   Doc,
@@ -1274,7 +1379,12 @@ const transformEffect = <
     () => transformEffect(reverse(self), f, options),
   );
 
-/** Options for the effectful transforms (`filterEffect`, `mapEffect`). */
+/**
+ * Options for the effectful transforms (`filterEffect`, `mapEffect`).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export interface EffectOptions {
   /**
    * How many documents' effects may run at once (`"unbounded"` for all).
@@ -1293,6 +1403,9 @@ export interface EffectOptions {
  *
  * Use `filterEffect` when the predicate needs to read the database or
  * another service.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const filter = dual<
   <Doc>(
@@ -1325,7 +1438,11 @@ export const filter = dual<
  * In SQL terms: a `WHERE` whose predicate runs a subquery — `WHERE EXISTS
  * (...)`, or any predicate that reads other tables. The predicate's
  * `E2`/`R2` flow into the stream's channels, and filtered-out elements
- * still advance cursors, as with `filter`. */
+ * still advance cursors, as with `filter`.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const filterEffect = dual<
   <Doc, E2, R2>(
     predicate: (doc: Doc) => Effect.Effect<boolean, E2, R2>,
@@ -1373,6 +1490,9 @@ export const filterEffect = dual<
  *
  * The mapper must not change the ordering semantics. Use `mapEffect` when
  * the mapper needs to read the database or another service.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const map = dual<
   <Doc, Doc2>(
@@ -1407,6 +1527,9 @@ export const map = dual<
  * channels.
  *
  * The mapper must not change the ordering semantics.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const mapEffect = dual<
   <Doc, Doc2, E2, R2>(
@@ -1481,6 +1604,9 @@ export const mapEffect = dual<
  * inner stream is flagged; in the data-last form the inner streams fix it,
  * so an outer stream typed with the union needs union-typed inner streams.
  * A mismatch the types can't see fails when the join runs.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const flatMap = dual<
   <
@@ -1791,6 +1917,9 @@ const makeFlatMap = <
  * `distinct`: narrowing a distinct stream truncates bounds to the distinct
  * prefix, so a cursor that lands on a filtered element before its group's
  * first present document resumes at the next group.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const distinct = dual<
   <const Fields extends ReadonlyArray<string>>(
@@ -1852,6 +1981,9 @@ export const distinct = dual<
  * the type level via tuple length. The implicit `_id` tiebreakers the
  * type-level key omits — the trailing one, and a `flatMap` result's
  * interior one — keep their names and positions.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const renameKey = dual<
   <const NewKey extends ReadonlyArray<string>>(
@@ -2023,6 +2155,9 @@ const makeDistinct = <
  * apply `distinct` to that for the mirror query, or paginate the distinct
  * stream in one direction only. Externally constructed streams (no
  * `reverseWith`) throw too.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const reverse = <
   Doc,
@@ -2044,6 +2179,9 @@ export const reverse = <
 /**
  * At least one endpoint in stream order. Omit the other to leave that side
  * unbounded.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export type NarrowBounds =
   | {
@@ -2072,7 +2210,11 @@ export type NarrowBounds =
  * their Convex queries with the bounds decomposed into `withIndex` ranges
  * (`splitRange`), and derived streams narrow their inputs and re-apply
  * their combinator. Streams without a `narrowWith` (constructed externally)
- * fall back to filtering the annotated stream in memory. */
+ * fall back to filtering the annotated stream in memory.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const narrow = dual<
   (
     bounds: NarrowBounds,
@@ -2194,6 +2336,10 @@ const narrowInMemory = <
 // Sinks
 // -----------------------------------------------------------------------------
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
   "NotUniqueError",
   {},
@@ -2207,7 +2353,11 @@ export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
  * Expect zero or one element; fail with `NotUniqueError` on two or more.
  *
  * In SQL terms: a query that must return at most one row (Convex's
- * `.unique()`) — `LIMIT 2` followed by a check. */
+ * `.unique()`) — `LIMIT 2` followed by a check.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const unique = <Doc, Key extends ReadonlyArray<string>, E, R>(
   self: QueryStream<Doc, Key, E, R>,
 ): Effect.Effect<Option.Option<Doc>, E | NotUniqueError, R> =>
@@ -2234,6 +2384,9 @@ const UNDEFINED_SENTINEL = { $undefined: true } as const;
  * remaining order key includes a sensitive indexed field exposes that
  * field's values at page boundaries. Pin such fields with `eq`, or don't
  * paginate over them publicly, until cursors are made opaque.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const serializeCursor = (key: OrderKey): string =>
   JSON.stringify(
@@ -2242,6 +2395,10 @@ export const serializeCursor = (key: OrderKey): string =>
     ),
   );
 
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const deserializeCursor = (cursor: string): OrderKey =>
   Array.map(JSON.parse(cursor) as ReadonlyArray<unknown>, (value) =>
     Predicate.hasProperty(value, "$undefined")
@@ -2289,7 +2446,12 @@ const deserializeCursorChecked = (
   }
 };
 
-/** The cursor denoting the end of the stream. */
+/**
+ * The cursor denoting the end of the stream.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export const END_CURSOR = "[]";
 
 /**
@@ -2303,6 +2465,9 @@ const SOFT_MAX_SCAN_LENGTH = 16000;
  * `convex/server`, aliased so the wire protocol has a single source of
  * truth (`@confect/core`'s `PaginationOptions` schema encodes the same
  * shape).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export type PaginateOptions = ConvexPaginationOptions;
 
@@ -2310,6 +2475,9 @@ export type PaginateOptions = ConvexPaginationOptions;
  * The pagination protocol's result — `PaginationResult` from
  * `convex/server` (whose `page` is a mutable array type, which is why
  * handlers can return this value where Convex expects its result shape).
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export type PaginationResult<Doc> = ConvexPaginationResult<Doc>;
 
@@ -2370,6 +2538,9 @@ const midpointCursor = (readKeys: Chunk.Chunk<OrderKey>): string =>
  * - `maximumBytesRead` is charged the estimated size of every document
  *   the stream's index queries read, whether or not it reaches the page;
  *   hitting either budget ends the page with `SplitRequired`.
+ *
+ * @experimental
+ * This API may change or be removed without a major version bump.
  */
 export const paginate = dual<
   (

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -27,7 +27,6 @@ export * as QueryInitializer from "./QueryInitializer";
 export * as QueryRunner from "./QueryRunner";
 /**
  * @experimental
- * This API may change or be removed without a major version bump.
  */
 export * as QueryStream from "./QueryStream";
 export * as RegisteredConvexFunction from "./RegisteredConvexFunction";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -25,6 +25,10 @@ export * as OrderedQuery from "./OrderedQuery";
 export * as QueryCtx from "./QueryCtx";
 export * as QueryInitializer from "./QueryInitializer";
 export * as QueryRunner from "./QueryRunner";
+/**
+ * @experimental
+ * This API may change or be removed without a major version bump.
+ */
 export * as QueryStream from "./QueryStream";
 export * as RegisteredConvexFunction from "./RegisteredConvexFunction";
 export * as RegisteredFunction from "./RegisteredFunction";


### PR DESCRIPTION
`QueryStream` is experimental, but its individual exports didn't communicate that status in their JSDoc.

Add standalone `@experimental` tags to all 48 export declarations and the package's `QueryStream` namespace re-export. Include a patch changeset for `@confect/server`. Runtime code and types are unchanged.

Validated with `pnpm build`, the server package's typecheck, Oxfmt, and scoped Oxlint (zero warnings or errors). Verified every export is annotated in both source and emitted `.d.ts` files, and that the TypeScript changes are JSDoc-only.