### PR TITLE
Trace query stream consumer operations

### DIFF
--- a/.changeset/trace-query-stream-consumers.md
+++ b/.changeset/trace-query-stream-consumers.md
@@ -1,0 +1,5 @@
+---
+"@confect/server": patch
+---
+
+Add named tracing spans for `QueryStream.unique` and `QueryStream.paginate`, with one span per execution.

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -2517,18 +2517,20 @@ export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
  *
  * @experimental
  */
-export const unique = <Doc, Key extends ReadonlyArray<string>, E, R>(
-  self: QueryStream<Doc, Key, E, R>,
-): Effect.Effect<Option.Option<Doc>, E | NotUniqueError, R> =>
-  self.pipe(
-    Stream.take(2),
-    Stream.runCollect,
-    Effect.flatMap((docs) =>
-      docs.length >= 2
-        ? Effect.fail(new NotUniqueError())
-        : Effect.succeed(Array.head(docs)),
+export const unique = Effect.fn("QueryStream.unique")(
+  <Doc, Key extends ReadonlyArray<string>, E, R>(
+    self: QueryStream<Doc, Key, E, R>,
+  ): Effect.Effect<Option.Option<Doc>, E | NotUniqueError, R> =>
+    self.pipe(
+      Stream.take(2),
+      Stream.runCollect,
+      Effect.flatMap((docs) =>
+        docs.length >= 2
+          ? Effect.fail(new NotUniqueError())
+          : Effect.succeed(Array.head(docs)),
+      ),
     ),
-  );
+);
 
 // -----------------------------------------------------------------------------
 // Pagination
@@ -2752,196 +2754,189 @@ export const paginate: {
   ): Effect.Effect<PaginationResult<Doc>, E | ReadBudgetExceededError, R>;
 } = dual(
   2,
-  <
+  Effect.fn("QueryStream.paginate")(function* <
     Doc,
     Key extends ReadonlyArray<string>,
     E,
     R,
     Direction extends OrderDirection,
-  >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-    options: PaginateOptions,
-  ) =>
-    Effect.gen(function* () {
-      if (options.numItems === 0) {
-        if (options.cursor === null) {
-          return yield* Effect.die(
-            new Error(
-              "QueryStream.paginate: numItems of 0 with a null cursor is not supported",
-            ),
-          );
-        }
-        return yield* Effect.succeed<PaginationResult<Doc>>({
-          page: [],
-          isDone: false,
-          continueCursor: options.cursor,
-        });
-      }
-
-      const after = Option.map(Option.fromNullOr(options.cursor), (cursor) =>
-        deserializeCursorChecked(cursor, self.keyFields.length),
-      );
-      const endCursor = Option.fromNullishOr(options.endCursor);
-      // An end cursor of `END_CURSOR` pins the page to the end of the
-      // stream rather than to a key.
-      const pinnedEnd = Option.filter(
-        endCursor,
-        (cursor) => cursor !== END_CURSOR,
-      );
-      const until = Option.map(pinnedEnd, (cursor) =>
-        deserializeCursorChecked(cursor, self.keyFields.length),
-      );
-      const start = Option.map(after, (key) => ({ key, inclusive: false }));
-      const end = Option.map(until, (key) => ({ key, inclusive: true }));
-      const narrowed = narrowByKeyBounds(
-        self,
-        self.order === "asc"
-          ? { lower: start, upper: end }
-          : { lower: end, upper: start },
-      );
-      // With an endCursor the page runs to it, however many items that is.
-      const maxRows = Option.match(endCursor, {
-        onNone: () => Option.some(options.numItems),
-        onSome: () => Option.none<number>(),
-      });
-      const maximumRowsRead = Option.fromUndefinedOr(options.maximumRowsRead);
-      const maximumBytesRead = Option.fromUndefinedOr(options.maximumBytesRead);
-      const limits: ReadBudgetLimits = { maximumRowsRead, maximumBytesRead };
-      const stateRef = yield* SynchronizedRef.make(
-        new ReadBudgetState({
-          rows: 0,
-          bytes: 0,
-          status: BudgetStatus.Active(),
-        }),
-      );
-      const budgetStatus = Option.as(
-        Option.orElse(maximumRowsRead, () => maximumBytesRead),
-        stateRef,
-      );
-      const collected = yield* pipe(
-        Stream.run(
-          narrowed.annotated,
-          Sink.fold(
-            () =>
-              new PaginateState<Doc>({
-                page: Chunk.empty(),
-                readKeys: Chunk.empty(),
-                stopped: false,
-                hitLimit: false,
-              }),
-            (state) => !state.stopped,
-            (state, { doc, key }: Element<Doc>) => {
-              const readKeys = Chunk.append(state.readKeys, key);
-              const page = Option.match(doc, {
-                onNone: () => state.page,
-                onSome: (value) => Chunk.append(state.page, value),
-              });
-              return Effect.map(SynchronizedRef.get(stateRef), (usage) => {
-                const hitLimit = isBudgetExhausted(limits, usage);
-                return new PaginateState({
-                  page,
-                  readKeys,
-                  hitLimit,
-                  stopped:
-                    hitLimit ||
-                    Option.exists(
-                      maxRows,
-                      (limit) => Chunk.size(page) >= limit,
-                    ),
-                });
-              });
-            },
+  >(self: QueryStream<Doc, Key, E, R, Direction>, options: PaginateOptions) {
+    if (options.numItems === 0) {
+      if (options.cursor === null) {
+        return yield* Effect.die(
+          new Error(
+            "QueryStream.paginate: numItems of 0 with a null cursor is not supported",
           ),
-        ),
-        Effect.provideService(ReadBudgetLimits, limits),
-        Effect.provideService(ReadBudgetStatus, budgetStatus),
-      );
-      const usage = yield* SynchronizedRef.get(stateRef);
-      const stopped = BudgetStatus.$is("Stopped")(usage.status);
-      const limited = stopped || collected.hitLimit;
-      if (
-        limited &&
-        (Chunk.isEmpty(collected.readKeys) ||
-          Option.exists(
-            pinnedEnd,
-            (endpoint) => midpointCursor(collected.readKeys) === endpoint,
-          ))
-      ) {
-        return yield* new ReadBudgetExceededError({
-          rowsRead: usage.rows,
-          ...Option.match(maximumBytesRead, {
-            onNone: () => ({}),
-            onSome: () => ({ bytesRead: usage.bytes }),
-          }),
-        });
+        );
       }
-      const state = stopped
-        ? new PaginateState({
-            page: collected.page,
-            readKeys: collected.readKeys,
-            stopped: true,
-            hitLimit: true,
-          })
-        : collected;
-      const page = Chunk.toArray(state.page);
-      // `stopped` implies at least one element was read, so the last
-      // read key exists exactly when the fold stopped early.
-      const stoppedAt = state.stopped
-        ? Chunk.last(state.readKeys)
-        : Option.none<OrderKey>();
-      return Option.match(stoppedAt, {
-        onSome: (lastKey) =>
-          state.hitLimit
+      return yield* Effect.succeed<PaginationResult<Doc>>({
+        page: [],
+        isDone: false,
+        continueCursor: options.cursor,
+      });
+    }
+
+    const after = Option.map(Option.fromNullOr(options.cursor), (cursor) =>
+      deserializeCursorChecked(cursor, self.keyFields.length),
+    );
+    const endCursor = Option.fromNullishOr(options.endCursor);
+    // An end cursor of `END_CURSOR` pins the page to the end of the
+    // stream rather than to a key.
+    const pinnedEnd = Option.filter(
+      endCursor,
+      (cursor) => cursor !== END_CURSOR,
+    );
+    const until = Option.map(pinnedEnd, (cursor) =>
+      deserializeCursorChecked(cursor, self.keyFields.length),
+    );
+    const start = Option.map(after, (key) => ({ key, inclusive: false }));
+    const end = Option.map(until, (key) => ({ key, inclusive: true }));
+    const narrowed = narrowByKeyBounds(
+      self,
+      self.order === "asc"
+        ? { lower: start, upper: end }
+        : { lower: end, upper: start },
+    );
+    // With an endCursor the page runs to it, however many items that is.
+    const maxRows = Option.match(endCursor, {
+      onNone: () => Option.some(options.numItems),
+      onSome: () => Option.none<number>(),
+    });
+    const maximumRowsRead = Option.fromUndefinedOr(options.maximumRowsRead);
+    const maximumBytesRead = Option.fromUndefinedOr(options.maximumBytesRead);
+    const limits: ReadBudgetLimits = { maximumRowsRead, maximumBytesRead };
+    const stateRef = yield* SynchronizedRef.make(
+      new ReadBudgetState({
+        rows: 0,
+        bytes: 0,
+        status: BudgetStatus.Active(),
+      }),
+    );
+    const budgetStatus = Option.as(
+      Option.orElse(maximumRowsRead, () => maximumBytesRead),
+      stateRef,
+    );
+    const collected = yield* pipe(
+      Stream.run(
+        narrowed.annotated,
+        Sink.fold(
+          () =>
+            new PaginateState<Doc>({
+              page: Chunk.empty(),
+              readKeys: Chunk.empty(),
+              stopped: false,
+              hitLimit: false,
+            }),
+          (state) => !state.stopped,
+          (state, { doc, key }: Element<Doc>) => {
+            const readKeys = Chunk.append(state.readKeys, key);
+            const page = Option.match(doc, {
+              onNone: () => state.page,
+              onSome: (value) => Chunk.append(state.page, value),
+            });
+            return Effect.map(SynchronizedRef.get(stateRef), (usage) => {
+              const hitLimit = isBudgetExhausted(limits, usage);
+              return new PaginateState({
+                page,
+                readKeys,
+                hitLimit,
+                stopped:
+                  hitLimit ||
+                  Option.exists(maxRows, (limit) => Chunk.size(page) >= limit),
+              });
+            });
+          },
+        ),
+      ),
+      Effect.provideService(ReadBudgetLimits, limits),
+      Effect.provideService(ReadBudgetStatus, budgetStatus),
+    );
+    const usage = yield* SynchronizedRef.get(stateRef);
+    const stopped = BudgetStatus.$is("Stopped")(usage.status);
+    const limited = stopped || collected.hitLimit;
+    if (
+      limited &&
+      (Chunk.isEmpty(collected.readKeys) ||
+        Option.exists(
+          pinnedEnd,
+          (endpoint) => midpointCursor(collected.readKeys) === endpoint,
+        ))
+    ) {
+      return yield* new ReadBudgetExceededError({
+        rowsRead: usage.rows,
+        ...Option.match(maximumBytesRead, {
+          onNone: () => ({}),
+          onSome: () => ({ bytesRead: usage.bytes }),
+        }),
+      });
+    }
+    const state = stopped
+      ? new PaginateState({
+          page: collected.page,
+          readKeys: collected.readKeys,
+          stopped: true,
+          hitLimit: true,
+        })
+      : collected;
+    const page = Chunk.toArray(state.page);
+    // `stopped` implies at least one element was read, so the last
+    // read key exists exactly when the fold stopped early.
+    const stoppedAt = state.stopped
+      ? Chunk.last(state.readKeys)
+      : Option.none<OrderKey>();
+    return Option.match(stoppedAt, {
+      onSome: (lastKey) =>
+        state.hitLimit
+          ? {
+              page,
+              isDone: false,
+              continueCursor: serializeCursor(lastKey),
+              pageStatus: "SplitRequired" as const,
+              splitCursor: midpointCursor(state.readKeys),
+            }
+          : // A growing page that had to scan far past its item budget
+            // (a filter-heavy stream) recommends a split so reactive
+            // clients can subdivide it instead of re-scanning forever.
+            Chunk.size(state.readKeys) >= SOFT_MAX_SCAN_LENGTH
             ? {
                 page,
                 isDone: false,
                 continueCursor: serializeCursor(lastKey),
-                pageStatus: "SplitRequired" as const,
-                splitCursor: midpointCursor(state.readKeys),
-              }
-            : // A growing page that had to scan far past its item budget
-              // (a filter-heavy stream) recommends a split so reactive
-              // clients can subdivide it instead of re-scanning forever.
-              Chunk.size(state.readKeys) >= SOFT_MAX_SCAN_LENGTH
-              ? {
-                  page,
-                  isDone: false,
-                  continueCursor: serializeCursor(lastKey),
-                  pageStatus: "SplitRecommended" as const,
-                  splitCursor: midpointCursor(state.readKeys),
-                }
-              : {
-                  page,
-                  isDone: false,
-                  continueCursor: serializeCursor(lastKey),
-                },
-        // The narrowed stream was exhausted: either we reached the
-        // pinned end cursor (more may follow it) or the true end of
-        // the stream. An endCursor-pinned page that has grown well
-        // past its requested size recommends a split, so reactive
-        // clients can subdivide it (as `convex-helpers` does).
-        onNone: () => {
-          // Any pinned page — including one pinned to the end of the
-          // stream — that has grown well past its requested size
-          // recommends a split.
-          const shouldRecommendSplit =
-            Option.isSome(endCursor) &&
-            (Chunk.size(state.readKeys) >= SOFT_MAX_SCAN_LENGTH ||
-              Chunk.size(state.page) > options.numItems + 1);
-          return shouldRecommendSplit && Chunk.size(state.readKeys) > 0
-            ? {
-                page,
-                isDone: false,
-                continueCursor: Option.getOrElse(pinnedEnd, () => END_CURSOR),
                 pageStatus: "SplitRecommended" as const,
                 splitCursor: midpointCursor(state.readKeys),
               }
             : {
                 page,
-                isDone: Option.isNone(pinnedEnd),
-                continueCursor: Option.getOrElse(pinnedEnd, () => END_CURSOR),
-              };
-        },
-      });
-    }),
+                isDone: false,
+                continueCursor: serializeCursor(lastKey),
+              },
+      // The narrowed stream was exhausted: either we reached the
+      // pinned end cursor (more may follow it) or the true end of
+      // the stream. An endCursor-pinned page that has grown well
+      // past its requested size recommends a split, so reactive
+      // clients can subdivide it (as `convex-helpers` does).
+      onNone: () => {
+        // Any pinned page — including one pinned to the end of the
+        // stream — that has grown well past its requested size
+        // recommends a split.
+        const shouldRecommendSplit =
+          Option.isSome(endCursor) &&
+          (Chunk.size(state.readKeys) >= SOFT_MAX_SCAN_LENGTH ||
+            Chunk.size(state.page) > options.numItems + 1);
+        return shouldRecommendSplit && Chunk.size(state.readKeys) > 0
+          ? {
+              page,
+              isDone: false,
+              continueCursor: Option.getOrElse(pinnedEnd, () => END_CURSOR),
+              pageStatus: "SplitRecommended" as const,
+              splitCursor: midpointCursor(state.readKeys),
+            }
+          : {
+              page,
+              isDone: Option.isNone(pinnedEnd),
+              continueCursor: Option.getOrElse(pinnedEnd, () => END_CURSOR),
+            };
+      },
+    });
+  }),
 );

