### PR TITLE
Remove the redundant stream limitations section

### DIFF
--- a/apps/docs/server/database/streams.mdx
+++ b/apps/docs/server/database/streams.mdx
@@ -797,7 +797,3 @@ A cursor that is malformed, or that was issued by a stream with a different orde
 ### On the client
 
 Pages of a stream-paginated query are not tracked by Convex's query journal, so [`usePaginatedQuery`](/clients/react#usepaginatedquery) can't keep them gap-free as data changes. Use [`useStreamPaginatedQuery`](/clients/react#usestreampaginatedquery) instead, which pins each loaded page with `endCursor` and splits pages that outgrow their size. Foldkit's [`PaginatedQuery`](/clients/foldkit#paginated-queries) machine works with stream-paginated queries as is: it pins each page it navigates away from, so going back reloads the same range.
-
-## Limitations
-
-- Cursors are not opaque (see the warning above).


### PR DESCRIPTION
The Streams page ended with a Limitations section that only pointed back to its existing cursor-security warning. Remove that redundant section while keeping the warning beside the pagination protocol.

The broader documentation review is reported separately; this PR does not rewrite the rest of the page.

Validated with Mintlify build validation and broken-link checks, Oxfmt, the stream-diagram consistency check, all 5 diagram tests, and the focused QueryStream suite (31 runtime and type tests).

<!-- capy-badge:start -->
<a href="https://capy.ai/thread/jam_01M29275Z1A7ES2TPJKZ7350QR"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->