### PR TITLE
Construct query stream elements with Data

### DIFF
--- a/.changeset/construct-query-stream-elements.md
+++ b/.changeset/construct-query-stream-elements.md
@@ -1,0 +1,23 @@
+---
+"@confect/server": major
+---
+
+Replace experimental `QueryStream.Element` tuples with a constructor accepting named `doc` and `key` fields.
+
+To migrate custom annotated streams, construct elements with `new QueryStream.Element({ doc, key })` and replace tuple indexing or destructuring with `.doc`, `.key`, or object destructuring. Document streams and pagination results are unchanged.
+
+**Before:**
+
+```ts
+const element = [Option.some(document), key] as const;
+const [doc, orderKey] = element;
+```
+
+**After:**
+
+```ts
+import { QueryStream } from "@confect/server";
+
+const element = new QueryStream.Element({ doc: Option.some(document), key });
+const { doc, key: orderKey } = element;
+```

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -122,7 +122,10 @@ const flipDirection = <Direction extends OrderDirection>(
  *
  * @experimental
  */
-export type Element<Doc> = readonly [Option.Option<Doc>, OrderKey];
+export class Element<Doc> extends Data.Class<{
+  readonly doc: Option.Option<Doc>;
+  readonly key: OrderKey;
+}> {}
 
 // -----------------------------------------------------------------------------
 // Typed index ranges
@@ -734,7 +737,7 @@ export class QueryStream<
   toStream(): Stream.Stream<Doc, E, R> {
     return Stream.filterMap(
       this.annotated,
-      Filter.fromPredicateOption(([doc, _key]) => doc),
+      Filter.fromPredicateOption(({ doc }) => doc),
     );
   }
 }
@@ -1070,13 +1073,13 @@ const makeLeaf = <Doc, Direction extends OrderDirection>(
       Effect.map(
         Document.decode(reflection.tableName, reflection.tableSchema)(encoded),
         (doc) =>
-          [
-            Option.some(doc as Doc),
-            extractOrderKey(
+          new Element({
+            doc: Option.some(doc as Doc),
+            key: extractOrderKey(
               encoded as Record.ReadonlyRecord<string, unknown>,
               keyPaths,
             ),
-          ] as const,
+          }),
       ),
     ),
   );
@@ -1245,7 +1248,7 @@ const mergeStep =
               Option.match(best, {
                 onNone: () => Option.some([index, head] as const),
                 onSome: ([, bestElement]) =>
-                  isEarlier(head[1], bestElement[1])
+                  isEarlier(head.key, bestElement.key)
                     ? Option.some([index, head] as const)
                     : best,
               }),
@@ -1400,7 +1403,7 @@ const transform = <
     self.keyFields,
     Stream.map(
       self.annotated,
-      ([doc, key]) => [Option.flatMap(doc, f), key] as const,
+      ({ doc, key }) => new Element({ doc: Option.flatMap(doc, f), key }),
     ),
     undefined,
     (keyBounds) => transform(narrowByKeyBounds(self, keyBounds), f),
@@ -1428,11 +1431,12 @@ const transformEffect = <
     self.keyFields,
     Stream.mapEffect(
       self.annotated,
-      ([doc, key]) =>
+      ({ doc, key }) =>
         Option.match(doc, {
-          onNone: () => Effect.succeed([Option.none<Doc2>(), key] as const),
+          onNone: () =>
+            Effect.succeed(new Element({ doc: Option.none<Doc2>(), key })),
           onSome: (value) =>
-            Effect.map(f(value), (mapped) => [mapped, key] as const),
+            Effect.map(f(value), (mapped) => new Element({ doc: mapped, key })),
         }),
       // Order is preserved at any concurrency: elements are emitted in
       // input order however their effects finish.
@@ -1865,7 +1869,9 @@ const makeFlatMap = <
   ): Stream.Stream<Element<Doc2 | Doc3>> =>
     admittedByLower(innerBounds.lower)(nullPadding) &&
     admittedByUpper(innerBounds.upper)(nullPadding)
-      ? Stream.succeed([doc, Array.appendAll(outerKey, nullPadding)] as const)
+      ? Stream.succeed(
+          new Element({ doc, key: Array.appendAll(outerKey, nullPadding) }),
+        )
       : Stream.empty;
 
   const annotated: Stream.Stream<
