### PR TITLE
Move QueryStream direction to the third parameter

### DIFF
--- a/.changeset/reorder-query-stream-direction.md
+++ b/.changeset/reorder-query-stream-direction.md
@@ -1,0 +1,19 @@
+---
+"@confect/server": major
+---
+
+Move `QueryStream`'s `Direction` type parameter from fifth to third. Update explicit type annotations to place the direction before the error and service requirements; inferred types and runtime behavior are unchanged.
+
+**Before:**
+
+```ts
+QueryStream<Doc, Key, Error, Requirements, Direction>;
+```
+
+**After:**
+
+```ts
+QueryStream<Doc, Key, Direction, Error, Requirements>;
+```
+
+If an annotation previously omitted `Direction` but specified an error or requirements, insert `QueryStream.OrderDirection` as the third argument to continue accepting either direction.

--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -20,28 +20,28 @@ A `QueryStream` describes an ordered query, not its results. Creating or composi
 The type has five parameters:
 
 ```text
-QueryStream<Doc, Key, Error, Requirements, Direction>
+QueryStream<Doc, Key, Direction, Error, Requirements>
 ```
 
 | Parameter      | Meaning                                                                                                                                                                                      |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Doc`          | The type of each emitted value. Initially a decoded document; after `map` or a join, it can be any result type. `never` means the stream emits no values, as with an empty stream.           |
 | `Key`          | An ordered tuple of field names, such as `["text", "_creationTime"]`, describing the stream's sort order. It tracks the index fields left after `eq` pins values, not the values themselves. |
+| `Direction`    | Whether keys are visited in ascending (`"asc"`) or descending (`"desc"`) order. The union `"asc" \| "desc"` accepts either direction.                                                        |
 | `Error`        | Typed failures that can occur while reading or transforming values. `never` means no typed failures, but defects can still occur.                                                            |
 | `Requirements` | Effect services needed to run the stream. `never` means there are no outstanding service requirements.                                                                                       |
-| `Direction`    | Whether keys are visited in ascending (`"asc"`) or descending (`"desc"`) order. The union `"asc" \| "desc"` accepts either direction.                                                        |
 
 The declaration abbreviates `Error` and `Requirements` as `E` and `R`. You normally let TypeScript infer all five parameters from `stream` and the operations you apply to it. Although the **type parameter** `Direction` defaults to the union, the **query method** `stream(...)` defaults to `"asc"`.
 
 For example, a notes query using the `by_text` index has this shape:
 
 ```text
