### PR TITLE
Keep distinct probe state inside its sink

### DIFF
--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -56,7 +56,6 @@ import * as Option from "effect/Option";
 import * as Order from "effect/Order";
 import * as Predicate from "effect/Predicate";
 import * as Pull from "effect/Pull";
-import * as Ref from "effect/Ref";
 import type * as Record from "effect/Record";
 import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
@@ -2251,23 +2250,29 @@ const makeDistinct = <
                   const next = Option.some(
                     narrowByKeyBounds(current, afterKey(prefix)),
                   );
-                  const firstKey = yield* Ref.make(Option.none<OrderKey>());
-                  const selected = yield* narrowByKeyBounds(self, {
-                    lower: Option.some({ key: prefix, inclusive: true }),
-                    upper: Option.some({ key: prefix, inclusive: true }),
-                  }).annotated.pipe(
-                    Stream.tap(({ key: selectedKey }) =>
-                      Ref.update(
-                        firstKey,
-                        Option.orElse(() => Option.some(selectedKey)),
+                  const { firstKey, selected } = yield* narrowByKeyBounds(
+                    self,
+                    {
+                      lower: Option.some({ key: prefix, inclusive: true }),
+                      upper: Option.some({ key: prefix, inclusive: true }),
+                    },
+                  ).annotated.pipe(
+                    Stream.run(
+                      Sink.fold(
+                        () => ({
+                          firstKey: Option.none<OrderKey>(),
+                          selected: Option.none<Element<Doc>>(),
+                        }),
+                        (probe) => Option.isNone(probe.selected),
+                        (probe, candidate: Element<Doc>) =>
+                          Effect.succeed({
+                            firstKey: Option.orElse(probe.firstKey, () =>
+                              Option.some(candidate.key),
+                            ),
+                            selected: Option.as(candidate.doc, candidate),
+                          }),
                       ),
                     ),
-                    Stream.filterMap(
-                      Filter.fromPredicateOption((selectedElement) =>
-                        Option.as(selectedElement.doc, selectedElement),
-                      ),
-                    ),
-                    Stream.runHead,
                   );
                   return yield* Option.match(selected, {
                     onNone: () =>
@@ -2275,7 +2280,7 @@ const makeDistinct = <
                         if (yield* isBudgetStopped(budgetStatus))
                           return Tuple.make([], Option.none());
                         const checkpoint = Option.getOrElse(
-                          yield* Ref.get(firstKey),
+                          firstKey,
                           () => key,
                         );
                         return Tuple.make(

--- a/packages/server/test/QueryStreamLifecycle.test.ts
+++ b/packages/server/test/QueryStreamLifecycle.test.ts
@@ -253,6 +253,72 @@ describe("QueryStream iterator lifecycle", () => {
   );
 
   it.effect(
+    "stops a representative probe at its first unfiltered document",
+    () =>
+      Effect.gen(function* () {
+        const reader = makeReader();
+        const head = yield* reader.stream.pipe(
+          QueryStream.filter((document) => document._id !== "b1"),
+          QueryStream.distinct(distinctFields),
+          QueryStream.reverse,
+          Stream.runHead,
+        );
+
+        expect(head).toEqual(Option.some(documents[3]));
+        expect(reader.runs).toEqual([
+          { order: "desc", next: 1, returned: 1, settled: 1 },
+          { order: "asc", next: 2, returned: 1, settled: 2 },
+        ]);
+        expect(reader.events).toEqual([
+          "0:open:desc",
+          "0:next",
+          "0:return",
+          "1:open:asc",
+          "1:next",
+          "1:next",
+          "1:return",
+        ]);
+      }),
+  );
+
+  it.effect(
+    "retains the first probe key when its entire group is filtered out",
+    () =>
+      Effect.gen(function* () {
+        const reader = makeReader();
+        const reversed = reader.stream.pipe(
+          QueryStream.filter((document) => document.group !== "b"),
+          QueryStream.distinct(distinctFields),
+          QueryStream.reverse,
+        );
+        const head = yield* Stream.runHead(reversed.annotated);
+
+        expect(head).toEqual(
+          Option.some(
+            new QueryStream.Element({
+              doc: Option.none(),
+              key: ["b", 3, "b1"],
+            }),
+          ),
+        );
+        expect(reader.runs).toEqual([
+          { order: "desc", next: 1, returned: 1, settled: 1 },
+          { order: "asc", next: 3, returned: 1, settled: 3 },
+        ]);
+        expect(reader.events).toEqual([
+          "0:open:desc",
+          "0:next",
+          "0:return",
+          "1:open:asc",
+          "1:next",
+          "1:next",
+          "1:next",
+          "1:return",
+        ]);
+      }),
+  );
+
+  it.effect(
     "closes the leaf when its read budget produces a partial page",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
Reverse-distinct probing tracked its first key through a side-channel `Ref` while selecting a representative with a separate stream pipeline. A short-circuiting `Sink.fold` now returns both values together; the module no longer imports `Ref`.

Adds lifecycle tests proving the probe closes at the first unfiltered document and preserves the first key when the entire group is filtered out. Existing budget-exhaustion and interruption tests continue to pass. This is an internal refactor with no changeset.

Layer 2 of 4 in the QueryStream Effect-idiom stack.

Validated independently at this layer: `pnpm build`, `pnpm typecheck`, Oxfmt and Oxlint on edited files, QueryStream unit/lifecycle tests, and `pnpm test:server:mock-backend queryStream`.