@@ -1873,7 +1879,7 @@ const makeFlatMap = <
     E | E2,
     R | R2
   > = self.annotated.pipe(
-    Stream.flatMap(([outerDoc, outerKey]) => {
+    Stream.flatMap(({ doc: outerDoc, key: outerKey }) => {
       const innerBounds = innerBoundsFor(outerKey);
       return Option.match(outerDoc, {
         onNone: () => markerStream(outerKey, innerBounds, Option.none()),
@@ -1881,8 +1887,11 @@ const makeFlatMap = <
           const inner = validated(f(doc));
           return narrowByKeyBounds(inner, innerBounds).annotated.pipe(
             Stream.map(
-              ([innerDoc, innerKey]) =>
-                [innerDoc, Array.appendAll(outerKey, innerKey)] as const,
+              ({ doc: innerDoc, key: innerKey }) =>
+                new Element({
+                  doc: innerDoc,
+                  key: Array.appendAll(outerKey, innerKey),
+                }),
             ),
             Stream.orElseIfEmpty(() =>
               Stream.unwrap(
@@ -2208,7 +2217,7 @@ const makeDistinct = <
               onNone: () => Effect.succeed([[], Option.none()] as const),
               onSome: (element) =>
                 Effect.gen(function* () {
-                  const [doc, key] = element;
+                  const { doc, key } = element;
                   const prefix = Array.take(key, distinctLength);
                   if (order === self.order) {
                     const nextKey = Option.match(doc, {
@@ -2230,7 +2239,7 @@ const makeDistinct = <
                     lower: Option.some({ key: prefix, inclusive: true }),
                     upper: Option.some({ key: prefix, inclusive: true }),
                   }).annotated.pipe(
-                    Stream.tap(([, selectedKey]) =>
+                    Stream.tap(({ key: selectedKey }) =>
                       Ref.update(
                         firstKey,
                         Option.orElse(() => Option.some(selectedKey)),
@@ -2238,7 +2247,7 @@ const makeDistinct = <
                     ),
                     Stream.filterMap(
                       Filter.fromPredicateOption((selectedElement) =>
-                        Option.as(selectedElement[0], selectedElement),
+                        Option.as(selectedElement.doc, selectedElement),
                       ),
                     ),
                     Stream.runHead,
@@ -2254,14 +2263,19 @@ const makeDistinct = <
                         );
                         return [
                           isAdmitted(checkpoint)
-                            ? [[Option.none<Doc>(), checkpoint] as const]
+                            ? [
+                                new Element({
+                                  doc: Option.none<Doc>(),
+                                  key: checkpoint,
+                                }),
+                              ]
                             : [],
                           next,
                         ] as const;
                       }),
                     onSome: (representative) =>
                       Effect.succeed([
-                        isAdmitted(representative[1]) ? [representative] : [],
+                        isAdmitted(representative.key) ? [representative] : [],
                         next,
                       ] as const),
                   });
@@ -2457,12 +2471,12 @@ const narrowInMemory = <
 
   const dropOutOfRange: Narrower =
     self.order === "asc"
-      ? Stream.dropWhile(([, key]) => !aboveLower(key))
-      : Stream.dropWhile(([, key]) => !belowUpper(key));
+      ? Stream.dropWhile(({ key }) => !aboveLower(key))
+      : Stream.dropWhile(({ key }) => !belowUpper(key));
   const takeInRange: Narrower =
     self.order === "asc"
-      ? Stream.takeWhile(([, key]) => belowUpper(key))
-      : Stream.takeWhile(([, key]) => aboveLower(key));
+      ? Stream.takeWhile(({ key }) => belowUpper(key))
+      : Stream.takeWhile(({ key }) => aboveLower(key));
 
   return new QueryStream(
     self.order,
@@ -2817,7 +2831,7 @@ export const paginate: {
           Sink.fold(
             initialPaginateState<Doc>,
             (state) => !state.stopped,
-            (state, [doc, key]: Element<Doc>) => {
+            (state, { doc, key }: Element<Doc>) => {
               const readKeys = Chunk.append(state.readKeys, key);
               const page = Option.match(doc, {
                 onNone: () => state.page,

--- a/packages/server/test/QueryStream.test.ts
+++ b/packages/server/test/QueryStream.test.ts
@@ -1,0 +1,100 @@
+import * as QueryStream from "@confect/server/QueryStream";
+import { describe, expect, expectTypeOf, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+
+describe("QueryStream.Element", () => {
+  it("constructs an element with an inferred document type and readonly fields", () => {
+    const doc = Option.some({ text: "hello" });
+    const key: QueryStream.OrderKey = ["hello", 1, "id"];
+    const element = new QueryStream.Element({ doc, key });
+
+    expectTypeOf(element).toEqualTypeOf<
+      QueryStream.Element<{ text: string }>
+    >();
+    expectTypeOf(element).toExtend<{
+      readonly doc: Option.Option<{ text: string }>;
+      readonly key: QueryStream.OrderKey;
+    }>();
+    expect(element.doc).toBe(doc);
+    expect(element.key).toBe(key);
+    expect(element.pipe((value) => Option.isSome(value.doc))).toBe(true);
+  });
+
+  it("constructs a filtered-out element without losing its order key", () => {
+    const key: QueryStream.OrderKey = [undefined, "id"];
+    const element = new QueryStream.Element({ doc: Option.none(), key });
+
+    expectTypeOf(element).toEqualTypeOf<QueryStream.Element<never>>();
+    expect(element.doc).toEqual(Option.none());
+    expect(element.key).toBe(key);
+  });
+});
+
+describe("QueryStream", () => {
+  const elements = [
+    new QueryStream.Element({ doc: Option.some(1), key: [1] }),
+    new QueryStream.Element({ doc: Option.none<number>(), key: [2] }),
+    new QueryStream.Element({ doc: Option.some(3), key: [3] }),
+  ];
+  const source = new QueryStream.QueryStream(
+    "asc",
+    ["_id"],
+    Stream.fromIterable(elements),
+  );
+
+  it.effect("consumes constructed elements as present documents only", () =>
+    Effect.gen(function* () {
+      expect(yield* Stream.runCollect(source)).toEqual([1, 3]);
+    }),
+  );
+
+  it.effect(
+    "constructs mapped and filtered elements with their original keys",
+    () =>
+      Effect.gen(function* () {
+        const transformed = source.pipe(
+          QueryStream.filter((doc) => doc > 1),
+          QueryStream.map((doc) => doc.toString()),
+        );
+        const result = yield* Stream.runCollect(transformed.annotated);
+
+        expect(result).toEqual([
+          new QueryStream.Element({ doc: Option.none(), key: [1] }),
+          new QueryStream.Element({ doc: Option.none(), key: [2] }),
+          new QueryStream.Element({ doc: Option.some("3"), key: [3] }),
+        ]);
+        for (const element of result) {
+          expect(element).toBeInstanceOf(QueryStream.Element);
+        }
+      }),
+  );
+
+  it.effect(
+    "preserves filtered elements through effectful transformations",
+    () =>
+      Effect.gen(function* () {
+        const visited: Array<number> = [];
+        const transformed = source.pipe(
+          QueryStream.mapEffect((doc) =>
+            Effect.sync(() => {
+              visited.push(doc);
+              return doc.toString();
+            }),
+          ),
+        );
+        const result = yield* Stream.runCollect(transformed.annotated);
+
+        expect(visited).toEqual([1, 3]);
+        expect(result).toEqual([
+          new QueryStream.Element({ doc: Option.some("1"), key: [1] }),
+          new QueryStream.Element({ doc: Option.none(), key: [2] }),
+          new QueryStream.Element({ doc: Option.some("3"), key: [3] }),
+        ]);
+        for (const element of result) {
+          expect(element).toBeInstanceOf(QueryStream.Element);
+        }
+      }),
+  );
+});

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -629,11 +629,11 @@ describe("QueryStream", () => {
               const elements = yield* Stream.runCollect(leaf.annotated);
               const texts = yield* collectTexts(leaf);
               const start = {
-                key: Array.getUnsafe(elements, 1)[1],
+                key: Array.getUnsafe(elements, 1).key,
                 inclusive: startInclusive,
               };
               const end = {
-                key: Array.getUnsafe(elements, 5)[1],
+                key: Array.getUnsafe(elements, 5).key,
                 inclusive: endInclusive,
               };
               const bounds = { start, end };
@@ -831,11 +831,11 @@ describe("QueryStream", () => {
                 const result = yield* Stream.runCollect(
                   QueryStream.narrow(joined, {
                     start: {
-                      key: Array.getUnsafe(elements, 0)[1],
+                      key: Array.getUnsafe(elements, 0).key,
                       inclusive: startInclusive,
                     },
                     end: {
-                      key: Array.getUnsafe(elements, endIndex)[1],
+                      key: Array.getUnsafe(elements, endIndex).key,
                       inclusive: endInclusive,
                     },
                   }).annotated,


### PR DESCRIPTION
`Element` values were hand-built tuples that required `as const` and positional access throughout the query stream implementation. Define `QueryStream.Element<Doc>` as a `Data.Class` with readonly `doc` and `key` fields so callers and combinators can construct them directly:

```ts
new QueryStream.Element({ doc: Option.some(document), key });
```

Update leaf decoding, transformations, joins, merging, distinct selection, narrowing, and pagination to use the named fields. The `[[], Option.none()]` pagination-step results are not elements and remain unchanged.

This changes the experimental `annotated` element shape; a major changeset includes migration instructions. Document streams and pagination results retain their existing behavior.

Validation: `pnpm build`, `pnpm typecheck`, Oxfmt and Oxlint on edited files, the QueryStream unit/lifecycle suites (15 runtime tests), and the query-stream mock-backend suites (76 runtime tests) all pass. New tests cover construction, type inference, document consumption, and preservation of filtered elements and order keys.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M25YSZETMSAY2BRBPX7B900C"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->