-QueryStream<Note, ["text", "_creationTime"], DocumentDecodeError, never, "asc">
+QueryStream<Note, ["text", "_creationTime"], "asc", DocumentDecodeError, never>
 ```
 
 Here, `Note` is the decoded note document type. The stream emits notes sorted by text and then creation time, can fail to decode a document, and needs no additional services. You create the query through Confect's `DatabaseReader` service, which provides access to your database, as shown in the [first query example](#a-first-query). The stream retains that database access, so you do not need to supply a reader again to consume it. Effectful operations such as `mapEffect` can add their own errors and service requirements.
 
-A `QueryStream<Doc, Key, Error, Requirements, Direction>` is also a `Stream<Doc, Error, Requirements>`: the emitted value, error, and requirement types carry over, but `Key` and `Direction` are specific to `QueryStream`.
+A `QueryStream<Doc, Key, Direction, Error, Requirements>` is also a `Stream<Doc, Error, Requirements>`: the emitted value, error, and requirement types carry over, but `Key` and `Direction` are specific to `QueryStream`.
 
 ## A first query
 

--- a/packages/server/src/QueryInitializer.ts
+++ b/packages/server/src/QueryInitializer.ts
@@ -141,9 +141,9 @@ export interface QueryInitializer<
     ): QueryStream.QueryStream<
       Doc,
       QueryStream.Remaining<Spec>,
+      "asc",
       Document.DocumentDecodeError,
-      never,
-      "asc"
+      never
     >;
     <
       IndexName extends keyof Indexes<
@@ -164,9 +164,9 @@ export interface QueryInitializer<
     ): QueryStream.QueryStream<
       Doc,
       QueryStream.Remaining<Spec>,
+      Direction,
       Document.DocumentDecodeError,
-      never,
-      Direction
+      never
     >;
     <
       IndexName extends keyof Indexes<
@@ -178,9 +178,9 @@ export interface QueryInitializer<
     ): QueryStream.QueryStream<
       Doc,
       NamedIndex<ConvexTableInfoFor<DataModel_, TableName>, IndexName>,
+      "asc",
       Document.DocumentDecodeError,
-      never,
-      "asc"
+      never
     >;
     <
       IndexName extends keyof Indexes<
@@ -194,9 +194,9 @@ export interface QueryInitializer<
     ): QueryStream.QueryStream<
       Doc,
       NamedIndex<ConvexTableInfoFor<DataModel_, TableName>, IndexName>,
+      Direction,
       Document.DocumentDecodeError,
-      never,
-      Direction
+      never
     >;
   };
 }

--- a/packages/server/src/QueryStream.ts
+++ b/packages/server/src/QueryStream.ts
@@ -671,9 +671,9 @@ const splitRange = (
 export class QueryStream<
   out Doc,
   Key extends ReadonlyArray<string> = ReadonlyArray<string>,
+  out Direction extends OrderDirection = OrderDirection,
   out E = never,
   out R = never,
-  out Direction extends OrderDirection = OrderDirection,
 > implements Stream.Stream<Doc, E, R> {
   declare readonly [TypeId]: TypeId;
   declare readonly "~key": Types.Invariant<Key>;
@@ -718,7 +718,7 @@ export class QueryStream<
      */
     readonly narrowWith?: (
       bounds: KeyBounds,
-    ) => QueryStream<Doc, Key, E, R, Direction>,
+    ) => QueryStream<Doc, Key, Direction, E, R>,
     /**
      * Positions in `keyFields` of the implicit `_id` tiebreakers the
      * type-level `Key` omits: normally the trailing one, plus—on a
@@ -737,7 +737,7 @@ export class QueryStream<
      * their representative-selection order. Absent on externally
      * constructed streams without a reversal recipe; `reverse` then throws.
      */
-    readonly reverseWith?: () => QueryStream<Doc, Key, E, R, Flip<Direction>>,
+    readonly reverseWith?: () => QueryStream<Doc, Key, Flip<Direction>, E, R>,
   ) {}
 
   toStream(): Stream.Stream<Doc, E, R> {
@@ -813,11 +813,11 @@ export const empty =
   <Doc>(): {
     <const Key extends ReadonlyArray<string>>(
       key: Key,
-    ): QueryStream<Doc, Types.Mutable<Key>, never, never, "asc">;
+    ): QueryStream<Doc, Types.Mutable<Key>, "asc", never, never>;
     <const Key extends ReadonlyArray<string>, Direction extends OrderDirection>(
       key: Key,
       order: Direction,
-    ): QueryStream<Doc, Types.Mutable<Key>, never, never, Direction>;
+    ): QueryStream<Doc, Types.Mutable<Key>, Direction, never, never>;
   } =>
   (key: ReadonlyArray<string>, order: OrderDirection = "asc") => {
     const keyFields = withIdTiebreaker(key);
@@ -826,7 +826,7 @@ export const empty =
     // literal types the caller supplied.
     const make = (
       direction: OrderDirection,
-    ): QueryStream<Doc, any, never, never, any> =>
+    ): QueryStream<Doc, any, any, never, never> =>
       new QueryStream(
         direction,
         keyFields,
@@ -961,9 +961,9 @@ export const fromReflection = <
 ): QueryStream<
   Doc,
   ReadonlyArray<string>,
+  Direction,
   Document.DocumentDecodeError,
-  never,
-  Direction
+  never
 > =>
   makeLeaf(
     reflection,
@@ -981,9 +981,9 @@ const makeLeaf = <Doc, Direction extends OrderDirection>(
 ): QueryStream<
   Doc,
   ReadonlyArray<string>,
+  Direction,
   Document.DocumentDecodeError,
-  never,
-  Direction
+  never
 > => {
   // Bounds and range splitting work in full index-key space: the index's
   // fields plus the implicit `_id` tiebreaker (already explicit for
@@ -1310,10 +1310,10 @@ export const merge = <
   Direction extends OrderDirection,
 >(
   streams: readonly [
-    QueryStream<Doc, Key, E, R, Direction>,
-    ...ReadonlyArray<QueryStream<Doc, Key, E, R, NoInfer<Direction>>>,
+    QueryStream<Doc, Key, Direction, E, R>,
+    ...ReadonlyArray<QueryStream<Doc, Key, NoInfer<Direction>, E, R>>,
   ],
-): QueryStream<Doc, Key, E, R, Direction> => {
+): QueryStream<Doc, Key, Direction, E, R> => {
   const head = Array.headNonEmpty(streams);
   const incompatible = Array.findFirst(
     Array.tailNonEmpty(streams),
@@ -1342,10 +1342,10 @@ const mergeUnchecked = <
   Direction extends OrderDirection,
 >(
   streams: readonly [
-    QueryStream<Doc, Key, E, R, Direction>,
-    ...ReadonlyArray<QueryStream<Doc, Key, E, R, Direction>>,
+    QueryStream<Doc, Key, Direction, E, R>,
+    ...ReadonlyArray<QueryStream<Doc, Key, Direction, E, R>>,
   ],
-): QueryStream<Doc, Key, E, R, Direction> => {
+): QueryStream<Doc, Key, Direction, E, R> => {
   const head = Array.headNonEmpty(streams);
   const annotated: Stream.Stream<Element<Doc>, E, R> = Stream.unwrap(
     Effect.map(
@@ -1406,9 +1406,9 @@ const transform = <
   Doc2,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
+  self: QueryStream<Doc, Key, Direction, E, R>,
   f: (doc: Doc) => Option.Option<Doc2>,
-): QueryStream<Doc2, Key, E, R, Direction> =>
+): QueryStream<Doc2, Key, Direction, E, R> =>
   new QueryStream(
     self.order,
     self.keyFields,
@@ -1433,10 +1433,10 @@ const transformEffect = <
   R2,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
+  self: QueryStream<Doc, Key, Direction, E, R>,
   f: (doc: Doc) => Effect.Effect<Option.Option<Doc2>, E2, R2>,
   options: EffectOptions | undefined,
-): QueryStream<Doc2, Key, E | E2, R | R2, Direction> =>
+): QueryStream<Doc2, Key, Direction, E | E2, R | R2> =>
   new QueryStream(
     self.order,
     self.keyFields,
@@ -1494,8 +1494,8 @@ export const filter = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc, Key, Direction, E, R>,
   <
     Doc,
     Key extends ReadonlyArray<string>,
@@ -1503,9 +1503,9 @@ export const filter = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     predicate: (doc: Doc) => boolean,
-  ) => QueryStream<Doc, Key, E, R, Direction>
+  ) => QueryStream<Doc, Key, Direction, E, R>
 >(2, (self, predicate) =>
   transform(self, (doc) => (predicate(doc) ? Option.some(doc) : Option.none())),
 );
@@ -1530,8 +1530,8 @@ export const filterEffect = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc, Key, E | E2, R | R2, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc, Key, Direction, E | E2, R | R2>,
   <
     Doc,
     Key extends ReadonlyArray<string>,
@@ -1541,10 +1541,10 @@ export const filterEffect = dual<
     R2,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     predicate: (doc: Doc) => Effect.Effect<boolean, E2, R2>,
     options?: EffectOptions,
-  ) => QueryStream<Doc, Key, E | E2, R | R2, Direction>
+  ) => QueryStream<Doc, Key, Direction, E | E2, R | R2>
 >(
   (args) => isQueryStream(args[0]),
   (self, predicate, options) =>
@@ -1579,8 +1579,8 @@ export const map = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc2, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc2, Key, Direction, E, R>,
   <
     Doc,
     Key extends ReadonlyArray<string>,
@@ -1589,9 +1589,9 @@ export const map = dual<
     Doc2,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     f: (doc: Doc) => Doc2,
-  ) => QueryStream<Doc2, Key, E, R, Direction>
+  ) => QueryStream<Doc2, Key, Direction, E, R>
 >(2, (self, f) => transform(self, (doc) => Option.some(f(doc))));
 
 /**
@@ -1616,8 +1616,8 @@ export const mapEffect = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc2, Key, E | E2, R | R2, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc2, Key, Direction, E | E2, R | R2>,
   <
     Doc,
     Key extends ReadonlyArray<string>,
@@ -1628,10 +1628,10 @@ export const mapEffect = dual<
     R2,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     f: (doc: Doc) => Effect.Effect<Doc2, E2, R2>,
     options?: EffectOptions,
-  ) => QueryStream<Doc2, Key, E | E2, R | R2, Direction>
+  ) => QueryStream<Doc2, Key, Direction, E | E2, R | R2>
 >(
   (args) => isQueryStream(args[0]),
   (self, f, options) =>
@@ -1691,19 +1691,19 @@ export const flatMap = dual<
     Direction extends OrderDirection,
     Doc3 = never,
   >(
-    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
+    f: (doc: Doc) => QueryStream<Doc2, InnerKey, Direction, E2, R2>,
     options: {
       readonly innerKey: NoInfer<InnerKey>;
       readonly onEmpty?: ((doc: Doc) => Doc3) | undefined;
     },
   ) => <Key extends ReadonlyArray<string>, E, R>(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
   ) => QueryStream<
     Doc2 | Doc3,
     readonly [...Key, ...InnerKey],
+    Direction,
     E | E2,
-    R | R2,
-    Direction
+    R | R2
   >,
   <
     Doc,
@@ -1717,8 +1717,8 @@ export const flatMap = dual<
     Direction extends OrderDirection,
     Doc3 = never,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-    f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, NoInfer<Direction>>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+    f: (doc: Doc) => QueryStream<Doc2, InnerKey, NoInfer<Direction>, E2, R2>,
     options: {
       readonly innerKey: NoInfer<InnerKey>;
       readonly onEmpty?: ((doc: Doc) => Doc3) | undefined;
@@ -1726,9 +1726,9 @@ export const flatMap = dual<
   ) => QueryStream<
     Doc2 | Doc3,
     readonly [...Key, ...InnerKey],
+    Direction,
     E | E2,
-    R | R2,
-    Direction
+    R | R2
   >
 >(3, (self, f, options) => {
   // Runtime inner key fields follow the same convention as leaves: the
@@ -1803,8 +1803,8 @@ const makeFlatMap = <
   Direction extends OrderDirection,
   Doc3 = never,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
-  f: (doc: Doc) => QueryStream<Doc2, InnerKey, E2, R2, Direction>,
+  self: QueryStream<Doc, Key, Direction, E, R>,
+  f: (doc: Doc) => QueryStream<Doc2, InnerKey, Direction, E2, R2>,
   innerKeyFields: ReadonlyArray<string>,
   innerTiebreakers: ReadonlyArray<number>,
   /** What an outer document with no inner rows emits, if it is kept. */
@@ -1813,9 +1813,9 @@ const makeFlatMap = <
 ): QueryStream<
   Doc2 | Doc3,
   readonly [...Key, ...InnerKey],
+  Direction,
   E | E2,
-  R | R2,
-  Direction
+  R | R2
 > => {
   const outerLength = self.keyFields.length;
   const keyFields = Array.appendAll(self.keyFields, innerKeyFields);
@@ -1835,8 +1835,8 @@ const makeFlatMap = <
   // direction case and untyped callers) covers the rest.
   let validatedOnce = false;
   const validated = (
-    inner: QueryStream<Doc2, InnerKey, E2, R2, Direction>,
-  ): QueryStream<Doc2, InnerKey, E2, R2, Direction> => {
+    inner: QueryStream<Doc2, InnerKey, Direction, E2, R2>,
+  ): QueryStream<Doc2, InnerKey, Direction, E2, R2> => {
     if (validatedOnce) {
       return inner;
     }
@@ -2038,8 +2038,8 @@ export const distinct = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc, Key, Direction, E, R>,
   <
     const Fields extends ReadonlyArray<string>,
     Doc,
@@ -2048,9 +2048,9 @@ export const distinct = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     fields: Fields,
-  ) => QueryStream<Doc, Key, E, R, Direction>
+  ) => QueryStream<Doc, Key, Direction, E, R>
 >(2, (self, fields) => {
   const visible = visibleKeyFields(self);
   if (!keyFieldsEquivalence(fields, Array.take(visible, fields.length))) {
@@ -2111,8 +2111,8 @@ export const renameKey = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc, Types.Mutable<NewKey>, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc, Types.Mutable<NewKey>, Direction, E, R>,
   <
     const NewKey extends ReadonlyArray<string>,
     Doc,
@@ -2123,9 +2123,9 @@ export const renameKey = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     key: NewKey,
-  ) => QueryStream<Doc, Types.Mutable<NewKey>, E, R, Direction>
+  ) => QueryStream<Doc, Types.Mutable<NewKey>, Direction, E, R>
 >(2, (self, key) => renameKeyImpl(self, key));
 
 const renameKeyImpl = <
@@ -2136,9 +2136,9 @@ const renameKeyImpl = <
   NewKey extends ReadonlyArray<string>,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
+  self: QueryStream<Doc, Key, Direction, E, R>,
   key: NewKey,
-): QueryStream<Doc, Types.Mutable<NewKey>, E, R, Direction> => {
+): QueryStream<Doc, Types.Mutable<NewKey>, Direction, E, R> => {
   const visible = visibleKeyFields(self);
   if (key.length !== visible.length) {
     throw new Error(
@@ -2181,11 +2181,11 @@ const makeDistinct = <
   R,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R>,
+  self: QueryStream<Doc, Key, OrderDirection, E, R>,
   distinctLength: number,
   order: Direction,
   bounds: KeyBounds,
-): QueryStream<Doc, Key, E, R, Direction> => {
+): QueryStream<Doc, Key, Direction, E, R> => {
   const afterKey = (key: OrderKey): KeyBounds => {
     const pastGroup: KeyBound = {
       key,
@@ -2212,7 +2212,7 @@ const makeDistinct = <
           upper: groupBound(bounds.upper),
         }),
         (
-          current: QueryStream<Doc, Key, E, R>,
+          current: QueryStream<Doc, Key, OrderDirection, E, R>,
         ): Effect.Effect<
           readonly [ReadonlyArray<Element<Doc>>, Option.Option<typeof current>],
           E,
@@ -2320,8 +2320,8 @@ export const reverse = <
   R,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
-): QueryStream<Doc, Key, E, R, Flip<Direction>> => {
+  self: QueryStream<Doc, Key, Direction, E, R>,
+): QueryStream<Doc, Key, Flip<Direction>, E, R> => {
   if (self.reverseWith === undefined) {
     throw new Error(
       "QueryStream.reverse: this stream cannot be reversed without a reversal recipe",
@@ -2376,8 +2376,8 @@ export const narrow = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
-  ) => QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
+  ) => QueryStream<Doc, Key, Direction, E, R>,
   <
     Doc,
     Key extends ReadonlyArray<string>,
@@ -2385,9 +2385,9 @@ export const narrow = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     bounds: NarrowBounds,
-  ) => QueryStream<Doc, Key, E, R, Direction>
+  ) => QueryStream<Doc, Key, Direction, E, R>
 >(
   2,
   <
@@ -2397,7 +2397,7 @@ export const narrow = dual<
     R,
     Direction extends OrderDirection,
   >(
-    self: QueryStream<Doc, Key, E, R, Direction>,
+    self: QueryStream<Doc, Key, Direction, E, R>,
     bounds: NarrowBounds,
   ) => {
     const start = Option.fromUndefinedOr(bounds.start);
@@ -2419,9 +2419,9 @@ const narrowByKeyBounds = <
   R,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
+  self: QueryStream<Doc, Key, Direction, E, R>,
   bounds: KeyBounds,
-): QueryStream<Doc, Key, E, R, Direction> =>
+): QueryStream<Doc, Key, Direction, E, R> =>
   Option.isNone(bounds.lower) && Option.isNone(bounds.upper)
     ? self
     : self.narrowWith !== undefined
@@ -2454,9 +2454,9 @@ const narrowInMemory = <
   R,
   Direction extends OrderDirection,
 >(
-  self: QueryStream<Doc, Key, E, R, Direction>,
+  self: QueryStream<Doc, Key, Direction, E, R>,
   bounds: KeyBounds,
-): QueryStream<Doc, Key, E, R, Direction> => {
+): QueryStream<Doc, Key, Direction, E, R> => {
   type Narrower = (
     annotated: Stream.Stream<Element<Doc>, E, R>,
   ) => Stream.Stream<Element<Doc>, E, R>;
@@ -2512,7 +2512,7 @@ export class NotUniqueError extends Schema.TaggedError<NotUniqueError>()(
  */
 export const unique = Effect.fn("QueryStream.unique")(
   <Doc, Key extends ReadonlyArray<string>, E, R>(
-    self: QueryStream<Doc, Key, E, R>,
+    self: QueryStream<Doc, Key, OrderDirection, E, R>,
   ): Effect.Effect<Option.Option<Doc>, E | NotUniqueError, R> =>
     self.pipe(
       Stream.take(2),
@@ -2738,10 +2738,10 @@ export const paginate: {
   (
     options: PaginateOptions,
   ): <Doc, Key extends ReadonlyArray<string>, E, R>(
-    self: QueryStream<Doc, Key, E, R>,
+    self: QueryStream<Doc, Key, OrderDirection, E, R>,
   ) => Effect.Effect<PaginationResult<Doc>, E | ReadBudgetExceededError, R>;
   <Doc, Key extends ReadonlyArray<string>, E, R>(
-    self: QueryStream<Doc, Key, E, R>,
+    self: QueryStream<Doc, Key, OrderDirection, E, R>,
     options: PaginateOptions,
   ): Effect.Effect<PaginationResult<Doc>, E | ReadBudgetExceededError, R>;
 } = dual(
@@ -2752,7 +2752,7 @@ export const paginate: {
     E,
     R,
     Direction extends OrderDirection,
-  >(self: QueryStream<Doc, Key, E, R, Direction>, options: PaginateOptions) {
+  >(self: QueryStream<Doc, Key, Direction, E, R>, options: PaginateOptions) {
     if (options.numItems === 0) {
       if (options.cursor === null) {
         return yield* Effect.die(

--- a/packages/server/test/QueryStream.bench.ts
+++ b/packages/server/test/QueryStream.bench.ts
@@ -27,7 +27,7 @@ const leaf = <Doc, Key extends ReadonlyArray<string>>(
     undefined,
     undefined,
     [keyFields.length - 1],
-  ) as unknown as QueryStream.QueryStream<Doc, Key, never, never, "asc">;
+  ) as unknown as QueryStream.QueryStream<Doc, Key, "asc", never, never>;
 
 const notes = leaf<Note, ["text", "_creationTime"]>([
   "text",

--- a/packages/server/test/QueryStream.test.ts
+++ b/packages/server/test/QueryStream.test.ts
@@ -4,6 +4,42 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 
+describe("QueryStream type parameters", () => {
+  it("accepts direction third and defaults errors and requirements to never", () => {
+    const source = new QueryStream.QueryStream<number, ["_id"], "desc">(
+      "desc",
+      ["_id"],
+      Stream.empty,
+    );
+
+    expect(source.order).toBe("desc");
+    expectTypeOf(source.toStream()).toEqualTypeOf<Stream.Stream<number>>();
+    expectTypeOf<QueryStream.QueryStream<number, ["_id"]>>().toEqualTypeOf<
+      QueryStream.QueryStream<number, ["_id"], QueryStream.OrderDirection>
+    >();
+    expectTypeOf<
+      QueryStream.QueryStream<number, ["_id"], "desc", Error>
+    >().toEqualTypeOf<
+      QueryStream.QueryStream<number, ["_id"], "desc", Error, never>
+    >();
+  });
+
+  it("carries the fourth and fifth parameters into the Effect stream channels", () => {
+    type Source = QueryStream.QueryStream<
+      number,
+      ["_id"],
+      "asc",
+      Error,
+      { readonly service: "query" }
+    >;
+
+    expectTypeOf<Source["order"]>().toEqualTypeOf<"asc">();
+    expectTypeOf<ReturnType<Source["toStream"]>>().toEqualTypeOf<
+      Stream.Stream<number, Error, { readonly service: "query" }>
+    >();
+  });
+});
+
 describe("QueryStream.RangeOp", () => {
   it.each(["eq", "gt", "gte", "lt", "lte"] as const)(
     "constructs %s operations with the existing record shape",

--- a/packages/server/test/mock-backend/queryStream.test.ts
+++ b/packages/server/test/mock-backend/queryStream.test.ts
@@ -25,7 +25,7 @@ const collectTexts = <E, R>(
 
 /** Walk a stream page by page until exhausted, returning the pages. */
 const paginateAll = <Doc, Key extends ReadonlyArray<string>, E, R>(
-  stream: QueryStream.QueryStream<Doc, Key, E, R>,
+  stream: QueryStream.QueryStream<Doc, Key, QueryStream.OrderDirection, E, R>,
   numItems: number,
 ): Effect.Effect<
   ReadonlyArray<ReadonlyArray<Doc>>,
@@ -1766,9 +1766,9 @@ describe("QueryStream types", () => {
         QueryStream.QueryStream<
           string,
           ["_creationTime"],
+          "asc",
           Document.DocumentDecodeError,
-          never,
-          "asc"
+          never
         >
       >();
 
@@ -1885,12 +1885,11 @@ describe("QueryStream types", () => {
         DirectionOf<typeof dynamic>
       >().toEqualTypeOf<QueryStream.OrderDirection>();
 
-      // The direction is covariant: a known direction is also "either", so
-      // annotations that omit it (and helpers generic over four
-      // parameters) accept every stream.
+      // The direction is covariant: a known direction is also "either".
       const widened: QueryStream.QueryStream<
         unknown,
         ["text", "_creationTime"],
+        QueryStream.OrderDirection,
         unknown,
         unknown
       > = full;

--- a/packages/server/test/mock-backend/queryStreamDistinct.test.ts
+++ b/packages/server/test/mock-backend/queryStreamDistinct.test.ts
@@ -58,9 +58,9 @@ const observeUpstreamEnd = <
   R,
   Direction extends QueryStream.OrderDirection,
 >(
-  stream: QueryStream.QueryStream<Doc, Key, E, R, Direction>,
+  stream: QueryStream.QueryStream<Doc, Key, Direction, E, R>,
   onEnd: Effect.Effect<void>,
-): QueryStream.QueryStream<Doc, Key, E, R, Direction> =>
+): QueryStream.QueryStream<Doc, Key, Direction, E, R> =>
   new QueryStream.QueryStream(
     stream.order,
     stream.keyFields,
@@ -78,7 +78,10 @@ const pageTags = Effect.fnUntraced(function* <
   Key extends ReadonlyArray<string>,
   E,
   R,
->(stream: QueryStream.QueryStream<Doc, Key, E, R>, numItems = 1) {
+>(
+  stream: QueryStream.QueryStream<Doc, Key, QueryStream.OrderDirection, E, R>,
+  numItems = 1,
+) {
   const pages: Array<Array<string | undefined>> = [];
   let cursor: string | null = null;
   for (let index = 0; index < 20; index++) {


### PR DESCRIPTION
Put the query-specific type parameters together before the Effect channels:

```ts
QueryStream<Doc, Key, Direction, Error, Requirements>
```

Update the stream constructors, combinators, explicit annotations, and documentation to use this order. Keep the existing defaults (`OrderDirection`, `never`, `never`) and runtime behavior unchanged. Annotations that previously omitted direction while specifying errors or requirements now explicitly use `OrderDirection` in the third slot.

Add type assertions for the new ordering and defaults, plus a major changeset with migration guidance for explicit annotations.

Verified with `pnpm build`, `pnpm typecheck`, targeted QueryStream unit/type tests and mock-backend tests, Oxfmt, and Oxlint (no diagnostics). Transpiled JavaScript for both changed source modules is identical before and after the refactor.

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M28ZQAVGMQNEP298W7KPPZCN"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->