### PR TITLE
Keep pagination bounds as options

### DIFF
--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -2810,18 +2810,14 @@ export const paginate: {
       const until = Option.map(pinnedEnd, (cursor) =>
         deserializeCursorChecked(cursor, self.keyFields.length),
       );
-      const start = Option.getOrUndefined(
-        Option.map(after, (key) => ({ key, inclusive: false })),
+      const start = Option.map(after, (key) => ({ key, inclusive: false }));
+      const end = Option.map(until, (key) => ({ key, inclusive: true }));
+      const narrowed = narrowByKeyBounds(
+        self,
+        self.order === "asc"
+          ? { lower: start, upper: end }
+          : { lower: end, upper: start },
       );
-      const end = Option.getOrUndefined(
-        Option.map(until, (key) => ({ key, inclusive: true })),
-      );
-      const narrowed =
-        start !== undefined
-          ? narrow(self, { start, end })
-          : end !== undefined
-            ? narrow(self, { end })
-            : self;
       // With an endCursor the page runs to it, however many items that is.
       const maxRows = Option.match(endCursor, {
         onNone: () => Option.some(options.numItems),

--- a/packages/server/test/QueryStream.test.ts
+++ b/packages/server/test/QueryStream.test.ts
@@ -56,6 +56,52 @@ describe("QueryStream.Element", () => {
   });
 });
 
+describe.each(["asc", "desc"] as const)(
+  "QueryStream.paginate (%s)",
+  (order) => {
+    it.effect.each([
+      { start: false, end: false },
+      { start: true, end: false },
+      { start: false, end: true },
+      { start: true, end: true },
+    ])(
+      "preserves optional bounds with start=$start and end=$end",
+      ({ start, end }) =>
+        Effect.gen(function* () {
+          const values = order === "asc" ? [1, 2, 3, 4, 5] : [5, 4, 3, 2, 1];
+          const source = new QueryStream.QueryStream(
+            order,
+            ["_id"],
+            Stream.fromIterable(
+              values.map(
+                (value) =>
+                  new QueryStream.Element({
+                    doc: Option.some(value),
+                    key: [value],
+                  }),
+              ),
+            ),
+          );
+          const result = yield* QueryStream.paginate(source, {
+            cursor: start ? QueryStream.serializeCursor([values[1]]) : null,
+            ...(end
+              ? { endCursor: QueryStream.serializeCursor([values[3]]) }
+              : {}),
+            numItems: 10,
+          });
+
+          expect(result.page).toEqual(values.slice(start ? 2 : 0, end ? 4 : 5));
+          expect(result.isDone).toBe(!end);
+          expect(result.continueCursor).toBe(
+            end
+              ? QueryStream.serializeCursor([values[3]])
+              : QueryStream.END_CURSOR,
+          );
+        }),
+    );
+  },
+);
+
 describe("QueryStream", () => {
   const elements = [
     new QueryStream.Element({ doc: Option.some(1), key: [1] }),


### PR DESCRIPTION
Pagination converted optional cursor keys to `undefined`, then `narrow` converted them back to options. Build `KeyBounds` directly and call the existing `narrowByKeyBounds` path, retaining the ascending/descending swap and the no-op case for absent bounds.

Adds eight cases covering both directions with neither, either, or both cursor bounds. This is an internal refactor with no changeset.

Layer 1 of 4 in the QueryStream Effect-idiom stack.

Validated independently at this layer: `pnpm build`, `pnpm typecheck`, Oxfmt and Oxlint on edited files, QueryStream unit/lifecycle tests, and `pnpm test:server:mock-backend queryStream`.