### PR TITLE
Name the fields of merge candidates

### DIFF
--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -1167,6 +1167,11 @@ const mergeSourceHead = <Doc, E>(
   source: MergeSource<Doc, E>,
 ): Option.Option<Element<Doc>> => Array.get(source.buffer, source.index);
 
+class MergeCandidate<Doc> extends Data.Class<{
+  readonly index: number;
+  readonly element: Element<Doc>;
+}> {}
+
 /**
  * Refill an exhausted-buffer source from its pull, translating the pull's
  * end-of-stream signal into a source status, retaining budget-limited stops.
@@ -1246,16 +1251,17 @@ const mergeStep =
 
       const earliest = Array.reduce(
         filled,
-        Option.none<readonly [number, Element<Doc>]>(),
+        Option.none<MergeCandidate<Doc>>(),
         (best, source, index) =>
           Option.match(mergeSourceHead(source), {
             onNone: () => best,
             onSome: (head) =>
               Option.match(best, {
-                onNone: () => Option.some([index, head] as const),
-                onSome: ([, bestElement]) =>
+                onNone: () =>
+                  Option.some(new MergeCandidate({ index, element: head })),
+                onSome: ({ element: bestElement }) =>
                   isEarlier(head.key, bestElement.key)
-                    ? Option.some([index, head] as const)
+                    ? Option.some(new MergeCandidate({ index, element: head }))
                     : best,
               }),
           }),
@@ -1264,7 +1270,7 @@ const mergeStep =
       return Option.getOrUndefined(
         Option.map(
           earliest,
-          ([index, element]) =>
+          ({ index, element }) =>
             [
               element,
               Array.map(filled, (source, sourceIndex) =>


### PR DESCRIPTION
Earliest-head selection paired the source index and element in hand-built tuples. Use an internal `MergeCandidate` Data constructor and named fields instead, preserving stable tie-breaking and advancement of only the selected source.

Internal refactor only; no changeset.

Layer 4 of 7 in the QueryStream constructor-refactor stack.

Validated independently at this layer: `pnpm build`, `pnpm typecheck`, Oxfmt, Oxlint, QueryStream unit/lifecycle tests, and `pnpm test:server:mock-backend queryStream`.