### PR TITLE
Construct query stream range operations

### DIFF
--- a/.changeset/construct-query-stream-range-operations.md
+++ b/.changeset/construct-query-stream-range-operations.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": minor
+---
+
+Add `QueryStream.RangeOp` constructors for `eq`, `gt`, `gte`, `lt`, and `lte` operations, accepting `{ field, value }` without requiring a hand-written `_tag`.

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -148,11 +148,14 @@ export type RangeSpecTypeId = typeof RangeSpecTypeId;
 /**
  * @experimental
  */
-export type RangeOp = {
-  readonly _tag: "eq" | "gt" | "gte" | "lt" | "lte";
-  readonly field: string;
-  readonly value: Value | undefined;
-};
+export type RangeOp = Data.TaggedEnum<{
+  [Tag in "eq" | "gt" | "gte" | "lt" | "lte"]: {
+    readonly field: string;
+    readonly value: Value | undefined;
+  };
+}>;
+
+export const RangeOp = Data.taggedEnum<RangeOp>();
 
 /**
  * The result of applying a range callback: the recorded operations, plus a
@@ -253,7 +256,7 @@ const makeRangeBuilder = (
     (field: string, value: Value | undefined) =>
       makeRangeBuilder(
         nextEqCount,
-        Array.append(ops, { _tag: tag, field, value }),
+        Array.append(ops, RangeOp[tag]({ field, value })),
       );
 
   return {
@@ -553,15 +556,16 @@ const rangeOpsFor = (
     onSome: (lastValue) =>
       pipe(
         Array.zip(fields, Array.dropRight(key, 1)),
-        Array.map(([field, value]): RangeOp => ({ _tag: "eq", field, value })),
+        Array.map(([field, value]) => RangeOp.eq({ field, value })),
         (eqOps) =>
           Array.appendAll(
             Array.appendAll(prefixOps, eqOps),
-            Array.of<RangeOp>({
-              _tag: tag,
-              field: fields[key.length - 1]!,
-              value: lastValue,
-            }),
+            Array.of(
+              RangeOp[tag]({
+                field: fields[key.length - 1]!,
+                value: lastValue,
+              }),
+            ),
           ),
       ),
   });
@@ -596,7 +600,7 @@ const splitRange = (
   ).length;
   const prefixOps = pipe(
     Array.zip(Array.take(fields, commonLength), bounds.lower.key),
-    Array.map(([field, value]): RangeOp => ({ _tag: "eq", field, value })),
+    Array.map(([field, value]) => RangeOp.eq({ field, value })),
   );
   const restFields = Array.drop(fields, commonLength);
 
@@ -624,17 +628,15 @@ const splitRange = (
     Array.isReadonlyArrayNonEmpty(lowerFinalKey) &&
     Array.isReadonlyArrayNonEmpty(upperFinalKey)
       ? Array.appendAll(prefixOps, [
-          {
-            _tag: lowerFinalTag,
+          RangeOp[lowerFinalTag]({
             field: restFields[0]!,
             value: Array.headNonEmpty(lowerFinalKey),
-          },
-          {
-            _tag: upperFinalTag,
+          }),
+          RangeOp[upperFinalTag]({
             field: restFields[0]!,
             value: Array.headNonEmpty(upperFinalKey),
-          },
-        ] as ReadonlyArray<RangeOp>)
+          }),
+        ])
       : Array.isReadonlyArrayNonEmpty(lowerFinalKey)
         ? rangeOpsFor(prefixOps, restFields, lowerFinalKey, lowerFinalTag)
         : rangeOpsFor(prefixOps, restFields, upperFinalKey, upperFinalTag);

--- a/packages/server/test/QueryStream.test.ts
+++ b/packages/server/test/QueryStream.test.ts
@@ -4,6 +4,30 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
+describe("QueryStream.RangeOp", () => {
+  it.each(["eq", "gt", "gte", "lt", "lte"] as const)(
+    "constructs %s operations with the existing record shape",
+    (tag) => {
+      expect(
+        QueryStream.RangeOp[tag]({ field: "text", value: "hello" }),
+      ).toEqual({
+        _tag: tag,
+        field: "text",
+        value: "hello",
+      });
+      expect(
+        QueryStream.RangeOp[tag]({ field: "text", value: undefined }).value,
+      ).toBeUndefined();
+    },
+  );
+
+  it("constructs precisely tagged operations", () => {
+    const op = QueryStream.RangeOp.eq({ field: "text", value: "hello" });
+    expectTypeOf(op._tag).toEqualTypeOf<"eq">();
+    expect(QueryStream.RangeOp.$is("eq")(op)).toBe(true);
+  });
+});
+
 describe("QueryStream.Element", () => {
   it("constructs an element with an inferred document type and readonly fields", () => {
     const doc = Option.some({ text: "hello" });


### PR DESCRIPTION
`RangeOp` tags were written by hand in range recording and splitting. Add `Data.taggedEnum` constructors for all five operations and use them at every production construction site. The existing `{ _tag, field, value }` shape is preserved, while constructors infer a precise tag.

Includes constructor and type-inference tests plus a minor changeset for the new public `QueryStream.RangeOp` constructors.

Layer 1 of 7 in the QueryStream constructor-refactor stack.

Validated independently at this layer: `pnpm build`, `pnpm typecheck`, Oxfmt, Oxlint, QueryStream unit/lifecycle tests, and `pnpm test:server:mock-backend queryStream`.