--- a/packages/server/test/tracing.test.ts
+++ b/packages/server/test/tracing.test.ts
@@ -7,6 +7,7 @@ import * as Document from "@confect/server/Document";
 import * as MutationRunner from "@confect/server/MutationRunner";
 import * as OrderedQuery from "@confect/server/OrderedQuery";
 import * as QueryRunner from "@confect/server/QueryRunner";
+import * as QueryStream from "@confect/server/QueryStream";
 import { assert, describe, expect, expectTypeOf, it } from "@effect/vitest";
 import type {
   GenericActionCtx,
@@ -15,11 +16,13 @@ import type {
   OrderedQuery as ConvexOrderedQuery,
 } from "convex/server";
 import { ConvexError, type GenericId } from "convex/values";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 import * as Tracer from "effect/Tracer";
 import { vi } from "vitest";
 
@@ -79,6 +82,148 @@ type ConvexDataModel = DataModel.ToConvex<
 const noteId = "note-id" as GenericId<"notes">;
 
 describe("server operation tracing", () => {
+  it.effect(
+    "traces lazy, repeatable query stream consumers without per-element spans",
+    () =>
+      Effect.gen(function* () {
+        const recorder = yield* makeRecorder;
+        let reads = 0;
+        const source = new QueryStream.QueryStream(
+          "asc",
+          ["_id"],
+          Stream.suspend(() => {
+            reads++;
+            return Stream.make(
+              new QueryStream.Element({ doc: Option.some(7), key: ["note"] }),
+            );
+          }),
+        ).pipe(QueryStream.map((value) => value + 1));
+        const unique = QueryStream.unique(source);
+        const paginate = QueryStream.paginate(source, {
+          numItems: 2,
+          cursor: null,
+        });
+        const curried = source.pipe(
+          QueryStream.paginate({ numItems: 2, cursor: null }),
+        );
+
+        expectTypeOf(unique).toEqualTypeOf<
+          Effect.Effect<Option.Option<number>, QueryStream.NotUniqueError>
+        >();
+        expectTypeOf(paginate).toEqualTypeOf<
+          Effect.Effect<
+            QueryStream.PaginationResult<number>,
+            QueryStream.ReadBudgetExceededError
+          >
+        >();
+        expectTypeOf(curried).toEqualTypeOf<typeof paginate>();
+        expect(reads).toBe(0);
+        expect(recorder.spans).toEqual([]);
+
+        const results = yield* Effect.all([
+          unique,
+          paginate,
+          curried,
+          unique,
+          paginate,
+          curried,
+        ]).pipe(Effect.withSpan("caller"), Effect.withTracer(recorder.tracer));
+
+        const page = {
+          page: [8],
+          isDone: true,
+          continueCursor: QueryStream.END_CURSOR,
+        };
+        expect(results).toEqual([
+          Option.some(8),
+          page,
+          page,
+          Option.some(8),
+          page,
+          page,
+        ]);
+        expect(reads).toBe(6);
+        expect(recorder.spans.map((span) => span.name)).toEqual([
+          "caller",
+          "QueryStream.unique",
+          "QueryStream.paginate",
+          "QueryStream.paginate",
+          "QueryStream.unique",
+          "QueryStream.paginate",
+          "QueryStream.paginate",
+        ]);
+        const [parent, ...children] = recorder.spans;
+        for (const child of children) {
+          expect(Option.getOrThrow(child.parent)).toBe(parent);
+          assert(child.status._tag === "Ended");
+          expect(Exit.isSuccess(child.status.exit)).toBe(true);
+        }
+        expect(children[0]).not.toBe(children[3]);
+      }),
+  );
+
+  it.effect(
+    "ends the unique span with its original typed cardinality error",
+    () =>
+      Effect.gen(function* () {
+        const recorder = yield* makeRecorder;
+        const source = new QueryStream.QueryStream(
+          "asc",
+          ["_id"],
+          Stream.make(
+            new QueryStream.Element({ doc: Option.some(1), key: [1] }),
+            new QueryStream.Element({ doc: Option.some(2), key: [2] }),
+          ),
+        );
+        const error = yield* QueryStream.unique(source).pipe(
+          Effect.flip,
+          Effect.withTracer(recorder.tracer),
+        );
+
+        assert.instanceOf(error, QueryStream.NotUniqueError);
+        expect(recorder.spans).toHaveLength(1);
+        const span = recorder.spans[0]!;
+        expect(span.name).toBe("QueryStream.unique");
+        assert(span.status._tag === "Ended");
+        assert(Exit.isFailure(span.status.exit));
+        expect(
+          Option.getOrThrow(Cause.findErrorOption(span.status.exit.cause)),
+        ).toBe(error);
+        expect(Cause.pretty(span.status.exit.cause)).toContain(
+          "QueryStream.unique",
+        );
+      }),
+  );
+
+  it.effect("preserves typed stream failures inside the pagination span", () =>
+    Effect.gen(function* () {
+      const recorder = yield* makeRecorder;
+      const failure = new OperationFailure({ reason: "query failed" });
+      const source = new QueryStream.QueryStream(
+        "asc",
+        ["_id"],
+        Stream.fail(failure),
+      );
+      const error = yield* QueryStream.paginate(source, {
+        numItems: 1,
+        cursor: null,
+      }).pipe(Effect.flip, Effect.withTracer(recorder.tracer));
+
+      expect(error).toBe(failure);
+      expect(recorder.spans).toHaveLength(1);
+      const span = recorder.spans[0]!;
+      expect(span.name).toBe("QueryStream.paginate");
+      assert(span.status._tag === "Ended");
+      assert(Exit.isFailure(span.status.exit));
+      expect(
+        Option.getOrThrow(Cause.findErrorOption(span.status.exit.cause)),
+      ).toBe(failure);
+      expect(Cause.pretty(span.status.exit.cause)).toContain(
+        "QueryStream.paginate",
+      );
+    }),
+  );
+
   it.effect(
     "traces lazy, repeatable RPC calls without a codec child span",
     () =>


### PR DESCRIPTION
Add named `Effect.fn` boundaries for `QueryStream.unique` and `QueryStream.paginate`, matching the server’s other effectful operations. Each execution creates one operation span with useful failure stack context, without per-element spans.

Extends the existing tracing harness to verify laziness, repeatability, parent spans, both pagination call styles, unchanged return/error types, original typed failures, and failure stack context. Includes a patch changeset for the observable tracing addition. Much of the source diff is indentation from the named generator.

The tracing suite and the existing QueryStream type benchmarks also pass; benchmark baselines were left unchanged.

Layer 4 of 4 in the QueryStream Effect-idiom stack.

Validated independently at this layer: `pnpm build`, `pnpm typecheck`, Oxfmt and Oxlint on edited files, QueryStream unit/lifecycle tests, and `pnpm test:server:mock-backend queryStream`.